### PR TITLE
Add GitHub Actions workflow for macOS binary builds

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,94 @@
+name: Build macOS Binary
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-macos:
+    runs-on: macos-14
+    defaults:
+      run:
+        working-directory: aibom
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Install PyInstaller
+        run: uv pip install pyinstaller
+
+      - name: Build binary
+        run: uv run pyinstaller cisco-aibom.spec --clean --noconfirm
+
+      - name: Smoke test
+        run: ./dist/cisco-aibom --help
+
+      - name: Get version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Create archive
+        run: >
+          tar -czf cisco-aibom-${{ steps.version.outputs.version }}-macos-arm64.tar.gz
+          -C dist cisco-aibom
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: "aibom/cisco-aibom-*-macos-arm64.tar.gz"
+
+  update-homebrew:
+    needs: build-macos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: cisco-ai-defense/homebrew-ai-defense
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Get version and SHA
+        id: info
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          URL="https://github.com/cisco-ai-defense/aibom/releases/download/${GITHUB_REF_NAME}/cisco-aibom-${VERSION}-macos-arm64.tar.gz"
+          for i in $(seq 1 10); do
+            HTTP_CODE=$(curl -sL -o /tmp/asset.tar.gz -w "%{http_code}" "$URL")
+            if [ "$HTTP_CODE" = "200" ]; then
+              SHA=$(shasum -a 256 /tmp/asset.tar.gz | cut -d' ' -f1)
+              break
+            fi
+            echo "Attempt $i: HTTP $HTTP_CODE, retrying in 15s..."
+            sleep 15
+          done
+          if [ -z "$SHA" ] || [ ${#SHA} -ne 64 ]; then
+            echo "Failed to download release asset"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "sha256=$SHA" >> $GITHUB_OUTPUT
+
+      - name: Update formula
+        run: |
+          sed -i 's/version ".*"/version "${{ steps.info.outputs.version }}"/' Formula/aibom.rb
+          sed -i 's|url ".*"|url "https://github.com/cisco-ai-defense/aibom/releases/download/${{ github.ref_name }}/cisco-aibom-${{ steps.info.outputs.version }}-macos-arm64.tar.gz"|' Formula/aibom.rb
+          sed -i 's/sha256 ".*"/sha256 "${{ steps.info.outputs.sha256 }}"/' Formula/aibom.rb
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/aibom.rb
+          git diff --staged --quiet && echo "No changes to commit" && exit 0
+          git commit -m "Update aibom to ${{ steps.info.outputs.version }}"
+          git push


### PR DESCRIPTION
## Summary
- Adds `build-macos.yml` workflow triggered on release publish events
- Builds PyInstaller arm64 binary on `macos-14` (Apple Silicon) runner using `working-directory: aibom`
- Uploads `.tar.gz` archive to the triggering GitHub Release
- Automatically updates the Homebrew formula in `cisco-ai-defense/homebrew-ai-defense`

## Required Setup
- Add `HOMEBREW_TAP_TOKEN` secret to the repo (GitHub PAT with `repo` scope for `cisco-ai-defense/homebrew-ai-defense`)

## Test plan
- [ ] Create a test release (e.g., `v0.2.4-test`) to verify workflow runs
- [ ] Verify binary is uploaded to the release assets
- [ ] Verify Homebrew formula is updated with correct version/SHA
- [ ] Run `brew install cisco-ai-defense/ai-defense/aibom` to verify installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)