### PR TITLE
feat(aibom): Phase 2 — 11 targeted AI asset detectors, KB enrichment scanner, CLI v2 wiring

### DIFF
--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -321,8 +321,44 @@ def _render_relationship_table(relationships: List[Any]) -> None:
     console.print(table)
 
 
+def _display_v2_summary(source: str, components: list, relationships: list) -> None:
+    """Rich summary for v2 detector output."""
+    from collections import Counter
+    panel_title = f"[bold green]Analysis Summary (v2)[/] • {source}"
+    console.print(Panel(panel_title, style="green", expand=False))
+    if not components:
+        console.print(Panel.fit("No AI components detected.", title=source, style="yellow"))
+        return
+    by_type: Counter = Counter()
+    grouped: Dict[str, list] = {}
+    for comp in components:
+        ctype = comp.component_type.value if hasattr(comp.component_type, "value") else str(comp.component_type)
+        by_type[ctype] += 1
+        grouped.setdefault(ctype, []).append(comp)
+    table = Table("Category", "Count", title=f"Components in {source}", box=box.SIMPLE_HEAVY, header_style="bold magenta")
+    for ctype, count in sorted(by_type.items()):
+        table.add_row(ctype, str(count))
+    console.print(table)
+    for ctype, items in sorted(grouped.items()):
+        console.print(Panel.fit(f"{ctype.upper()} details", style="bold white"))
+        for comp in items[:5]:
+            loc = f"{comp.file_path}:{comp.line_path}" if hasattr(comp, "line_path") else f"{comp.file_path}:{comp.line_number}"
+            extra = ""
+            if comp.model_name:
+                extra = f" model={comp.model_name}"
+            elif comp.framework:
+                extra = f" framework={comp.framework}"
+            provider = comp.metadata.get("provider", "")
+            if provider and provider != "unknown":
+                extra += f" provider={provider}"
+            console.print(f"  [cyan]{comp.name}[/]{extra} [dim]{loc}[/]")
+
+
 def _display_analysis_summary(all_analysis_outputs: Dict[str, Any], max_examples: int = 3) -> None:
     for source, output in all_analysis_outputs.items():
+        if isinstance(output, dict) and output.get("_v2"):
+            _display_v2_summary(source, output["components"], output["relationships"])
+            continue
         categorized_components = getattr(output, "components", output)
         panel_title = f"[bold green]Analysis Summary[/] • {source}"
         console.print(Panel(panel_title, style="green", expand=False))
@@ -815,6 +851,14 @@ def analyze(
         "--validate",
         help="Validate the output against the format's schema and report errors.",
     ),
+    legacy_mode: bool = typer.Option(
+        False,
+        "--legacy-mode",
+        help=(
+            "Use the v1 KB-symbol-matching pipeline instead of the v2 "
+            "targeted detectors.  Intended for backward compatibility only."
+        ),
+    ),
 ):
     """Analyzes a Python codebase to generate an AI BOM."""
     # Configure logging
@@ -893,14 +937,13 @@ def analyze(
         "sources_requested": len(sources_to_process),
     }
     db_path: Optional[Path] = None
-    try:
-        db_path = ensure_local_database(console=console)
-    except Exception as exc:  # noqa: BLE001
-        console.print(f"[bold red]Knowledge base error:[/] {exc}")
-        raise typer.Exit(code=1)
+    if legacy_mode:
+        try:
+            db_path = ensure_local_database(console=console)
+        except Exception as exc:  # noqa: BLE001
+            console.print(f"[bold red]Knowledge base error:[/] {exc}")
+            raise typer.Exit(code=1)
 
-    # Load explicit custom catalog (global override for all sources).
-    # Per-source auto-discovery is handled inside the source loop below.
     explicit_config: Optional[CustomCatalogConfig] = None
     if custom_catalog:
         explicit_config = load_custom_catalog(Path(custom_catalog))
@@ -961,6 +1004,43 @@ def analyze(
                 shutil.rmtree(temp_dir)
             continue
 
+        # -----------------------------------------------------------------
+        # v2 path: targeted detectors via run_scanners()
+        # -----------------------------------------------------------------
+        if not legacy_mode:
+            from .models import ScanContext as V2ScanContext
+            from .scanners import run_scanners
+
+            scan_path = str(path_to_analyze)
+            v2_ctx = V2ScanContext(
+                paths=[scan_path],
+                output_format=output_format,
+                output_file=str(output_file) if output_file else None,
+                llm_config=llm_config,
+                kb_path=str(db_path) if db_path else None,
+                fail_on=fail_on_severity,
+                min_severity=severity_filter,
+            )
+            with console.status(f"[cyan]Scanning {source} (v2 detectors)"):
+                v2_components, v2_relationships = run_scanners(v2_ctx)
+
+            all_analysis_outputs[source] = {
+                "_v2": True,
+                "components": v2_components,
+                "relationships": v2_relationships,
+            }
+            source_summary["assets_discovered"] = len(v2_components)
+            source_summary["last_generated_at"] = _utcnow_iso()
+            if source_summary["status"] == "in_progress":
+                source_summary["status"] = "completed"
+
+            if temp_dir:
+                shutil.rmtree(temp_dir)
+            continue
+
+        # -----------------------------------------------------------------
+        # Legacy path: KB-driven symbol matching (v1)
+        # -----------------------------------------------------------------
         python_files = _find_python_files(path_to_analyze)
         if not python_files:
             logging.warning("No Python files found to analyze in this source.")
@@ -1017,8 +1097,6 @@ def analyze(
         except Exception as workflow_error:
             logging.debug(f"Failed to build workflow index: {workflow_error}")
 
-        # Resolve custom catalog for this source: explicit flag is a
-        # global override; otherwise auto-discover per source directory.
         config_root = path_to_analyze if path_to_analyze.is_dir() else path_to_analyze.parent
         source_custom: Optional[CustomCatalogConfig] = explicit_config
         if source_custom is None:
@@ -1083,7 +1161,12 @@ def analyze(
     report_data = None
     reporter = get_reporter(output_format)
 
-    if reporter and output_format not in ("json", "plaintext"):
+    has_v2_output = any(
+        isinstance(o, dict) and o.get("_v2")
+        for o in all_analysis_outputs.values()
+    )
+
+    if has_v2_output or (reporter and output_format not in ("json", "plaintext")):
         from .models import (
             AIComponent as V2Component,
             AIComponentType,
@@ -1093,29 +1176,70 @@ def analyze(
         )
         from .risk import RiskScorer
 
-        scan_result = _build_scan_result(
-            all_analysis_outputs, run_metadata, run_errors,
-        )
+        if has_v2_output:
+            v2_sources = []
+            for source_path, output in all_analysis_outputs.items():
+                if isinstance(output, dict) and output.get("_v2"):
+                    v2_sources.append(SourceResult(
+                        path=source_path,
+                        components=output["components"],
+                        relationships=output["relationships"],
+                    ))
+                else:
+                    legacy_sr = _build_scan_result(
+                        {source_path: output}, run_metadata, [],
+                    )
+                    v2_sources.extend(legacy_sr.sources)
+            scan_result = ScanResult(
+                metadata=run_metadata,
+                sources=v2_sources,
+                errors=[e.get("message", str(e)) for e in run_errors],
+            )
+        else:
+            scan_result = _build_scan_result(
+                all_analysis_outputs, run_metadata, run_errors,
+            )
+
         scorer = RiskScorer()
         scan_result.risk = scorer.score(scan_result)
 
-        if validate:
-            errors = reporter.validate(scan_result)
-            if errors:
-                for err in errors:
-                    console.print(f"[yellow]Validation: {err}[/]")
-            else:
-                console.print("[green]Validation passed.[/]")
+        if not reporter:
+            reporter = get_reporter(output_format)
 
-        if output_file:
+        if reporter:
+            if validate:
+                errors = reporter.validate(scan_result)
+                if errors:
+                    for err in errors:
+                        console.print(f"[yellow]Validation: {err}[/]")
+                else:
+                    console.print("[green]Validation passed.[/]")
+
+            if output_file:
+                import io
+                buf = io.StringIO()
+                reporter.render(scan_result, buf)
+                output_file.write_text(buf.getvalue(), encoding="utf-8")
+                console.print(f"[green]Report written to {output_file}[/]")
+            else:
+                import sys
+                reporter.render(scan_result, sys.stdout)
+        elif output_format == "json":
             import io
-            buf = io.StringIO()
-            reporter.render(scan_result, buf)
-            output_file.write_text(buf.getvalue(), encoding="utf-8")
-            console.print(f"[green]Report written to {output_file}[/]")
-        else:
-            import sys
-            reporter.render(scan_result, sys.stdout)
+            json_rep = get_reporter("json")
+            if json_rep and output_file:
+                buf = io.StringIO()
+                json_rep.render(scan_result, buf)
+                output_file.write_text(buf.getvalue(), encoding="utf-8")
+                console.print(f"[green]Report written to {output_file}[/]")
+        elif output_format == "plaintext":
+            plaintext_rep = get_reporter("plaintext")
+            if plaintext_rep and output_file:
+                import io
+                buf = io.StringIO()
+                plaintext_rep.render(scan_result, buf)
+                output_file.write_text(buf.getvalue(), encoding="utf-8")
+                console.print(f"[green]Report written to {output_file}[/]")
 
         if fail_on_severity and scorer.should_fail(scan_result.risk, fail_on_severity):
             console.print(

--- a/aibom/src/aibom/scanners/__init__.py
+++ b/aibom/src/aibom/scanners/__init__.py
@@ -15,5 +15,45 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .base import BaseScanner, scanner_registry, run_scanners
+from .config_scanner import ConfigScanner
+from .dependency_scanner import DependencyScanner
+from .kb_enrichment_scanner import KBEnrichmentScanner
+from .mcp_detector import McpDetector
+from .ml_lifecycle_detector import MLLifecycleDetector
+from .model_detector import ModelDetector
+from .multi_language_scanner import MultiLanguageScanner
+from .secret_detector import SecretDetector
+from .shadow_ai_detector import ShadowAIDetector
+from .skill_detector import SkillDetector
+from .vuln_scanner import (
+    BaseVulnProvider,
+    GrypeProvider,
+    OsvProvider,
+    PackageRef,
+    VulnScanner,
+    Vulnerability,
+    vuln_provider_registry,
+)
 
-__all__ = ["BaseScanner", "scanner_registry", "run_scanners"]
+__all__ = [
+    "BaseScanner",
+    "BaseVulnProvider",
+    "ConfigScanner",
+    "DependencyScanner",
+    "GrypeProvider",
+    "KBEnrichmentScanner",
+    "McpDetector",
+    "MLLifecycleDetector",
+    "ModelDetector",
+    "MultiLanguageScanner",
+    "OsvProvider",
+    "PackageRef",
+    "SecretDetector",
+    "ShadowAIDetector",
+    "SkillDetector",
+    "VulnScanner",
+    "Vulnerability",
+    "run_scanners",
+    "scanner_registry",
+    "vuln_provider_registry",
+]

--- a/aibom/src/aibom/scanners/config_scanner.py
+++ b/aibom/src/aibom/scanners/config_scanner.py
@@ -1,0 +1,783 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml  # type: ignore[import-untyped]
+from pathspec import PathSpec
+
+from ..models import AIComponent, ComponentRelationship, ScanContext
+from ..models.enums import AIComponentType, DetectionSource, RelationshipType
+from .base import BaseScanner
+
+_LOGGER = logging.getLogger(__name__)
+
+_SKIP_DIR_NAMES = frozenset({"node_modules", ".git", ".venv", "venv", "__pycache__"})
+
+_AI_COMPOSE_IMAGE_MARKERS = (
+    "ollama/ollama",
+    "ollama/",
+    "vllm/vllm",
+    "vllm-openai",
+    "text-generation-inference",
+    "tritonserver",
+    "localai/localai",
+    "localai/",
+    "ggerganov/llama.cpp",
+    "llama.cpp",
+)
+
+_ENV_LINE = re.compile(
+    r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?:\"([^\"]*)\"|'([^']*)'|([^\s#]*))\s*(?:#.*)?$"
+)
+
+_MODEL_NAME_RE = re.compile(
+    r"(?i)^(gpt-|claude-|o\d|gemini-|mistral|meta-llama|llama[-_]?[0-9]|text-embedding|"
+    r"command-|jamba-|cohere|azure/|models/|[a-z0-9][a-z0-9_.-]{0,40}/[a-z0-9_.-]+)"
+)
+
+_FROM_RE = re.compile(r"^\s*FROM\s+(--platform=\S+\s+)?(\S+)", re.IGNORECASE)
+_ENV_RE = re.compile(
+    r"^\s*ENV\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+?)\s*$",
+    re.IGNORECASE,
+)
+_COPY_MODEL_RE = re.compile(
+    r"^\s*COPY\s+.+?\.(gguf|safetensors|onnx|pt|pth|bin|ckpt|h5|pb)\b",
+    re.IGNORECASE,
+)
+_TOML_SECTION = re.compile(
+    r"^\s*\[tool\.(langchain|crewai|dspy)([^\]]*)\]\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_DSPY_MODEL_LINE = re.compile(r"(?im)^\s*model\s*=\s*[\"']?([^\"'\s#]+)[\"']?")
+
+
+def _line_for_substring(text: str, needle: str) -> int:
+    idx = text.find(needle)
+    if idx < 0:
+        return 1
+    return text.count("\n", 0, idx) + 1
+
+
+def _load_exclude_spec(context: ScanContext) -> Optional[PathSpec]:
+    if not context.exclude_patterns:
+        return None
+    return PathSpec.from_lines("gitwildmatch", context.exclude_patterns)
+
+
+def _is_excluded(abs_file: Path, root: Path, spec: Optional[PathSpec]) -> bool:
+    if not spec:
+        return False
+    try:
+        rel = abs_file.relative_to(root).as_posix()
+    except ValueError:
+        rel = abs_file.as_posix()
+    return spec.match_file(rel)
+
+
+def _is_config_target(name: str) -> bool:
+    n = name.lower()
+    if n in {
+        "langgraph.json",
+        "crewai.yaml",
+        "crewai.yml",
+        "dspy.toml",
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        "dockerfile",
+        "pyproject.toml",
+    }:
+        return True
+    if n == ".env" or n.startswith(".env."):
+        return True
+    if n.endswith(".dockerfile"):
+        return True
+    return False
+
+
+def _iter_config_files(context: ScanContext) -> Iterator[tuple[Path, Path]]:
+    spec = _load_exclude_spec(context)
+    for root_str in context.paths:
+        root = Path(root_str).resolve()
+        if root.is_file():
+            if not _is_config_target(root.name):
+                continue
+            parent = root.parent
+            if _is_excluded(root, parent, spec):
+                continue
+            yield root, parent
+            continue
+        if not root.is_dir():
+            continue
+        for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+            dp = Path(dirpath)
+            rel_root = dp.relative_to(root).as_posix() if dp != root else ""
+            dirnames[:] = [
+                d
+                for d in dirnames
+                if d not in _SKIP_DIR_NAMES
+                and not any(
+                    p in _SKIP_DIR_NAMES for p in (rel_root + "/" + d).split("/") if p
+                )
+            ]
+            for fn in filenames:
+                if not _is_config_target(fn):
+                    continue
+                file_path = dp / fn
+                if _is_excluded(file_path, root, spec):
+                    continue
+                yield file_path, root
+
+
+def _read_text(path: Path) -> Optional[str]:
+    try:
+        raw = path.read_bytes()
+    except OSError as e:
+        _LOGGER.debug("Unreadable %s: %s", path, e)
+        return None
+    if b"\x00" in raw[:8192]:
+        return None
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+def _looks_like_model_name(value: str) -> bool:
+    v = value.strip().strip("\"'")
+    if not v or len(v) > 256:
+        return False
+    if v.startswith("http://") or v.startswith("https://"):
+        return False
+    if _MODEL_NAME_RE.match(v):
+        return True
+    if "/" in v and re.match(r"^[a-z0-9_.-]+/[a-zA-Z0-9_.-]+$", v):
+        return True
+    return False
+
+
+def _provider_from_env_key(key: str) -> Optional[str]:
+    ku = key.upper()
+    for pref, name in (
+        ("OPENAI_", "openai"),
+        ("ANTHROPIC_", "anthropic"),
+        ("GOOGLE_", "google"),
+        ("AZURE_", "azure"),
+        ("COHERE_", "cohere"),
+        ("MISTRAL_", "mistral"),
+    ):
+        if ku.startswith(pref):
+            return name
+    return None
+
+
+def _docker_image_is_ai(image: str) -> bool:
+    img = image.lower().split("@", 1)[0]
+    for m in _AI_COMPOSE_IMAGE_MARKERS:
+        if m in img:
+            return True
+    return False
+
+
+def _parse_langgraph(
+    path: Path, text: str
+) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+    out: list[AIComponent] = []
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return [], []
+    if not isinstance(data, dict):
+        return [], []
+    graphs = data.get("graphs")
+    if isinstance(graphs, dict):
+        for gid, spec in graphs.items():
+            if not isinstance(gid, str):
+                continue
+            ln = _line_for_substring(text, f'"{gid}"')
+            desc = str(spec) if spec is not None else ""
+            out.append(
+                AIComponent(
+                    name=f"langgraph_graph_{gid}",
+                    component_type=AIComponentType.AGENT,
+                    file_path=str(path.resolve()),
+                    line_number=ln,
+                    framework="langgraph",
+                    detection_source=DetectionSource.CONFIG_FILE,
+                    description=f"LangGraph graph `{gid}` → {desc}",
+                    config_source=str(path),
+                    metadata={
+                        "graph_id": gid,
+                        "graph_spec": desc,
+                        "config_kind": "langgraph.json",
+                    },
+                ),
+            )
+    nodes = data.get("nodes")
+    if isinstance(nodes, list):
+        for i, node in enumerate(nodes):
+            if not isinstance(node, dict):
+                continue
+            ntype = node.get("type") or node.get("node_type") or "node"
+            nid = node.get("id") or node.get("name") or f"node_{i}"
+            raw_snip = json.dumps(node, default=str)[:500]
+            ln = _line_for_substring(
+                text, raw_snip[:40] if len(raw_snip) > 40 else str(nid)
+            )
+            out.append(
+                AIComponent(
+                    name=f"langgraph_{nid}",
+                    component_type=AIComponentType.AGENT,
+                    file_path=str(path.resolve()),
+                    line_number=ln,
+                    framework="langgraph",
+                    detection_source=DetectionSource.CONFIG_FILE,
+                    description=f"LangGraph node type `{ntype}`",
+                    metadata={"node_type": str(ntype), "config_kind": "langgraph.json"},
+                ),
+            )
+    elif isinstance(nodes, dict):
+        for nid, node in nodes.items():
+            if not isinstance(node, dict):
+                continue
+            ntype = node.get("type") or node.get("node_type") or "node"
+            ln = _line_for_substring(text, str(nid))
+            out.append(
+                AIComponent(
+                    name=f"langgraph_{nid}",
+                    component_type=AIComponentType.AGENT,
+                    file_path=str(path.resolve()),
+                    line_number=ln,
+                    framework="langgraph",
+                    detection_source=DetectionSource.CONFIG_FILE,
+                    description=f"LangGraph node type `{ntype}`",
+                    metadata={"node_type": str(ntype), "config_kind": "langgraph.json"},
+                ),
+            )
+
+    def _walk_models(obj: Any, depth: int = 0) -> None:
+        if depth > 12:
+            return
+        if isinstance(obj, str) and _looks_like_model_name(obj):
+            ln = _line_for_substring(text, obj[: min(40, len(obj))])
+            out.append(
+                AIComponent(
+                    name=obj[:120],
+                    component_type=AIComponentType.MODEL,
+                    file_path=str(path.resolve()),
+                    line_number=ln,
+                    framework="langgraph",
+                    detection_source=DetectionSource.CONFIG_FILE,
+                    model_name=obj.strip().strip("\"'")[:256],
+                    metadata={"config_kind": "langgraph.json"},
+                ),
+            )
+        elif isinstance(obj, dict):
+            for v in obj.values():
+                _walk_models(v, depth + 1)
+        elif isinstance(obj, list):
+            for v in obj:
+                _walk_models(v, depth + 1)
+
+    _walk_models(data)
+    return out, []
+
+
+def _crew_agent_name(ag: dict[str, Any], idx: int) -> str:
+    for k in ("name", "role", "id"):
+        v = ag.get(k)
+        if isinstance(v, str) and v.strip():
+            return v.strip()[:200]
+    return f"agent_{idx}"
+
+
+def _parse_crewai(
+    path: Path, text: str
+) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+    components: list[AIComponent] = []
+    relationships: list[ComponentRelationship] = []
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return [], []
+    if not isinstance(data, dict):
+        return [], []
+    agents_raw = data.get("agents")
+    agent_by_name: dict[str, AIComponent] = {}
+    if isinstance(agents_raw, list):
+        for i, ag in enumerate(agents_raw):
+            if not isinstance(ag, dict):
+                continue
+            nm = _crew_agent_name(ag, i)
+            needle = nm if nm in text else (ag.get("role") or nm)
+            ln = _line_for_substring(text, str(needle)) if needle else 1
+            comp = AIComponent(
+                name=f"crewai_agent_{nm}",
+                component_type=AIComponentType.AGENT,
+                file_path=str(path.resolve()),
+                line_number=ln,
+                framework="crewai",
+                detection_source=DetectionSource.CONFIG_FILE,
+                description=f"CrewAI agent `{nm}`",
+                config_source=str(path),
+                metadata={"config_kind": "crewai", "agent_name": nm},
+            )
+            components.append(comp)
+            agent_by_name[nm] = comp
+            tools = ag.get("tools")
+            if isinstance(tools, list):
+                for t in tools:
+                    tname = (
+                        str(t)
+                        if not isinstance(t, dict)
+                        else str(
+                            t.get("name") or t.get("tool") or t,
+                        )
+                    )
+                    tln = _line_for_substring(text, tname[:80])
+                    tool_comp = AIComponent(
+                        name=f"crewai_tool_{tname}",
+                        component_type=AIComponentType.TOOL,
+                        file_path=str(path.resolve()),
+                        line_number=tln,
+                        framework="crewai",
+                        detection_source=DetectionSource.CONFIG_FILE,
+                        description=f"CrewAI tool `{tname}` (agent `{nm}`)",
+                        metadata={"tool_name": tname, "agent": nm},
+                    )
+                    components.append(tool_comp)
+                    relationships.append(
+                        ComponentRelationship(
+                            source_instance_id=comp.instance_id,
+                            target_instance_id=tool_comp.instance_id,
+                            relationship_type=RelationshipType.USES_TOOL,
+                            label=RelationshipType.USES_TOOL.value,
+                            source_name=comp.name,
+                            target_name=tool_comp.name,
+                            source_type=AIComponentType.AGENT,
+                            target_type=AIComponentType.TOOL,
+                        ),
+                    )
+    tools_top = data.get("tools")
+    if isinstance(tools_top, list):
+        for t in tools_top:
+            tname = (
+                str(t)
+                if not isinstance(t, dict)
+                else str(
+                    t.get("name") or t.get("id") or t,
+                )
+            )
+            tln = _line_for_substring(text, tname[:80])
+            components.append(
+                AIComponent(
+                    name=f"crewai_tool_{tname}",
+                    component_type=AIComponentType.TOOL,
+                    file_path=str(path.resolve()),
+                    line_number=tln,
+                    framework="crewai",
+                    detection_source=DetectionSource.CONFIG_FILE,
+                    description=f"CrewAI tool `{tname}`",
+                    metadata={"config_kind": "crewai", "tool_name": tname},
+                ),
+            )
+    tasks = data.get("tasks")
+    if isinstance(tasks, list):
+        for i, task in enumerate(tasks):
+            if not isinstance(task, dict):
+                continue
+            tid = str(task.get("name") or task.get("id") or f"task_{i}")
+            tln = _line_for_substring(text, tid)
+            task_comp = AIComponent(
+                name=f"crewai_task_{tid}",
+                component_type=AIComponentType.AGENT,
+                file_path=str(path.resolve()),
+                line_number=tln,
+                framework="crewai",
+                detection_source=DetectionSource.CONFIG_FILE,
+                description=f"CrewAI task `{tid}`",
+                metadata={"config_kind": "crewai", "task_name": tid},
+            )
+            components.append(task_comp)
+            agent_key = task.get("agent") or task.get("agent_id")
+            if isinstance(agent_key, str):
+                src = agent_by_name.get(agent_key)
+                if src is None:
+                    for anm, ac in agent_by_name.items():
+                        if agent_key in (anm, f"crewai_agent_{anm}"):
+                            src = ac
+                            break
+                if src is not None:
+                    relationships.append(
+                        ComponentRelationship(
+                            source_instance_id=src.instance_id,
+                            target_instance_id=task_comp.instance_id,
+                            relationship_type=RelationshipType.CUSTOM,
+                            label="TASK_FOR_AGENT",
+                            source_name=src.name,
+                            target_name=task_comp.name,
+                            source_type=AIComponentType.AGENT,
+                            target_type=AIComponentType.AGENT,
+                        ),
+                    )
+    return components, relationships
+
+
+def _parse_dspy_toml(
+    path: Path, text: str
+) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+    out: list[AIComponent] = []
+    for m in _DSPY_MODEL_LINE.finditer(text):
+        val = m.group(1).strip().strip("\"'")
+        if not val:
+            continue
+        ln = text.count("\n", 0, m.start()) + 1
+        out.append(
+            AIComponent(
+                name=f"dspy_model_{val[:100]}",
+                component_type=AIComponentType.MODEL,
+                file_path=str(path.resolve()),
+                line_number=ln,
+                framework="dspy",
+                detection_source=DetectionSource.CONFIG_FILE,
+                model_name=val[:256],
+                description="DSPy model configuration",
+                metadata={"config_kind": "dspy.toml"},
+            ),
+        )
+    return out, []
+
+
+def _parse_env(
+    path: Path, text: str
+) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+    out: list[AIComponent] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        m = _ENV_LINE.match(line)
+        if not m:
+            continue
+        key = m.group(1)
+        value = next(g for g in m.groups()[1:] if g is not None)
+        ku = key.upper()
+
+        if ku.endswith("_API_KEY"):
+            out.append(
+                AIComponent(
+                    name=f"env_secret_{key}",
+                    component_type=AIComponentType.SECRET,
+                    file_path=str(path.resolve()),
+                    line_number=i,
+                    detection_source=DetectionSource.CONFIG_FILE,
+                    description=f"API key variable `{key}` present (value redacted)",
+                    text=None,
+                    metadata={
+                        "env_var": key,
+                        "redacted": True,
+                        "config_kind": ".env",
+                    },
+                ),
+            )
+            continue
+
+        if (
+            ku.endswith("_API_BASE")
+            or ku.endswith("_API_VERSION")
+            or ku.endswith("_BASE_URL")
+        ):
+            prov = _provider_from_env_key(key)
+            out.append(
+                AIComponent(
+                    name=f"env_api_config_{key}",
+                    component_type=AIComponentType.MODEL,
+                    file_path=str(path.resolve()),
+                    line_number=i,
+                    detection_source=DetectionSource.CONFIG_FILE,
+                    description=f"API configuration `{key}` (value redacted)",
+                    text=None,
+                    framework=prov or "",
+                    metadata={
+                        "env_var": key,
+                        "redacted": True,
+                        "config_kind": ".env",
+                    },
+                ),
+            )
+            continue
+
+        if "MODEL" in ku or "LLM" in ku:
+            if _looks_like_model_name(value):
+                v = value.strip().strip("\"'")
+                out.append(
+                    AIComponent(
+                        name=f"env_model_{key}",
+                        component_type=AIComponentType.MODEL,
+                        file_path=str(path.resolve()),
+                        line_number=i,
+                        detection_source=DetectionSource.CONFIG_FILE,
+                        model_name=v[:256],
+                        description=f"Model from `{key}`",
+                        metadata={"env_var": key, "config_kind": ".env"},
+                    ),
+                )
+            continue
+
+        prov = _provider_from_env_key(key)
+        if prov:
+            out.append(
+                AIComponent(
+                    name=f"env_provider_{prov}",
+                    component_type=AIComponentType.MODEL,
+                    file_path=str(path.resolve()),
+                    line_number=i,
+                    detection_source=DetectionSource.CONFIG_FILE,
+                    framework=prov,
+                    description=f"Provider env prefix `{key.split('_', 1)[0]}`",
+                    text=None,
+                    metadata={
+                        "env_var": key,
+                        "provider": prov,
+                        "redacted": True,
+                        "config_kind": ".env",
+                    },
+                ),
+            )
+    return out, []
+
+
+def _parse_docker_compose(
+    path: Path, text: str
+) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+    out: list[AIComponent] = []
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return [], []
+    if not isinstance(data, dict):
+        return [], []
+    services = data.get("services")
+    if not isinstance(services, dict):
+        return [], []
+    for svc_name, svc in services.items():
+        if not isinstance(svc, dict):
+            continue
+        image = svc.get("image")
+        if not isinstance(image, str) or not _docker_image_is_ai(image):
+            continue
+        needle = image.split("\n", 1)[0][:80]
+        ln = _line_for_substring(text, needle)
+        out.append(
+            AIComponent(
+                name=f"compose_service_{svc_name}",
+                component_type=AIComponentType.MODEL,
+                file_path=str(path.resolve()),
+                line_number=ln,
+                detection_source=DetectionSource.CONFIG_FILE,
+                model_name=image[:256],
+                description=f"Docker Compose service `{svc_name}` uses AI image",
+                metadata={
+                    "service": str(svc_name),
+                    "image": image,
+                    "config_kind": "docker-compose",
+                },
+            ),
+        )
+    return out, []
+
+
+def _parse_dockerfile(
+    path: Path, text: str
+) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+    out: list[AIComponent] = []
+    lines = text.splitlines()
+    for i, line in enumerate(lines, start=1):
+        fm = _FROM_RE.match(line)
+        if fm:
+            img = fm.group(2)
+            if _docker_image_is_ai(img):
+                out.append(
+                    AIComponent(
+                        name=f"dockerfile_from_{i}",
+                        component_type=AIComponentType.MODEL,
+                        file_path=str(path.resolve()),
+                        line_number=i,
+                        detection_source=DetectionSource.CONFIG_FILE,
+                        model_name=img[:256],
+                        description="AI-related base image",
+                        metadata={"image": img, "config_kind": "Dockerfile"},
+                    ),
+                )
+        em = _ENV_RE.match(line)
+        if em:
+            ek = em.group(1)
+            ev = em.group(2).strip().strip("\"'")
+            ku = ek.upper()
+            if "MODEL" in ku or "LLM" in ku:
+                if _looks_like_model_name(ev):
+                    out.append(
+                        AIComponent(
+                            name=f"dockerfile_env_{ek}",
+                            component_type=AIComponentType.MODEL,
+                            file_path=str(path.resolve()),
+                            line_number=i,
+                            detection_source=DetectionSource.CONFIG_FILE,
+                            model_name=ev[:256],
+                            metadata={"config_kind": "Dockerfile", "env": ek},
+                        ),
+                    )
+        if _COPY_MODEL_RE.match(line):
+            out.append(
+                AIComponent(
+                    name=f"dockerfile_copy_models_{i}",
+                    component_type=AIComponentType.MODEL_ARTIFACT,
+                    file_path=str(path.resolve()),
+                    line_number=i,
+                    detection_source=DetectionSource.CONFIG_FILE,
+                    description="COPY of model-like artifact",
+                    text=line.strip()[:500],
+                    metadata={"config_kind": "Dockerfile"},
+                ),
+            )
+    return out, []
+
+
+def _parse_pyproject_config(
+    path: Path, text: str
+) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+    out: list[AIComponent] = []
+    for m in _TOML_SECTION.finditer(text):
+        tool = m.group(1).lower()
+        extra = (m.group(2) or "").strip()
+        start = m.start()
+        ln = text.count("\n", 0, start) + 1
+        section_header = f"[tool.{tool}{extra}]"
+        next_hdr = re.search(
+            r"^\s*\[",
+            text[m.end() :],
+            re.MULTILINE,
+        )
+        body_end = m.end() + (next_hdr.start() if next_hdr else len(text) - m.end())
+        body = text[m.end() : body_end]
+
+        if tool == "langchain":
+            ctype = AIComponentType.AGENT
+            framework = "langchain"
+        elif tool == "crewai":
+            ctype = AIComponentType.AGENT
+            framework = "crewai"
+        else:
+            ctype = AIComponentType.MODEL
+            framework = "dspy"
+
+        out.append(
+            AIComponent(
+                name=f"pyproject_tool_{tool}",
+                component_type=ctype,
+                file_path=str(path.resolve()),
+                line_number=ln,
+                framework=framework,
+                detection_source=DetectionSource.CONFIG_FILE,
+                description=f"pyproject `[tool.{tool}{extra}]` section",
+                config_source=str(path),
+                metadata={"section": section_header, "config_kind": "pyproject.toml"},
+            ),
+        )
+
+        for mm in re.finditer(
+            r"(?im)^\s*(default_model|model|llm|language_model)\s*=\s*[\"']([^\"']+)[\"']",
+            body,
+        ):
+            mname = mm.group(2).strip()
+            if not mname:
+                continue
+            mln = ln + body.count("\n", 0, mm.start())
+            out.append(
+                AIComponent(
+                    name=f"pyproject_{tool}_model",
+                    component_type=AIComponentType.MODEL,
+                    file_path=str(path.resolve()),
+                    line_number=mln,
+                    framework=framework,
+                    detection_source=DetectionSource.CONFIG_FILE,
+                    model_name=mname[:256],
+                    metadata={
+                        "section": section_header,
+                        "config_kind": "pyproject.toml",
+                    },
+                ),
+            )
+    return out, []
+
+
+def _dispatch(
+    path: Path, text: str
+) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+    n = path.name.lower()
+    if n == "langgraph.json":
+        return _parse_langgraph(path, text)
+    if n in ("crewai.yaml", "crewai.yml"):
+        return _parse_crewai(path, text)
+    if n == "dspy.toml":
+        return _parse_dspy_toml(path, text)
+    if n == ".env" or n.startswith(".env."):
+        return _parse_env(path, text)
+    if n in ("docker-compose.yml", "docker-compose.yaml"):
+        return _parse_docker_compose(path, text)
+    if n == "dockerfile" or n.endswith(".dockerfile"):
+        return _parse_dockerfile(path, text)
+    if n == "pyproject.toml":
+        return _parse_pyproject_config(path, text)
+    return [], []
+
+
+class ConfigScanner(BaseScanner):
+    name = "config_scanner"
+
+    def supports(self, context: ScanContext) -> bool:
+        return True
+
+    def scan(
+        self, context: ScanContext
+    ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+        components: list[AIComponent] = []
+        relationships: list[ComponentRelationship] = []
+        seen: set[Path] = set()
+        for file_path, _root in _iter_config_files(context):
+            resolved = file_path.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            text = _read_text(resolved)
+            if text is None:
+                continue
+            try:
+                c, r = _dispatch(resolved, text)
+            except Exception:
+                _LOGGER.debug("Config parse failed for %s", resolved, exc_info=True)
+                continue
+            components.extend(c)
+            relationships.extend(r)
+        return components, relationships

--- a/aibom/src/aibom/scanners/dependency_scanner.py
+++ b/aibom/src/aibom/scanners/dependency_scanner.py
@@ -1,0 +1,927 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Callable, Iterator, Optional
+
+import yaml  # type: ignore[import-untyped]
+from pathspec import PathSpec
+
+from ..models import AIComponent, ComponentRelationship, ScanContext
+from ..models.enums import AIComponentType, DetectionSource
+from .base import BaseScanner
+
+AI_PACKAGES: dict[str, set[str]] = {
+    "pypi": {
+        "openai",
+        "langchain",
+        "langchain-core",
+        "langchain-community",
+        "langchain-openai",
+        "anthropic",
+        "google-generativeai",
+        "google-cloud-aiplatform",
+        "crewai",
+        "autogen",
+        "autogen-agentchat",
+        "mcp",
+        "fastmcp",
+        "llama-index",
+        "llama-index-core",
+        "chromadb",
+        "pinecone-client",
+        "weaviate-client",
+        "qdrant-client",
+        "transformers",
+        "torch",
+        "tensorflow",
+        "keras",
+        "jax",
+        "flax",
+        "sentence-transformers",
+        "diffusers",
+        "accelerate",
+        "peft",
+        "trl",
+        "datasets",
+        "evaluate",
+        "tokenizers",
+        "safetensors",
+        "bitsandbytes",
+        "vllm",
+        "text-generation-inference",
+        "mlflow",
+        "wandb",
+        "dvc",
+        "comet-ml",
+        "neptune",
+        "ray",
+        "kubeflow",
+        "bentoml",
+        "litellm",
+        "dspy",
+        "instructor",
+        "guidance",
+        "semantic-kernel",
+        "promptflow",
+        "deepeval",
+    },
+    "npm": {
+        "openai",
+        "@langchain/core",
+        "@langchain/openai",
+        "@langchain/anthropic",
+        "@langchain/community",
+        "@anthropic-ai/sdk",
+        "ai",
+        "@ai-sdk/openai",
+        "@google/generative-ai",
+        "cohere-ai",
+        "@modelcontextprotocol/sdk",
+        "llamaindex",
+        "chromadb",
+        "@pinecone-database/pinecone",
+        "weaviate-ts-client",
+        "@qdrant/js-client-rest",
+    },
+    "go": {
+        "github.com/sashabaranov/go-openai",
+        "github.com/anthropics/anthropic-sdk-go",
+        "github.com/google/generative-ai-go",
+        "github.com/tmc/langchaingo",
+    },
+    "maven": {
+        "dev.langchain4j",
+        "com.azure:azure-ai-openai",
+        "com.google.cloud:google-cloud-aiplatform",
+        "io.github.sashirestela:simple-openai",
+    },
+    "cargo": {
+        "async-openai",
+        "llm",
+        "candle-core",
+        "candle-nn",
+        "burn",
+    },
+    "rubygems": {
+        "ruby-openai",
+        "langchainrb",
+    },
+}
+
+_MAVEN_GROUP_PREFIX = "dev.langchain4j"
+_MAVEN_EXACT_COORDS = frozenset(
+    c
+    for c in AI_PACKAGES["maven"]
+    if ":" in c and not c.startswith(_MAVEN_GROUP_PREFIX + ":")
+)
+
+_REQUIREMENT_NAME = re.compile(r"^([a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?)")
+_PIPFILE_PKG = re.compile(r"^([a-zA-Z0-9_.-]+)\s*=")
+_TOML_STRING_DEP = re.compile(r"""["']([^"']+)["']""")
+_POETRY_DEP_KEY = re.compile(r"^([a-zA-Z0-9_.-]+)\s*=")
+_LOCK_PACKAGE = re.compile(r"^\[\[package\]\]\s*$")
+_LOCK_NAME = re.compile(r'^name\s*=\s*["\']([^"\']+)["\']')
+_LOCK_VERSION = re.compile(r'^version\s*=\s*["\']([^"\']+)["\']')
+_INSTALL_REQUIRES = re.compile(r"install_requires\s*=\s*\[([\s\S]*?)\]", re.MULTILINE)
+_GRADLE_DEP = re.compile(
+    r"""(?:(?:implementation|api|compileOnly|runtimeOnly|compile|classpath)\s*)"""
+    r"""[\(\s]*["']([^"']+)["']""",
+    re.MULTILINE,
+)
+_GRADLE_KTS = re.compile(
+    r"""(?:implementation|api|compileOnly|runtimeOnly)\s*\(\s*["']([^"']+)["']\s*\)""",
+    re.MULTILINE,
+)
+_POM_DEP = re.compile(
+    r"<dependency>\s*([\s\S]*?)</dependency>", re.IGNORECASE | re.DOTALL
+)
+_POM_GROUP = re.compile(r"<groupId>\s*([^<]+?)\s*</groupId>", re.IGNORECASE)
+_POM_ARTIFACT = re.compile(r"<artifactId>\s*([^<]+?)\s*</artifactId>", re.IGNORECASE)
+_POM_VERSION = re.compile(r"<version>\s*([^<]+?)\s*</version>", re.IGNORECASE)
+_CSPROJ_REF = re.compile(
+    r'<PackageReference\s+Include\s*=\s*["\']([^"\']+)["\']\s+'
+    r'Version\s*=\s*["\']([^"\']+)["\']',
+    re.IGNORECASE,
+)
+_GO_REQUIRE = re.compile(
+    r"^([a-zA-Z0-9_.\-/]+(?:/v\d+)?)\s+v([0-9][^\s#]*)",
+)
+_GEM_LINE = re.compile(
+    r"""gem\s+["']([^"']+)["']""" r"""(?:\s*,\s*["']([^"']*)["'])?""",
+)
+_SETUP_CFG_REQUIRES = re.compile(r"(?m)^install_requires\s*=\s*\n((?:[ \t]+[^\n]+\n)+)")
+
+
+def _normalize_pypi_name(name: str) -> str:
+    return name.strip().lower().replace("_", "-")
+
+
+def _pypi_spec_pinned(raw: str) -> tuple[bool, Optional[str]]:
+    s = raw.strip()
+    if "===" in s:
+        parts = s.split("===", 1)
+        return True, parts[1].strip() if len(parts) > 1 else None
+    if "==" in s:
+        parts = s.split("==", 1)
+        return True, parts[1].strip() if len(parts) > 1 else None
+    if s and re.fullmatch(r"[0-9][0-9a-zA-Z._\-*!]*", s):
+        return True, s
+    return False, None
+
+
+def _parse_pep508_name_version(spec: str) -> tuple[str, str, bool, Optional[str]]:
+    spec = spec.strip()
+    if not spec or spec.startswith("#"):
+        return "", "", False, None
+    base = spec.split(";", 1)[0].strip()
+    sep_used: Optional[str] = None
+    name_part = base
+    ver_part = ""
+    for sep in ("===", "==", ">=", "<=", "~=", "!=", ">", "<"):
+        if sep in base:
+            name_part, ver_part = base.split(sep, 1)
+            name_part = name_part.strip()
+            ver_part = ver_part.strip()
+            sep_used = sep
+            break
+    if "[" in name_part:
+        name_part = name_part.split("[", 1)[0].strip()
+    m = _REQUIREMENT_NAME.match(name_part)
+    if not m:
+        return "", "", False, None
+    name = m.group(1)
+    if not ver_part:
+        return name, "*", False, None
+    if sep_used in ("==", "==="):
+        pinned, v = _pypi_spec_pinned(ver_part)
+        return name, ver_part, pinned, v
+    return name, ver_part, False, None
+
+
+def _parse_requirements_txt(
+    text: str, base_dir: Path, visited: Optional[set[Path]] = None
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    if visited is None:
+        visited = set()
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        lineno = i + 1
+        i += 1
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("-r ") or stripped.startswith("--requirement "):
+            inc = stripped.split(None, 1)[1].strip()
+            p = (base_dir / inc).resolve()
+            if p in visited or not p.is_file():
+                continue
+            visited.add(p)
+            try:
+                sub = p.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            out.extend(_parse_requirements_txt(sub, p.parent, visited))
+            continue
+        name, raw_spec, pinned, ver = _parse_pep508_name_version(stripped)
+        if not name:
+            continue
+        out.append((name, raw_spec, lineno, ver if pinned else None, "pypi"))
+    return out
+
+
+def _section_lines(text: str, header: str) -> list[str]:
+    header_l = header.lower()
+    in_section = False
+    collected: list[str] = []
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("[") and s.endswith("]"):
+            in_section = s.lower() == header_l
+            continue
+        if in_section:
+            if s.startswith("[") and s.endswith("]"):
+                break
+            collected.append(line)
+    return collected
+
+
+def _parse_pipfile(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    lines = _section_lines(text, "[packages]")
+    for idx, line in enumerate(lines, start=1):
+        raw = line.strip()
+        if not raw or raw.startswith("#"):
+            continue
+        m = _PIPFILE_PKG.match(raw)
+        if not m:
+            continue
+        name = m.group(1)
+        rest = raw[m.end() :].strip()
+        ver_m = re.search(r'version\s*=\s*["\']([^"\']+)["\']', rest)
+        quoted = re.search(r"=\s*[\"']([^\"']+)[\"']", rest)
+        raw_spec = ver_m.group(1) if ver_m else (quoted.group(1) if quoted else "*")
+        pinned, pv = _pypi_spec_pinned(raw_spec)
+        out.append((name, raw_spec, idx, pv if pinned else None, "pypi"))
+    return out
+
+
+def _parse_pyproject_toml(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    lower = text.lower()
+    for marker in ("[project.dependencies]", "[tool.poetry.dependencies]"):
+        pos = lower.find(marker.lower())
+        if pos < 0:
+            continue
+        chunk = text[pos:]
+        end = re.search(r"^\[", chunk[1:], re.MULTILINE)
+        section = chunk[: end.start() + 1] if end else chunk
+        line_base = text[:pos].count("\n")
+        for i, line in enumerate(section.splitlines(), start=0):
+            ls = line.strip()
+            if marker.endswith("poetry.dependencies") and ls.startswith("python "):
+                continue
+            for m in _TOML_STRING_DEP.finditer(line):
+                spec = m.group(1)
+                name, raw_spec, pinned, ver = _parse_pep508_name_version(spec)
+                if name:
+                    out.append(
+                        (
+                            name,
+                            raw_spec,
+                            line_base + i + 1,
+                            ver if pinned else None,
+                            "pypi",
+                        ),
+                    )
+    opt_re = re.compile(
+        r"^\[project\.optional-dependencies\.([^\]]+)\]\s*$",
+        re.MULTILINE | re.IGNORECASE,
+    )
+    for m in opt_re.finditer(text):
+        start = m.end()
+        rest = text[start:]
+        endm = re.search(r"^\[", rest, re.MULTILINE)
+        block = rest[: endm.start()] if endm else rest
+        line_base = text[:start].count("\n")
+        for i, line in enumerate(block.splitlines(), start=1):
+            for sm in _TOML_STRING_DEP.finditer(line):
+                spec = sm.group(1)
+                name, raw_spec, pinned, ver = _parse_pep508_name_version(spec)
+                if name:
+                    out.append(
+                        (
+                            name,
+                            raw_spec,
+                            line_base + i,
+                            ver if pinned else None,
+                            "pypi",
+                        ),
+                    )
+    return out
+
+
+def _parse_setup_content(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    for m in _INSTALL_REQUIRES.finditer(text):
+        inner = m.group(1)
+        line_base = text[: m.start()].count("\n")
+        for sm in _TOML_STRING_DEP.finditer(inner):
+            spec = sm.group(1)
+            name, raw_spec, pinned, ver = _parse_pep508_name_version(spec)
+            if name:
+                rel_line = inner[: sm.start()].count("\n")
+                out.append(
+                    (
+                        name,
+                        raw_spec,
+                        line_base + rel_line + 1,
+                        ver if pinned else None,
+                        "pypi",
+                    ),
+                )
+    for m in re.finditer(r"install_requires\s*=\s*\(([\s\S]*?)\)", text, re.MULTILINE):
+        inner = m.group(1)
+        line_base = text[: m.start()].count("\n")
+        for sm in _TOML_STRING_DEP.finditer(inner):
+            spec = sm.group(1)
+            name, raw_spec, pinned, ver = _parse_pep508_name_version(spec)
+            if name:
+                rel_line = inner[: sm.start()].count("\n")
+                out.append(
+                    (
+                        name,
+                        raw_spec,
+                        line_base + rel_line + 1,
+                        ver if pinned else None,
+                        "pypi",
+                    ),
+                )
+    return out
+
+
+def _parse_setup_cfg(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    for m in _SETUP_CFG_REQUIRES.finditer(text):
+        block = m.group(1)
+        line_base = text[: m.start(1)].count("\n") + 1
+        for i, line in enumerate(block.splitlines()):
+            spec = line.strip()
+            if not spec or spec.startswith("#"):
+                continue
+            name, raw_spec, pinned, ver = _parse_pep508_name_version(spec)
+            if name:
+                out.append(
+                    (name, raw_spec, line_base + i, ver if pinned else None, "pypi"),
+                )
+    joined = "\n".join(_section_lines(text, "[options]"))
+    out.extend(_parse_setup_content(joined))
+    return out
+
+
+def _parse_poetry_uv_lock(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        if _LOCK_PACKAGE.match(lines[i].strip()):
+            block_start = i + 1
+            i += 1
+            name_v: Optional[str] = None
+            ver_v: Optional[str] = None
+            name_line = block_start
+            while i < len(lines) and not lines[i].strip().startswith("["):
+                ln = lines[i]
+                nm = _LOCK_NAME.match(ln.strip())
+                if nm:
+                    name_v = nm.group(1)
+                    name_line = i + 1
+                vm = _LOCK_VERSION.match(ln.strip())
+                if vm:
+                    ver_v = vm.group(1)
+                i += 1
+            if name_v:
+                out.append((name_v, ver_v or "", name_line, ver_v, "pypi"))
+        else:
+            i += 1
+    return out
+
+
+def _line_for_needle(text: str, needle: str) -> int:
+    for idx, line in enumerate(text.splitlines(), start=1):
+        if needle in line:
+            return idx
+    return 1
+
+
+def _npm_pinned_version(raw: str) -> Optional[str]:
+    v = raw.strip()
+    if not v or v[0] in "^~>*<":
+        return None
+    if "||" in v or " - " in v:
+        return None
+    if re.fullmatch(r"\d[\d.]*", v):
+        return v
+    if re.fullmatch(r"\d+\.\d+\.\d+[\w.-]*", v):
+        return v
+    return None
+
+
+def _parse_package_json(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return out
+    for key in ("dependencies", "devDependencies"):
+        block = data.get(key)
+        if not isinstance(block, dict):
+            continue
+        for name, ver in block.items():
+            if not isinstance(ver, str):
+                continue
+            raw = ver.strip()
+            pv = _npm_pinned_version(raw)
+            needle = f'"{name}"'
+            ln = _line_for_needle(text, needle)
+            out.append((name, raw, ln, pv, "npm"))
+    return out
+
+
+def _walk_pkg_lock_deps(
+    obj: object,
+    text: str,
+    out: list[tuple[str, str, int, Optional[str], str]],
+) -> None:
+    if not isinstance(obj, dict):
+        return
+    for name, meta in obj.items():
+        if not isinstance(meta, dict):
+            continue
+        ver = meta.get("version")
+        if isinstance(ver, str):
+            ln = _line_for_needle(text, f'"{name}"')
+            out.append((name, ver, ln, ver, "npm"))
+        nested = meta.get("dependencies")
+        if isinstance(nested, dict):
+            _walk_pkg_lock_deps(nested, text, out)
+
+
+def _parse_package_lock_json(
+    text: str,
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return out
+    packages = data.get("packages")
+    if isinstance(packages, dict) and len(packages) > 0:
+        for path_key, meta in packages.items():
+            if not isinstance(meta, dict):
+                continue
+            if path_key == "":
+                continue
+            ver = meta.get("version")
+            if not isinstance(ver, str):
+                continue
+            name = meta.get("name")
+            if isinstance(name, str) and name:
+                disp = name
+            else:
+                parts = path_key.replace("\\", "/").split("/")
+                if "node_modules" in parts:
+                    idx = len(parts) - 1
+                    while idx >= 0 and parts[idx] != "node_modules":
+                        idx -= 1
+                    disp = "/".join(parts[idx + 1 :]) if idx >= 0 else path_key
+                else:
+                    disp = path_key
+            needle = disp.split("/")[-1]
+            ln = _line_for_needle(text, needle)
+            out.append((disp, ver, ln, ver, "npm"))
+    else:
+        deps = data.get("dependencies")
+        if isinstance(deps, dict):
+            _walk_pkg_lock_deps(deps, text, out)
+    return out
+
+
+def _parse_yarn_lock(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    for idx, line in enumerate(text.splitlines(), start=1):
+        if line.startswith("#") or not line.strip():
+            continue
+        if re.match(r"^[\w@./-]+@[^:]+:\s*$", line.strip()):
+            head = line.strip().rstrip(":").strip('"')
+            at_idx = head.rfind("@")
+            if at_idx <= 0:
+                continue
+            name = head[:at_idx]
+            ver = head[at_idx + 1 :]
+            if name.startswith('"') and name.endswith('"'):
+                name = name[1:-1]
+            out.append((name, ver, idx, ver, "npm"))
+    return out
+
+
+def _parse_pnpm_lock_yaml(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return out
+    packages = data.get("packages") if isinstance(data, dict) else None
+    if not isinstance(packages, dict):
+        return out
+    for key, _ in packages.items():
+        if not isinstance(key, str):
+            continue
+        k = key.strip("/")
+        parts = k.split("/")
+        if len(parts) >= 3 and parts[0] == "" and parts[1].startswith("@"):
+            name = f"{parts[1]}/{parts[2]}"
+            ver = parts[3] if len(parts) > 3 else ""
+        elif len(parts) >= 2 and parts[0] == "":
+            name, ver = parts[1], parts[2] if len(parts) > 2 else ""
+        elif len(parts) >= 2 and parts[0].startswith("@"):
+            name = f"{parts[0]}/{parts[1]}"
+            ver = parts[2] if len(parts) > 2 else ""
+        elif len(parts) >= 2:
+            name, ver = parts[0], parts[1]
+        else:
+            continue
+        pv: Optional[str] = ver if ver and ver[0].isdigit() else None
+        ln = _line_for_needle(text, k[: min(60, len(k))])
+        out.append((name, ver or "*", ln, pv, "npm"))
+    return out
+
+
+def _parse_cargo_toml(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    lines = _section_lines(text, "[dependencies]")
+    for idx, line in enumerate(lines, start=1):
+        raw = line.split("#", 1)[0].strip()
+        if not raw:
+            continue
+        m = _POETRY_DEP_KEY.match(raw)
+        if not m:
+            continue
+        name = m.group(1)
+        rest = raw[m.end() :].strip()
+        ver_m = re.search(r'version\s*=\s*["\']([^"\']+)["\']', rest)
+        simple = re.search(r"=\s*[\"']([^\"']+)[\"']", rest)
+        raw_spec = ver_m.group(1) if ver_m else (simple.group(1) if simple else "*")
+        pv: Optional[str] = None
+        if ver_m:
+            pv = ver_m.group(1)
+        elif simple and re.fullmatch(r"[\d.]+", simple.group(1)):
+            pv = simple.group(1)
+        out.append((name, raw_spec, idx, pv, "cargo"))
+    return out
+
+
+def _parse_go_mod(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    in_require = False
+    for idx, line in enumerate(text.splitlines(), start=1):
+        s = line.strip()
+        if s.startswith("require ("):
+            in_require = True
+            continue
+        if in_require:
+            if s == ")":
+                in_require = False
+                continue
+            m = _GO_REQUIRE.match(line.strip())
+            if m:
+                out.append((m.group(1), m.group(2), idx, m.group(2), "go"))
+            continue
+        if s.startswith("require ") and "(" not in s:
+            rest = s[8:].strip()
+            m = _GO_REQUIRE.match(rest)
+            if m:
+                out.append((m.group(1), m.group(2), idx, m.group(2), "go"))
+    return out
+
+
+def _parse_gemfile(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    for idx, line in enumerate(text.splitlines(), start=1):
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        m = _GEM_LINE.match(s)
+        if m:
+            name = m.group(1)
+            ver = (m.group(2) or "").strip()
+            pv = ver if ver and re.fullmatch(r"[\d.]+", ver) else None
+            out.append((name, ver or "*", idx, pv, "rubygems"))
+    return out
+
+
+def _parse_pom_xml(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    for dm in _POM_DEP.finditer(text):
+        block = dm.group(1)
+        gm = _POM_GROUP.search(block)
+        am = _POM_ARTIFACT.search(block)
+        if not gm or not am:
+            continue
+        g, a = gm.group(1).strip(), am.group(1).strip()
+        coord = f"{g}:{a}"
+        vm = _POM_VERSION.search(block)
+        ver_raw = vm.group(1).strip() if vm else ""
+        if ver_raw.startswith("${"):
+            pv: Optional[str] = None
+        else:
+            pv = ver_raw if ver_raw else None
+        line = text[: dm.start()].count("\n") + 1
+        out.append((coord, ver_raw or "*", line, pv, "maven"))
+    return out
+
+
+def _parse_gradle(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    for m in _GRADLE_DEP.finditer(text):
+        spec = m.group(1)
+        parts = spec.split(":")
+        line = text[: m.start()].count("\n") + 1
+        if len(parts) >= 3:
+            g, a, v = parts[0], parts[1], ":".join(parts[2:])
+            coord = f"{g}:{a}"
+            pv = v if v and not v.startswith("$") else None
+            out.append((coord, v, line, pv, "maven"))
+        elif len(parts) == 2:
+            out.append((f"{parts[0]}:{parts[1]}", "*", line, None, "maven"))
+    for m in _GRADLE_KTS.finditer(text):
+        spec = m.group(1)
+        parts = spec.split(":")
+        line = text[: m.start()].count("\n") + 1
+        if len(parts) >= 3:
+            g, a, v = parts[0], parts[1], ":".join(parts[2:])
+            coord = f"{g}:{a}"
+            pv = v if v and not v.startswith("$") else None
+            out.append((coord, v, line, pv, "maven"))
+    return out
+
+
+def _parse_csproj(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
+    out: list[tuple[str, str, int, Optional[str], str]] = []
+    for m in _CSPROJ_REF.finditer(text):
+        name, ver = m.group(1), m.group(2)
+        line = text[: m.start()].count("\n") + 1
+        pv = ver if ver and not ver.startswith("$") else None
+        out.append((name, ver, line, pv, "nuget"))
+    return out
+
+
+def _parse_requirements_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_requirements_txt(text, path.parent)
+
+
+def _parse_pipfile_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_pipfile(text)
+
+
+def _parse_pyproject_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_pyproject_toml(text)
+
+
+def _parse_setup_py_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_setup_content(text)
+
+
+def _parse_setup_cfg_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_setup_cfg(text)
+
+
+def _parse_lock_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_poetry_uv_lock(text)
+
+
+def _parse_package_json_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_package_json(text)
+
+
+def _parse_package_lock_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_package_lock_json(text)
+
+
+def _parse_yarn_lock_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_yarn_lock(text)
+
+
+def _parse_pnpm_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_pnpm_lock_yaml(text)
+
+
+def _parse_cargo_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_cargo_toml(text)
+
+
+def _parse_go_mod_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_go_mod(text)
+
+
+def _parse_gemfile_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_gemfile(text)
+
+
+def _parse_pom_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_pom_xml(text)
+
+
+def _parse_gradle_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_gradle(text)
+
+
+def _parse_gradle_kts_file(
+    path: Path, text: str
+) -> list[tuple[str, str, int, Optional[str], str]]:
+    return _parse_gradle(text)
+
+
+_ManifestParser = Callable[[Path, str], list[tuple[str, str, int, Optional[str], str]]]
+
+_MANIFEST_PARSERS: dict[str, _ManifestParser] = {
+    "requirements.txt": _parse_requirements_file,
+    "pipfile": _parse_pipfile_file,
+    "pyproject.toml": _parse_pyproject_file,
+    "setup.py": _parse_setup_py_file,
+    "setup.cfg": _parse_setup_cfg_file,
+    "poetry.lock": _parse_lock_file,
+    "uv.lock": _parse_lock_file,
+    "package.json": _parse_package_json_file,
+    "package-lock.json": _parse_package_lock_file,
+    "yarn.lock": _parse_yarn_lock_file,
+    "pnpm-lock.yaml": _parse_pnpm_file,
+    "cargo.toml": _parse_cargo_file,
+    "go.mod": _parse_go_mod_file,
+    "gemfile": _parse_gemfile_file,
+    "pom.xml": _parse_pom_file,
+    "build.gradle": _parse_gradle_file,
+    "build.gradle.kts": _parse_gradle_kts_file,
+}
+
+
+def _is_ai(ecosystem: str, name: str) -> bool:
+    if ecosystem == "nuget":
+        return False
+    if ecosystem == "maven":
+        g, _, a = name.partition(":")
+        if not a:
+            return False
+        coord = f"{g}:{a}"
+        if coord in _MAVEN_EXACT_COORDS:
+            return True
+        if g == _MAVEN_GROUP_PREFIX or g.startswith(_MAVEN_GROUP_PREFIX + "."):
+            return True
+        return False
+    if ecosystem == "go":
+        for mod in AI_PACKAGES["go"]:
+            if name == mod or name.startswith(mod + "/"):
+                return True
+        return False
+    pkgs = AI_PACKAGES.get(ecosystem, set())
+    if ecosystem == "pypi":
+        return _normalize_pypi_name(name) in pkgs
+    return name in pkgs
+
+
+def _display_name(ecosystem: str, name: str) -> str:
+    if ecosystem == "pypi":
+        return _normalize_pypi_name(name)
+    return name
+
+
+def _iter_scan_paths(context: ScanContext) -> Iterator[Path]:
+    spec: Optional[PathSpec] = None
+    if context.exclude_patterns:
+        spec = PathSpec.from_lines("gitwildmatch", context.exclude_patterns)
+    for p in context.paths:
+        root = Path(p)
+        if not root.exists():
+            continue
+        if root.is_file():
+            if spec:
+                rel = root.name
+                if spec.match_file(rel):
+                    continue
+            yield root
+            continue
+        for f in root.rglob("*"):
+            if not f.is_file():
+                continue
+            try:
+                rel = f.relative_to(root).as_posix()
+            except ValueError:
+                rel = str(f)
+            if spec and spec.match_file(rel):
+                continue
+            yield f
+
+
+def _parse_manifest(path: Path) -> list[tuple[str, str, int, Optional[str], str]]:
+    name = path.name.lower()
+    if name.endswith(".csproj"):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return []
+        return _parse_csproj(text)
+    parser = _MANIFEST_PARSERS.get(name)
+    if not parser:
+        return []
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    return parser(path, text)
+
+
+class DependencyScanner(BaseScanner):
+    name = "dependency_scanner"
+
+    def supports(self, context: ScanContext) -> bool:
+        return True
+
+    def scan(
+        self, context: ScanContext
+    ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+        components: list[AIComponent] = []
+        for path in _iter_scan_paths(context):
+            key = path.name.lower()
+            if key not in _MANIFEST_PARSERS and not key.endswith(".csproj"):
+                continue
+            for name, raw_spec, line_no, pinned_ver, ecosystem in _parse_manifest(path):
+                if not _is_ai(ecosystem, name):
+                    continue
+                disp = _display_name(ecosystem, name)
+                meta = {
+                    "ecosystem": ecosystem,
+                    "version_spec": raw_spec,
+                    "manifest": path.name,
+                }
+                components.append(
+                    AIComponent(
+                        name=disp,
+                        component_type=AIComponentType.DEPENDENCY,
+                        file_path=str(path.resolve()),
+                        line_number=line_no,
+                        sdk_version=pinned_ver,
+                        detection_source=DetectionSource.DEPENDENCY_MANIFEST,
+                        metadata=meta,
+                    ),
+                )
+        return components, []

--- a/aibom/src/aibom/scanners/kb_enrichment_scanner.py
+++ b/aibom/src/aibom/scanners/kb_enrichment_scanner.py
@@ -1,0 +1,430 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""KB Enrichment Scanner -- combines LibCST parsing with the DuckDB knowledge
+base to detect and classify AI framework usage in Python source code.
+
+Unlike the legacy ``categorize_symbols`` path which emits every KB match, this
+scanner filters results to only high-signal AI asset concepts: agents, models,
+tools, vector stores, embeddings, prompts, memory, and retrievers.  When no KB
+is installed the scanner gracefully no-ops, letting the other v2 detectors
+carry the workload.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from ..catalog_db import CatalogDB
+from ..cst_parser import parse_source_code
+from ..db_loader import DatabaseLoadError, ensure_local_database
+from ..models import (
+    AIComponent,
+    AIComponentType,
+    ComponentRelationship,
+    DetectionSource,
+    ScanContext,
+)
+from ..structures import CodeAnalysisResult
+from .base import BaseScanner
+
+_LOGGER = logging.getLogger(__name__)
+
+ALLOWED_CONCEPTS: frozenset[str] = frozenset(
+    {"agent", "model", "tool", "datastore", "embedding", "prompt", "memory", "retriever"}
+)
+
+_CONCEPT_TO_TYPE: dict[str, AIComponentType] = {
+    "agent": AIComponentType.AGENT,
+    "model": AIComponentType.MODEL,
+    "tool": AIComponentType.TOOL,
+    "datastore": AIComponentType.VECTOR_STORE,
+    "embedding": AIComponentType.EMBEDDING,
+    "prompt": AIComponentType.PROMPT,
+    "memory": AIComponentType.MEMORY,
+    "retriever": AIComponentType.RETRIEVER,
+}
+
+
+def _resolve_kb_path(context: ScanContext) -> Optional[Path]:
+    """Locate the KB DuckDB file.  Returns ``None`` when unavailable."""
+    if context.kb_path:
+        p = Path(context.kb_path)
+        if p.is_file():
+            return p
+
+    try:
+        return ensure_local_database()
+    except (DatabaseLoadError, Exception):  # noqa: BLE001
+        pass
+
+    catalogs_dir = Path.home() / ".aibom" / "catalogs"
+    if catalogs_dir.is_dir():
+        dbs = sorted(catalogs_dir.glob("*.duckdb"), reverse=True)
+        if dbs:
+            return dbs[0]
+
+    return None
+
+
+def _extract_frameworks_from_imports(imports: list[str]) -> set[str]:
+    """Derive top-level package names from import statements.
+
+    e.g. ``"from langchain_openai import ChatOpenAI"`` → ``{"langchain_openai"}``
+    """
+    frameworks: set[str] = set()
+    for stmt in imports:
+        if stmt.startswith("from "):
+            module = stmt.split()[1] if len(stmt.split()) > 1 else ""
+            top = module.split(".")[0]
+            if top:
+                frameworks.add(top)
+        elif stmt.startswith("import "):
+            module = stmt.split()[1] if len(stmt.split()) > 1 else ""
+            top = module.split(".")[0]
+            if top:
+                frameworks.add(top)
+    return frameworks
+
+
+class KBEnrichmentScanner(BaseScanner):
+    """Detect AI framework usage by matching LibCST observations against the KB.
+
+    Only emits for concepts in :data:`ALLOWED_CONCEPTS`, suppressing the noise
+    that made the legacy categorizer output hard to use.
+    """
+
+    name = "kb_enrichment"
+
+    def supports(self, context: ScanContext) -> bool:
+        return _resolve_kb_path(context) is not None
+
+    def scan(
+        self, context: ScanContext
+    ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+        kb_path = _resolve_kb_path(context)
+        if not kb_path:
+            return [], []
+
+        _LOGGER.info("KB enrichment: using %s", kb_path)
+        components: list[AIComponent] = []
+
+        with CatalogDB(kb_path) as db:
+            custom_cfg = context.config.get("custom_catalog")
+            if custom_cfg is not None:
+                try:
+                    from ..custom_catalog import CustomCatalogConfig
+
+                    if isinstance(custom_cfg, CustomCatalogConfig) and not custom_cfg.is_empty:
+                        db.add_custom_entries(
+                            [c.to_catalog_dict() for c in custom_cfg.components]
+                        )
+                        if custom_cfg.excludes:
+                            db.add_excludes(custom_cfg.excludes)
+                except Exception:  # noqa: BLE001
+                    _LOGGER.debug("KB enrichment: custom catalog load failed", exc_info=True)
+
+            for py_file in _find_python_files(context):
+                try:
+                    source = py_file.read_text(encoding="utf-8")
+                    result = parse_source_code(str(py_file), source)
+                    components.extend(_process_file(result, db))
+                except Exception:  # noqa: BLE001
+                    _LOGGER.debug("KB enrichment: failed to parse %s", py_file, exc_info=True)
+
+        return components, []
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_python_files(context: ScanContext) -> list[Path]:
+    files: list[Path] = []
+    for p in context.paths:
+        path = Path(p)
+        if path.is_file() and path.suffix == ".py":
+            files.append(path)
+        elif path.is_dir():
+            files.extend(sorted(path.rglob("*.py")))
+    return files
+
+
+def _process_file(
+    result: CodeAnalysisResult, db: CatalogDB
+) -> list[AIComponent]:
+    """Match one file's parsed observations against the KB."""
+
+    variable_map: dict[str, str] = {}
+    for assignment in result.assignments:
+        if assignment.target_qualified_name and assignment.call.qualified_name:
+            variable_map[assignment.target_qualified_name] = assignment.call.qualified_name
+
+    observations: list[dict[str, Any]] = []
+    symbols: set[str] = set()
+
+    for assignment in result.assignments:
+        name = _resolve_chain(assignment.call.qualified_name, variable_map)
+        observations.append(
+            _obs(name, result.file_path, assignment.line_number, "assignment",
+                 args=assignment.call.arguments,
+                 assigned_target=assignment.target_qualified_name)
+        )
+        symbols.add(name)
+
+    for dec in result.decorators:
+        name = dec.decorator_qualified_name
+        if dec.instance_variable and dec.instance_variable in variable_map:
+            base = variable_map[dec.instance_variable]
+            attr = name.split(".", 1)[-1] if "." in name else name
+            name = f"{base}.{attr}"
+        name = _resolve_chain(name, variable_map)
+        observations.append(
+            _obs(name, result.file_path, dec.line_number, "decorator",
+                 decorated=dec.decorated_function_name)
+        )
+        symbols.add(name)
+
+    for ctx in result.context_managers:
+        if not ctx.context_expr_qualified_name:
+            continue
+        name = _resolve_chain(ctx.context_expr_qualified_name, variable_map)
+        observations.append(
+            _obs(name, result.file_path, ctx.line_number, "context_manager")
+        )
+        symbols.add(name)
+
+    if not symbols:
+        return []
+
+    query_suffixes = set(symbols)
+    for s in symbols:
+        if "." in s:
+            query_suffixes.add(s.rsplit(".", 1)[-1])
+            cls = _extract_class_segment(s)
+            if cls:
+                query_suffixes.add(cls)
+
+    matched = db.find_components_by_suffixes(list(query_suffixes))
+
+    kb_by_id: dict[str, dict[str, Any]] = {}
+    for entry in matched:
+        concept = (entry.get("concept") or "").lower()
+        if concept not in ALLOWED_CONCEPTS:
+            continue
+        eid = entry["id"]
+        if eid not in kb_by_id:
+            kb_by_id[eid] = entry
+
+    imported_frameworks = _extract_frameworks_from_imports(getattr(result, "imports", []) or [])
+
+    components: list[AIComponent] = []
+    seen: set[tuple[str, int]] = set()
+
+    for obs_data in observations:
+        key = (obs_data["file"], obs_data["line"])
+        if key in seen:
+            continue
+
+        kb_entry = _match_observation(obs_data["name"], kb_by_id, imported_frameworks)
+        if not kb_entry:
+            continue
+
+        concept = kb_entry["concept"].lower()
+        comp_type = _CONCEPT_TO_TYPE.get(concept)
+        if not comp_type:
+            continue
+
+        seen.add(key)
+
+        display_name = obs_data["name"]
+        if obs_data["type"] == "decorator" and obs_data.get("decorated"):
+            display_name = obs_data["decorated"]
+
+        components.append(
+            AIComponent(
+                name=display_name,
+                component_type=comp_type,
+                file_path=obs_data["file"],
+                line_number=obs_data["line"],
+                framework=kb_entry.get("framework", ""),
+                detection_source=DetectionSource.KB_ENRICHMENT,
+                kb_concept=concept,
+                kb_label=kb_entry.get("label", ""),
+                metadata={
+                    "kb_id": kb_entry["id"],
+                    "observation_type": obs_data["type"],
+                },
+            )
+        )
+
+    return components
+
+
+def _obs(
+    name: str,
+    file_path: str,
+    line: int,
+    obs_type: str,
+    *,
+    args: Optional[dict[str, Any]] = None,
+    assigned_target: Optional[str] = None,
+    decorated: Optional[str] = None,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "file": file_path,
+        "line": line,
+        "type": obs_type,
+        "args": args or {},
+        "assigned_target": assigned_target,
+        "decorated": decorated,
+    }
+
+
+def _resolve_chain(name: str, variable_map: dict[str, str]) -> str:
+    """Resolve ``var.method`` → ``FullyQualified.method`` via the variable map."""
+    if "." in name:
+        head, tail = name.split(".", 1)
+        if head in variable_map:
+            return f"{variable_map[head]}.{tail}"
+    return name
+
+
+def _match_observation(
+    obs_name: str,
+    kb_by_id: dict[str, dict[str, Any]],
+    imported_frameworks: set[str],
+) -> Optional[dict[str, Any]]:
+    """Return the best KB entry for *obs_name*, or ``None``.
+
+    Tier 1: exact match on KB id.
+    Tier 2: suffix match on full qualified name.
+    Tier 3: suffix match on the SHORT class/function name (last dot-segment),
+            disambiguated by imported frameworks.  This handles the common case
+            where a wrapper package (``langchain_openai``) re-exports from an
+            implementation package (``langchain_community``).
+    """
+    # Tier 1 -- exact
+    if obs_name in kb_by_id:
+        return kb_by_id[obs_name]
+
+    obs_module = obs_name.split(".")[0] if "." in obs_name else ""
+
+    # Tier 2 -- full qualified suffix, validated against framework family.
+    # Without this check ``openai.OpenAI`` would match
+    # ``langchain_community.llms.openai.OpenAI`` via the coincidental
+    # ``.openai.OpenAI`` submodule path.
+    candidates: list[dict[str, Any]] = []
+    for kb_id, entry in kb_by_id.items():
+        if kb_id.endswith("." + obs_name):
+            if not obs_module or _frameworks_related(obs_module, entry.get("framework", "")):
+                candidates.append(entry)
+
+    if candidates:
+        return _pick_best(candidates, imported_frameworks, obs_module)
+
+    # Tier 3 -- short-name suffix using the nearest class-like (uppercase)
+    # segment from the observation name.  This handles wrapper re-exports
+    # (``langchain_openai.ChatOpenAI`` → KB has ``langchain_community.*.ChatOpenAI``)
+    # and factory calls (``FAISS.from_texts`` → class segment ``FAISS``).
+    class_name = _extract_class_segment(obs_name)
+    if not class_name:
+        return None
+
+    for kb_id, entry in kb_by_id.items():
+        if kb_id.endswith("." + class_name):
+            candidates.append(entry)
+
+    if not candidates:
+        return None
+
+    # Tier 3 is the loosest match; require the best candidate's framework to
+    # share a package-family prefix with the observation's module so that
+    # ``openai.OpenAI.chat.completions.create`` doesn't match a
+    # ``langchain_community`` entry just because both have an ``OpenAI`` class.
+    best = _pick_best(candidates, imported_frameworks, obs_module)
+    if obs_module and not _frameworks_related(obs_module, best.get("framework", "")):
+        return None
+    return best
+
+
+def _extract_class_segment(obs_name: str) -> Optional[str]:
+    """Return the nearest class-like (uppercase-start) segment from a dotted name.
+
+    Scans right-to-left so that ``pkg.FAISS.from_texts`` yields ``FAISS`` and
+    ``openai.OpenAI.chat.completions.create`` yields ``OpenAI``.  Returns
+    ``None`` when no uppercase segment is found or the result would be the
+    entire *obs_name* (already covered by Tier 1).
+    """
+    if "." not in obs_name:
+        return None
+    parts = obs_name.split(".")
+    for segment in reversed(parts):
+        if segment and segment[0].isupper():
+            if segment == obs_name:
+                return None
+            return segment
+    return None
+
+
+def _frameworks_related(obs_module: str, kb_framework: str) -> bool:
+    """Return ``True`` when the observation module and KB framework belong to
+    the same package family.
+
+    ``langchain_openai`` and ``langchain_community`` share the ``langchain``
+    prefix; ``crewai`` matches ``crewai``; ``openai`` does not match
+    ``langchain_community``.
+    """
+    if not obs_module or not kb_framework:
+        return True
+    if obs_module == kb_framework:
+        return True
+    obs_top = obs_module.split("_")[0].split("-")[0]
+    kb_top = kb_framework.split("_")[0].split("-")[0]
+    return obs_top == kb_top
+
+
+def _pick_best(
+    candidates: list[dict[str, Any]],
+    imported_frameworks: set[str],
+    obs_module: str = "",
+) -> dict[str, Any]:
+    """From a set of KB candidates, prefer the one whose framework matches best.
+
+    Priority: framework matches the observation's module prefix > framework is
+    imported > first candidate.
+    """
+    if len(candidates) == 1:
+        return candidates[0]
+
+    # Prefer the candidate whose framework matches the observation module prefix.
+    if obs_module:
+        for c in candidates:
+            fw = c.get("framework") or ""
+            if fw == obs_module or fw.startswith(obs_module):
+                return c
+
+    for c in candidates:
+        fw = c.get("framework") or ""
+        fw_top = fw.split("_")[0].split("-")[0]
+        if fw in imported_frameworks or fw_top in imported_frameworks:
+            return c
+
+    return candidates[0]

--- a/aibom/src/aibom/scanners/mcp_detector.py
+++ b/aibom/src/aibom/scanners/mcp_detector.py
@@ -1,0 +1,329 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+from pathspec import PathSpec
+
+from ..models import AIComponent, ComponentRelationship, ScanContext
+from ..models.enums import AIComponentType, DetectionSource
+from .base import BaseScanner
+
+_LOGGER = logging.getLogger(__name__)
+
+_CONFIG_NAMES = frozenset(
+    {
+        "mcp.json",
+        ".mcp.json",
+        "mcp_config.json",
+        "claude_desktop_config.json",
+        "cline_mcp_settings.json",
+    }
+)
+
+_RE_FROM_MCP_IMPORT = re.compile(r"from\s+mcp\s+import\b")
+_RE_FROM_MCP_SERVER_IMPORT = re.compile(r"from\s+mcp\.server\s+import\b")
+_RE_FASTMCP = re.compile(r"\bFastMCP\s*\(")
+_RE_SERVER_CALL = re.compile(r"\bServer\s*\(")
+_RE_MCP_TOOL_DECORATOR = re.compile(
+    r"@\s*\w+\s*\.\s*(tool|resource|prompt)\s*\(", re.MULTILINE
+)
+_RE_MCP_CLIENT = re.compile(r"\bMCPClient\s*\(")
+_RE_MULTI_MCP_CLIENT = re.compile(r"\bMultiServerMCPClient\s*\(")
+_RE_LANGCHAIN_MCP_ADAPTERS = re.compile(r"from\s+langchain_mcp_adapters\b")
+_RE_CLIENT_SESSION = re.compile(r"\bClientSession\s*\(")
+_RE_MCP_CLIENT_MODULE = re.compile(r"\bmcp\.client\b")
+
+
+def _is_mcp_config_path(path: Path) -> bool:
+    if path.name in _CONFIG_NAMES:
+        return True
+    parts = path.parts
+    return len(parts) >= 2 and parts[-2] == ".cursor" and path.name == "mcp.json"
+
+
+def _load_exclude_spec(patterns: list[str]) -> Optional[PathSpec]:
+    if not patterns:
+        return None
+    return PathSpec.from_lines("gitwildmatch", patterns)
+
+
+def _is_excluded(
+    file_path: Path, root: Path, spec: Optional[PathSpec]
+) -> bool:
+    if not spec:
+        return False
+    try:
+        rel = file_path.relative_to(root).as_posix()
+    except ValueError:
+        rel = file_path.as_posix()
+    return spec.match_file(rel)
+
+
+def _iter_files_under(root: Path, spec: Optional[PathSpec]) -> list[Path]:
+    out: list[Path] = []
+    if root.is_file():
+        if not _is_excluded(root, root.parent, spec):
+            out.append(root)
+        return out
+    if not root.is_dir():
+        return out
+    for p in root.rglob("*"):
+        if p.is_file() and not _is_excluded(p, root, spec):
+            out.append(p)
+    return out
+
+
+def _extract_servers_blob(data: Any) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        return {}
+    for key in ("mcpServers", "servers"):
+        blob = data.get(key)
+        if isinstance(blob, dict):
+            return blob
+    return {}
+
+
+def _infer_transport(server: dict[str, Any]) -> str:
+    raw = server.get("transport") or server.get("type")
+    if isinstance(raw, str) and raw.strip():
+        t = raw.strip().lower()
+        if t in ("stdio", "sse", "streamable-http", "streamable_http"):
+            return "streamable-http" if t == "streamable_http" else t
+    if server.get("url"):
+        url = str(server.get("url", "")).lower()
+        if "streamable" in url:
+            return "streamable-http"
+        return "sse"
+    return "stdio"
+
+
+def _server_metadata(server: dict[str, Any]) -> dict[str, Any]:
+    meta: dict[str, Any] = {}
+    if "command" in server:
+        meta["command"] = server.get("command")
+    if "args" in server:
+        meta["args"] = server.get("args")
+    if "url" in server:
+        meta["url"] = server.get("url")
+    env = server.get("env")
+    if isinstance(env, dict):
+        meta["env_keys"] = sorted(str(k) for k in env.keys())
+    return meta
+
+
+def _parse_config_file(path: Path) -> tuple[Optional[dict[str, Any]], bool]:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        data = json.loads(text)
+    except (OSError, json.JSONDecodeError):
+        return None, False
+    servers = _extract_servers_blob(data)
+    return data, bool(servers)
+
+
+def _components_from_config(path: Path) -> list[AIComponent]:
+    data, has_servers = _parse_config_file(path)
+    if not has_servers or data is None:
+        return []
+    servers = _extract_servers_blob(data)
+    cfg = str(path.resolve())
+    out: list[AIComponent] = []
+    for name, raw in servers.items():
+        if not isinstance(raw, dict):
+            continue
+        transport = _infer_transport(raw)
+        meta = _server_metadata(raw)
+        out.append(
+            AIComponent(
+                name=str(name),
+                component_type=AIComponentType.MCP_SERVER,
+                file_path=cfg,
+                line_number=0,
+                framework="mcp",
+                detection_source=DetectionSource.CONFIG_FILE,
+                transport=transport,
+                config_source=cfg,
+                metadata=meta,
+            )
+        )
+    return out
+
+
+def _line_for_match(text: str, pos: int) -> int:
+    return text.count("\n", 0, pos) + 1
+
+
+def _first_match_line(pattern: re.Pattern[str], text: str) -> Optional[int]:
+    m = pattern.search(text)
+    if not m:
+        return None
+    return _line_for_match(text, m.start())
+
+
+def _components_from_python(path: Path) -> list[AIComponent]:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    fp = str(path.resolve())
+    out: list[AIComponent] = []
+
+    server_hits: list[tuple[str, int]] = []
+    m_imp = _RE_FROM_MCP_IMPORT.search(text)
+    if m_imp:
+        server_hits.append(("from_mcp_import", _line_for_match(text, m_imp.start())))
+    m_srv_imp = _RE_FROM_MCP_SERVER_IMPORT.search(text)
+    if m_srv_imp:
+        server_hits.append(
+            (
+                "from_mcp_server_import",
+                _line_for_match(text, m_srv_imp.start()),
+            )
+        )
+    ln = _first_match_line(_RE_FASTMCP, text)
+    if ln is not None:
+        server_hits.append(("FastMCP", ln))
+    m_srv_call = _RE_SERVER_CALL.search(text)
+    if m_srv_call and (
+        _RE_FROM_MCP_SERVER_IMPORT.search(text) or "mcp.server" in text
+    ):
+        server_hits.append(("Server", _line_for_match(text, m_srv_call.start())))
+    if server_hits:
+        server_hits.sort(key=lambda x: x[1])
+        kinds = [k for k, _ in server_hits]
+        out.append(
+            AIComponent(
+                name=f"{path.stem}_mcp_server",
+                component_type=AIComponentType.MCP_SERVER,
+                file_path=fp,
+                line_number=server_hits[0][1],
+                framework="mcp",
+                detection_source=DetectionSource.CODE_ANALYSIS,
+                metadata={"patterns": kinds},
+            )
+        )
+
+    mdec = _RE_MCP_TOOL_DECORATOR.search(text)
+    if mdec:
+        out.append(
+            AIComponent(
+                name=f"{path.stem}_mcp_tooling",
+                component_type=AIComponentType.TOOL,
+                file_path=fp,
+                line_number=_line_for_match(text, mdec.start()),
+                framework="mcp",
+                detection_source=DetectionSource.CODE_ANALYSIS,
+                metadata={"mcp_decorators": True},
+            )
+        )
+
+    client_hits: list[tuple[str, int]] = []
+    for label, pat in (
+        ("MCPClient", _RE_MCP_CLIENT),
+        ("MultiServerMCPClient", _RE_MULTI_MCP_CLIENT),
+    ):
+        m = pat.search(text)
+        if m:
+            client_hits.append((label, _line_for_match(text, m.start())))
+    m_lc = _RE_LANGCHAIN_MCP_ADAPTERS.search(text)
+    if m_lc:
+        client_hits.append(
+            ("langchain_mcp_adapters", _line_for_match(text, m_lc.start()))
+        )
+    m_cs = _RE_CLIENT_SESSION.search(text)
+    if m_cs and _RE_MCP_CLIENT_MODULE.search(text):
+        client_hits.append(("ClientSession", _line_for_match(text, m_cs.start())))
+    if client_hits:
+        client_hits.sort(key=lambda x: x[1])
+        out.append(
+            AIComponent(
+                name=f"{path.stem}_mcp_client",
+                component_type=AIComponentType.MCP_CLIENT,
+                file_path=fp,
+                line_number=client_hits[0][1],
+                framework="mcp",
+                detection_source=DetectionSource.CODE_ANALYSIS,
+                metadata={"patterns": [k for k, _ in client_hits]},
+            )
+        )
+
+    return out
+
+
+def _run_optional_yara_on_configs(config_paths: list[str]) -> None:
+    try:
+        from mcpscanner import Config, Scanner
+        from mcpscanner.core.models import AnalyzerEnum
+    except ImportError:
+        return
+
+    async def _scan_all() -> None:
+        scanner = Scanner(Config())
+        for cfg in config_paths:
+            try:
+                await scanner.scan_mcp_config_file(
+                    cfg,
+                    analyzers=[AnalyzerEnum.YARA],
+                )
+            except Exception:
+                _LOGGER.debug(
+                    "mcpscanner YARA scan failed for %s", cfg, exc_info=True
+                )
+
+    try:
+        asyncio.run(_scan_all())
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(_scan_all())
+        finally:
+            loop.close()
+
+
+class McpDetector(BaseScanner):
+    name = "mcp_detector"
+
+    def supports(self, context: ScanContext) -> bool:
+        return True
+
+    def scan(
+        self, context: ScanContext
+    ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+        spec = _load_exclude_spec(context.exclude_patterns)
+        components: list[AIComponent] = []
+        config_paths_seen: set[str] = set()
+
+        for raw in context.paths:
+            root = Path(raw).expanduser()
+            for file_path in _iter_files_under(root, spec):
+                if _is_mcp_config_path(file_path):
+                    config_paths_seen.add(str(file_path.resolve()))
+                    components.extend(_components_from_config(file_path))
+                elif file_path.suffix == ".py":
+                    components.extend(_components_from_python(file_path))
+
+        if config_paths_seen:
+            _run_optional_yara_on_configs(sorted(config_paths_seen))
+
+        return components, []

--- a/aibom/src/aibom/scanners/ml_lifecycle_detector.py
+++ b/aibom/src/aibom/scanners/ml_lifecycle_detector.py
@@ -1,0 +1,558 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Optional
+from urllib.parse import urlparse
+
+from pathspec import PathSpec
+
+from ..models import AIComponent, ComponentRelationship, ScanContext
+from ..models.enums import AIComponentType, DetectionSource
+from .base import BaseScanner
+
+
+@dataclass(frozen=True)
+class ConceptPattern:
+    concept: AIComponentType
+    patterns: list[tuple[re.Pattern[str], str]]
+    import_patterns: list[tuple[str, str]]
+    description: str
+
+
+def _build_pathspec(patterns: list[str]) -> Optional[PathSpec]:
+    if not patterns:
+        return None
+    return PathSpec.from_lines("gitwildmatch", patterns)
+
+
+def _iter_files(context: ScanContext) -> Iterator[tuple[Path, str]]:
+    spec = _build_pathspec(context.exclude_patterns)
+    for scan_root in context.paths:
+        root = Path(scan_root)
+        if not root.exists():
+            continue
+        if root.is_file():
+            rel = root.name
+            if spec and spec.match_file(rel):
+                continue
+            yield root, rel
+            continue
+        base = root.resolve()
+        for f in root.rglob("*"):
+            if not f.is_file():
+                continue
+            try:
+                rel = f.resolve().relative_to(base).as_posix()
+            except ValueError:
+                rel = f.as_posix()
+            if spec and spec.match_file(rel):
+                continue
+            yield f, rel
+
+
+def _line_number(text: str, pos: int) -> int:
+    return text.count("\n", 0, pos) + 1
+
+
+def _normalize_hp_value(raw: str) -> Any:
+    s = raw.strip().rstrip(",").strip()
+    if (s.startswith('"') and s.endswith('"')) or (s.startswith("'") and s.endswith("'")):
+        return s[1:-1]
+    low = s.lower()
+    if low in ("true", "false"):
+        return low == "true"
+    if low == "none":
+        return None
+    try:
+        if "." in s or "e" in low:
+            return float(s)
+        return int(s)
+    except ValueError:
+        return s
+
+
+def _extract_uri_from_line(line: str) -> Optional[str]:
+    for m in re.finditer(
+        r"(?:s3|gs)://[^\s\"'<>]+|https?://[^\s\"'<>]+", line, re.IGNORECASE
+    ):
+        u = m.group(0).rstrip(").,;]}'\"")
+        if urlparse(u).scheme:
+            return u
+    return None
+
+
+_CI_PATH_RE = re.compile(
+    r"(?i)(?:s3|aws)\s+cp\s+[^\n]*\.(?:safetensors|gguf|pt|pth|onnx|h5|pb|tflite|bin|mlmodel)\b"
+)
+_CI_GSUTIL_RE = re.compile(
+    r"(?i)gsutil\s+cp\s+[^\n]*\.(?:safetensors|gguf|pt|pth|onnx|h5|pb|tflite|bin|mlmodel)\b"
+)
+_CI_ARTIFACT_RE = re.compile(
+    r"(?i)(?:upload-artifact|actions/upload-artifact|artifacts?:|archiveartifacts)\s*[^\n]*"
+    r"(?:safetensors|gguf|\.pt\b|\.pth\b|onnx|\.h5\b|\.pb\b|tflite|\.bin\b|mlmodel|\.parquet|\.csv)"
+)
+_CI_TRAIN_IMAGE_RE = re.compile(
+    r"(?i)(?:image:\s*[\"']?|docker://|docker\.io/)"
+    r"(?:tensorflow/tensorflow|pytorch/pytorch|nvidia/cuda|huggingface/|"
+    r"ghcr\.io/huggingface)[^\s\"']*"
+)
+
+_HP_RULES: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\blearning_rate\s*=\s*([^,\n#)]+)"), "learning_rate"),
+    (re.compile(r"\bbatch_size\s*=\s*([^,\n#)]+)"), "batch_size"),
+    (re.compile(r"\bnum_epochs\s*=\s*([^,\n#)]+)"), "num_epochs"),
+    (re.compile(r"\bwarmup_steps\s*=\s*([^,\n#)]+)"), "warmup_steps"),
+    (re.compile(r"\bweight_decay\s*=\s*([^,\n#)]+)"), "weight_decay"),
+    (re.compile(r"\bmax_seq_length\s*=\s*([^,\n#)]+)"), "max_seq_length"),
+    (
+        re.compile(r"\bgradient_accumulation_steps\s*=\s*([^,\n#)]+)"),
+        "gradient_accumulation_steps",
+    ),
+    (re.compile(r"\bfp16\s*=\s*([^,\n#)]+)"), "fp16"),
+    (re.compile(r"\bbf16\s*=\s*([^,\n#)]+)"), "bf16"),
+]
+
+_CONCEPT_PATTERNS: list[ConceptPattern] = [
+    ConceptPattern(
+        AIComponentType.DATASET,
+        [
+            (re.compile(r"\bload_dataset\s*\("), "huggingface/datasets"),
+            (re.compile(r"\bpd\.read_csv\s*\("), "pandas"),
+            (re.compile(r"\bpd\.read_parquet\s*\("), "pandas"),
+            (re.compile(r"\btf\.data\.Dataset\b"), "tensorflow"),
+            (re.compile(r"\btorch\.utils\.data\.DataLoader\b"), "pytorch"),
+            (re.compile(r"\bDataLoader\s*\("), "pytorch"),
+            (re.compile(r"\bImageFolder\s*\("), "torchvision"),
+            (re.compile(r"\bload_from_disk\s*\("), "huggingface/datasets"),
+            (
+                re.compile(
+                    r"(?i)(?:s3|gs)://[^\s\"']+\.(?:csv|parquet|jsonl|tfrecord)\b"
+                ),
+                "cloud-storage",
+            ),
+            (
+                re.compile(
+                    r"(?i)https?://[^\s\"']*\.blob\.core\.windows\.net[^\s\"']*"
+                    r"\.(?:csv|parquet|jsonl|tfrecord)\b"
+                ),
+                "azure-blob",
+            ),
+        ],
+        [
+            ("from datasets import", "huggingface/datasets"),
+            ("import datasets", "huggingface/datasets"),
+        ],
+        "Training or analytics data loading",
+    ),
+    ConceptPattern(
+        AIComponentType.TRAINING_RUN,
+        [
+            (re.compile(r"\bTrainer\s*\("), "huggingface/transformers"),
+            (re.compile(r"\.fit\s*\("), "keras/pytorch"),
+            (re.compile(r"\.train\s*\("), "pytorch"),
+            (re.compile(r"\bmodel\.compile\s*\("), "tensorflow/keras"),
+            (re.compile(r"\bAccelerator\s*\("), "huggingface/accelerate"),
+            (re.compile(r"\btrainer\.train\s*\("), "huggingface/transformers"),
+            (re.compile(r"\btraining_args\s*="), "huggingface/transformers"),
+            (re.compile(r"\bTrainingArguments\s*\("), "huggingface/transformers"),
+            (re.compile(r"\bAdam\s*\("), "pytorch/tensorflow"),
+            (re.compile(r"\bSGD\s*\("), "pytorch/tensorflow"),
+            (re.compile(r"\bAdamW\s*\("), "pytorch/tensorflow"),
+            (re.compile(r"\blr_scheduler\b"), "pytorch/tensorflow"),
+        ],
+        [],
+        "Model training execution",
+    ),
+    ConceptPattern(
+        AIComponentType.MODEL_ARTIFACT,
+        [
+            (
+                re.compile(
+                    r"(?i)(?:s3|gs)://[^\s\"']+\.(?:safetensors|gguf|onnx|h5|pb|tflite|mlmodel|pt|pth)\b"
+                ),
+                "cloud-storage",
+            ),
+            (
+                re.compile(
+                    r"(?i)https?://[^\s\"']*\.blob\.core\.windows\.net[^\s\"']*"
+                    r"\.(?:safetensors|gguf|onnx|h5|pb|tflite|mlmodel|pt|pth)\b"
+                ),
+                "azure-blob",
+            ),
+            (
+                re.compile(
+                    r"(?i)(?:model|weights|checkpoint|pretrained|lfs).{0,160}\.bin\b"
+                ),
+                "model-weights",
+            ),
+            (re.compile(r"(?<![A-Za-z0-9_])\.safetensors\b"), "safetensors"),
+            (re.compile(r"(?<![A-Za-z0-9_])\.gguf\b"), "gguf"),
+            (re.compile(r"(?<![A-Za-z0-9_])\.onnx\b"), "onnx"),
+            (re.compile(r"(?<![A-Za-z0-9_])\.h5\b"), "keras"),
+            (re.compile(r"(?<![A-Za-z0-9_])\.pb\b"), "tensorflow"),
+            (re.compile(r"(?<![A-Za-z0-9_])\.tflite\b"), "tensorflow"),
+            (re.compile(r"(?<![A-Za-z0-9_])\.pth\b"), "pytorch"),
+            (re.compile(r"(?<![A-Za-z0-9_])\.pt\b"), "pytorch"),
+            (re.compile(r"(?<![A-Za-z0-9_])\.mlmodel\b"), "coreml"),
+            (re.compile(r"\bmodel\.save\s*\("), "keras/tensorflow"),
+            (re.compile(r"\btorch\.save\s*\("), "pytorch"),
+            (re.compile(r"\bmodel\.save_pretrained\s*\("), "huggingface/transformers"),
+            (re.compile(r"\btf\.saved_model\.save\s*\("), "tensorflow"),
+            (re.compile(r"\bexport_to_onnx\s*\("), "onnx"),
+        ],
+        [],
+        "Serialized model weights or export",
+    ),
+    ConceptPattern(
+        AIComponentType.EXPERIMENT_TRACKER,
+        [
+            (re.compile(r"\bwandb\.(init|log)\s*\("), "wandb"),
+            (re.compile(r"\bmlflow\.(start_run|log_metric|log_param|autolog)\s*\("), "mlflow"),
+            (re.compile(r"\bmlflow\.(log_metric|log_param|set_tag)\s*\("), "mlflow"),
+            (re.compile(r"\bneptune\.(init_run|Run)\s*\("), "neptune"),
+            (re.compile(r"\bcomet_ml\.Experiment\s*\("), "comet_ml"),
+            (re.compile(r"\bSummaryWriter\s*\("), "tensorboard"),
+            (re.compile(r"\btorch\.utils\.tensorboard\b"), "tensorboard"),
+            (re.compile(r"\bclearml\.(Task|Logger)\b"), "clearml"),
+            (re.compile(r"\btrackio\b"), "trackio"),
+            (re.compile(r"\bswanlab\.(init|log)\s*\("), "swanlab"),
+        ],
+        [
+            ("import wandb", "wandb"),
+            ("import mlflow", "mlflow"),
+            ("from mlflow", "mlflow"),
+            ("import comet_ml", "comet_ml"),
+            ("from comet_ml", "comet_ml"),
+            ("import neptune", "neptune"),
+            ("from neptune", "neptune"),
+        ],
+        "Experiment metrics and run tracking",
+    ),
+    ConceptPattern(
+        AIComponentType.MODEL_REGISTRY,
+        [
+            (re.compile(r"\bmlflow\.register_model\s*\("), "mlflow"),
+            (re.compile(r"\bregister_model\s*\("), "ml-registry"),
+            (re.compile(r"\bcreate_model_version\s*\("), "model-registry"),
+            (re.compile(r"\btransition_model_version_stage\s*\("), "mlflow"),
+            (re.compile(r"\bModelRegistry\b"), "model-registry"),
+            (re.compile(r"\bupload_model_version\s*\("), "vertex-ai"),
+            (re.compile(r"\bModelVersion\s*\("), "model-registry"),
+        ],
+        [
+            ("from azure.ai.ml.entities import Model", "azure-ml"),
+            ("from google.cloud import aiplatform", "vertex-ai"),
+        ],
+        "Registered model versioning and staging",
+    ),
+    ConceptPattern(
+        AIComponentType.DATA_VERSIONING,
+        [
+            (re.compile(r"\bdvc\.(pull|push|repro|status)\s*\("), "dvc"),
+            (re.compile(r"\bdvc\.api\."), "dvc"),
+        ],
+        [
+            ("import dvc", "dvc"),
+            ("from dvc", "dvc"),
+            ("import dvc.api", "dvc"),
+        ],
+        "Data and artifact versioning",
+    ),
+    ConceptPattern(
+        AIComponentType.ML_PIPELINE,
+        [
+            (re.compile(r"@dsl\.pipeline\b"), "kubeflow"),
+            (re.compile(r"@kfp\.dsl\.pipeline\b"), "kubeflow"),
+            (re.compile(r"@component\b"), "kubeflow/zenml"),
+            (re.compile(r"@step\b"), "zenml/metaflow"),
+            (re.compile(r"@task\b"), "prefect/airflow"),
+            (re.compile(r"\bfrom airflow import DAG\b"), "airflow"),
+            (re.compile(r"\bwith\s+DAG\s*\("), "airflow"),
+            (re.compile(r"\bfrom airflow\.decorators import\b"), "airflow"),
+            (re.compile(r"\bfrom zenml import step\b"), "zenml"),
+            (re.compile(r"\bfrom metaflow import\b"), "metaflow"),
+            (re.compile(r"\bfrom prefect import flow\b"), "prefect"),
+            (re.compile(r"\bPipelineJob\b"), "vertex-ai"),
+            (re.compile(r"apiVersion:\s*argoproj\.io"), "argo"),
+        ],
+        [
+            ("from kfp import dsl", "kubeflow"),
+            ("from kfp.dsl import", "kubeflow"),
+        ],
+        "ML workflow orchestration",
+    ),
+]
+
+_YAML_DATA_SECTION_RE = re.compile(r"^\s*data:\s*(?:#.*)?$")
+
+
+def _emit(
+    concept: AIComponentType,
+    framework: str,
+    description: str,
+    file_path: str,
+    line_number: int,
+    *,
+    detection_source: DetectionSource = DetectionSource.CODE_ANALYSIS,
+    hyperparameters: Optional[dict[str, Any]] = None,
+    storage_uri: Optional[str] = None,
+    text: Optional[str] = None,
+) -> AIComponent:
+    hp = hyperparameters or {}
+    name = concept.value
+    if hp:
+        name = f"{concept.value}:{next(iter(hp.keys()))}"
+    return AIComponent(
+        name=name,
+        component_type=concept,
+        file_path=file_path,
+        line_number=line_number,
+        framework=framework,
+        detection_source=detection_source,
+        confidence=0.85,
+        description=description,
+        text=text,
+        storage_uri=storage_uri,
+        hyperparameters=hp,
+    )
+
+
+class MLLifecycleDetector(BaseScanner):
+    name = "ml_lifecycle_detector"
+
+    def supports(self, context: ScanContext) -> bool:
+        return True
+
+    def scan(
+        self, context: ScanContext
+    ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+        components: list[AIComponent] = []
+        seen: set[tuple[Any, ...]] = set()
+
+        def add(comp: AIComponent) -> None:
+            key = (
+                comp.file_path,
+                comp.line_number,
+                comp.component_type,
+                comp.framework,
+                tuple(sorted(comp.hyperparameters.items())),
+            )
+            if key in seen:
+                return
+            seen.add(key)
+            components.append(comp)
+
+        for fpath, rel in _iter_files(context):
+            fp_str = str(fpath)
+            suffix = fpath.suffix.lower()
+            name_lower = fpath.name.lower()
+
+            try:
+                text = fpath.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+
+            is_ci = (
+                rel.startswith(".github/workflows/")
+                and name_lower.endswith((".yml", ".yaml"))
+            ) or name_lower == ".gitlab-ci.yml" or name_lower == "jenkinsfile"
+            is_yaml = suffix in (".yaml", ".yml")
+            is_jenkins = name_lower == "jenkinsfile"
+
+            if name_lower in ("dvc.yaml", "dvc.lock") or name_lower.endswith(".dvc"):
+                add(
+                    _emit(
+                        AIComponentType.DATA_VERSIONING,
+                        "dvc",
+                        "DVC project metadata",
+                        fp_str,
+                        1,
+                        detection_source=DetectionSource.CONFIG_FILE,
+                    )
+                )
+
+            if name_lower == "pipeline.yaml" or name_lower == "pipeline.yml":
+                add(
+                    _emit(
+                        AIComponentType.ML_PIPELINE,
+                        "pipeline-config",
+                        "Pipeline configuration file",
+                        fp_str,
+                        1,
+                        detection_source=DetectionSource.CONFIG_FILE,
+                    )
+                )
+
+            if is_yaml and (
+                "pipelines.kubeflow.org" in text
+                or "kubeflow" in rel.lower()
+                or "kubeflow" in text.lower()
+            ):
+                for i, line in enumerate(text.splitlines(), start=1):
+                    if "pipelines.kubeflow.org" in line or "kubeflow.org" in line:
+                        add(
+                            _emit(
+                                AIComponentType.ML_PIPELINE,
+                                "kubeflow",
+                                "Kubeflow pipeline manifest",
+                                fp_str,
+                                i,
+                                detection_source=DetectionSource.CONFIG_FILE,
+                                text=line.strip()[:200],
+                            )
+                        )
+                        break
+
+            scan_lines = text.splitlines()
+            for line_no, line in enumerate(scan_lines, start=1):
+                stripped = line.strip()
+
+                if is_yaml and _YAML_DATA_SECTION_RE.match(line):
+                    uri = _extract_uri_from_line(line)
+                    add(
+                        _emit(
+                            AIComponentType.DATASET,
+                            "yaml-config",
+                            "YAML data section",
+                            fp_str,
+                            line_no,
+                            detection_source=DetectionSource.CONFIG_FILE,
+                            storage_uri=uri,
+                            text=stripped[:200],
+                        )
+                    )
+
+                if suffix == ".py":
+                    for hp_rx, hp_key in _HP_RULES:
+                        for m in hp_rx.finditer(line):
+                            raw = m.group(1).strip()
+                            val = _normalize_hp_value(raw)
+                            comp = _emit(
+                                AIComponentType.HYPERPARAMETER,
+                                "python-kwargs",
+                                f"Hyperparameter {hp_key}",
+                                fp_str,
+                                line_no,
+                                hyperparameters={hp_key: val},
+                                text=stripped[:200],
+                            )
+                            key = (
+                                fp_str,
+                                line_no,
+                                AIComponentType.HYPERPARAMETER,
+                                comp.framework,
+                                (hp_key, val),
+                            )
+                            if key not in seen:
+                                seen.add(key)
+                                components.append(comp)
+
+                scan_concepts = suffix == ".py" or is_ci or is_jenkins or is_yaml
+                if not scan_concepts:
+                    continue
+
+                for cp in _CONCEPT_PATTERNS:
+                    for sub, fw in cp.import_patterns:
+                        if sub in line:
+                            add(
+                                _emit(
+                                    cp.concept,
+                                    fw,
+                                    cp.description,
+                                    fp_str,
+                                    line_no,
+                                    text=stripped[:200],
+                                )
+                            )
+                    for rx, fw in cp.patterns:
+                        if rx.search(line):
+                            uri = None
+                            if cp.concept in (
+                                AIComponentType.DATASET,
+                                AIComponentType.MODEL_ARTIFACT,
+                            ):
+                                uri = _extract_uri_from_line(line)
+                            add(
+                                _emit(
+                                    cp.concept,
+                                    fw,
+                                    cp.description,
+                                    fp_str,
+                                    line_no,
+                                    storage_uri=uri,
+                                    text=stripped[:200],
+                                )
+                            )
+
+                if is_ci or is_jenkins:
+                    if _CI_PATH_RE.search(line) or _CI_GSUTIL_RE.search(line):
+                        add(
+                            _emit(
+                                AIComponentType.MODEL_ARTIFACT,
+                                "ci-cd",
+                                "CI artifact transfer for model files",
+                                fp_str,
+                                line_no,
+                                detection_source=DetectionSource.CONFIG_FILE,
+                                text=stripped[:200],
+                            )
+                        )
+                    if _CI_ARTIFACT_RE.search(line):
+                        add(
+                            _emit(
+                                AIComponentType.MODEL_ARTIFACT,
+                                "ci-cd",
+                                "CI artifact upload referencing ML assets",
+                                fp_str,
+                                line_no,
+                                detection_source=DetectionSource.CONFIG_FILE,
+                                text=stripped[:200],
+                            )
+                        )
+                    if _CI_TRAIN_IMAGE_RE.search(line):
+                        add(
+                            _emit(
+                                AIComponentType.TRAINING_RUN,
+                                "ci-cd",
+                                "ML training container image reference",
+                                fp_str,
+                                line_no,
+                                detection_source=DetectionSource.CONFIG_FILE,
+                                text=stripped[:200],
+                            )
+                        )
+
+            if is_yaml and "dag" in text.lower() and (
+                "airflow" in text.lower() or "schedule" in text.lower()
+            ):
+                if any("airflow" in ln.lower() for ln in scan_lines[:50]):
+                    add(
+                        _emit(
+                            AIComponentType.ML_PIPELINE,
+                            "airflow",
+                            "Airflow DAG configuration in YAML",
+                            fp_str,
+                            1,
+                            detection_source=DetectionSource.CONFIG_FILE,
+                        )
+                    )
+
+        return components, []

--- a/aibom/src/aibom/scanners/model_detector.py
+++ b/aibom/src/aibom/scanners/model_detector.py
@@ -1,0 +1,791 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from pathlib import Path
+from typing import Any, Iterator, Optional
+from urllib.parse import quote_plus
+
+import yaml
+from pathspec import PathSpec
+from platformdirs import user_cache_dir
+
+from ..models import AIComponent, ComponentRelationship, ScanContext
+from ..models.enums import AIComponentType, DetectionSource
+from .base import BaseScanner
+
+_LOGGER = logging.getLogger(__name__)
+
+_LITELLM_CATALOG_URL = "https://models.litellm.ai/model_catalog"
+_HF_API_URL = "https://huggingface.co/api/models"
+_CACHE_TTL_SECONDS = 86400  # 24 hours
+_CACHE_DIR = Path(user_cache_dir("aibom")) / "model_cache"
+
+_HF_SLUG_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+# ---------------------------------------------------------------------------
+# Generic cache helpers
+# ---------------------------------------------------------------------------
+
+
+def _cache_file(name: str) -> Path:
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    return _CACHE_DIR / name
+
+
+def _load_cached(name: str) -> dict[str, dict[str, Any]] | None:
+    cp = _cache_file(name)
+    if not cp.exists():
+        return None
+    try:
+        data = json.loads(cp.read_text(encoding="utf-8"))
+        if time.time() - data.get("_ts", 0) > _CACHE_TTL_SECONDS:
+            return None
+        return data.get("models", {})
+    except Exception:
+        return None
+
+
+def _save_cached(name: str, models: dict[str, dict[str, Any]]) -> None:
+    try:
+        cp = _cache_file(name)
+        cp.write_text(
+            json.dumps({"_ts": time.time(), "models": models}),
+            encoding="utf-8",
+        )
+    except Exception:
+        _LOGGER.debug("Failed to write cache %s", name, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 -- LiteLLM Model Catalog  (commercial API models, 2500+)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_litellm_catalog(
+    provider: str | None = None,
+) -> list[dict[str, Any]]:
+    import httpx
+
+    params: dict[str, str] = {}
+    if provider:
+        params["provider"] = provider
+    try:
+        with httpx.Client(timeout=10) as client:
+            resp = client.get(_LITELLM_CATALOG_URL, params=params)
+            resp.raise_for_status()
+            data = resp.json()
+            if isinstance(data, list):
+                return data
+            if isinstance(data, dict):
+                return data.get("data", data.get("models", []))
+    except Exception:
+        _LOGGER.debug("LiteLLM catalog fetch failed", exc_info=True)
+    return []
+
+
+def _provider_from_litellm_id(model_id: str) -> str:
+    if "/" in model_id:
+        return model_id.split("/", 1)[0]
+    return "unknown"
+
+
+_BEDROCK_VERSION_RE = re.compile(r":[0-9]+$")
+_DATE_SUFFIX_RE = re.compile(r"-\d{4}-?\d{2}-?\d{2}(-v\d+)?$")
+
+
+def _litellm_alias_keys(raw_id: str) -> list[str]:
+    """Generate all normalized lookup keys for a LiteLLM model ID.
+
+    Handles: slash-prefixed (azure/gpt-4o), dot-prefixed Bedrock ARNs
+    (us.anthropic.claude-3-5-sonnet-20241022-v2:0), fine-tune prefixes
+    (ft:gpt-4o-2024-08-06), and date suffixes (-20241022).
+    """
+    keys: list[str] = []
+    low = raw_id.lower()
+    keys.append(low)
+
+    current = low
+
+    # Strip slash prefix: azure/eu/gpt-4o-2024-08-06 → gpt-4o-2024-08-06
+    if "/" in current:
+        current = current.rsplit("/", 1)[-1]
+        keys.append(current)
+
+    # Strip ft: prefix: ft:gpt-4o-2024-08-06 → gpt-4o-2024-08-06
+    if current.startswith("ft:"):
+        current = current[3:]
+        keys.append(current)
+
+    # Strip dot-separated provider/region prefix for Bedrock ARNs:
+    #   us.anthropic.claude-3-5-sonnet-20241022-v2:0
+    #   → anthropic.claude-3-5-sonnet-20241022-v2:0
+    #   → claude-3-5-sonnet-20241022-v2:0
+    if "." in current:
+        parts = current.split(".")
+        stripped = current
+        for part in parts[:-1]:
+            stripped = stripped[len(part) + 1 :]
+            if stripped:
+                keys.append(stripped)
+        current = parts[-1]
+
+    # Strip Bedrock version suffix: claude-3-5-sonnet-20241022-v2:0 → claude-3-5-sonnet-20241022-v2
+    no_ver = _BEDROCK_VERSION_RE.sub("", current)
+    if no_ver != current:
+        keys.append(no_ver)
+        current = no_ver
+
+    # Strip date suffix: claude-3-5-sonnet-20241022-v2 → claude-3-5-sonnet
+    #                     gpt-4o-2024-08-06 → gpt-4o
+    no_date = _DATE_SUFFIX_RE.sub("", current)
+    if no_date != current and len(no_date) >= 3:
+        keys.append(no_date)
+
+    return list(dict.fromkeys(keys))
+
+
+def _build_litellm_registry() -> dict[str, dict[str, Any]]:
+    cached = _load_cached("litellm_models.json")
+    if cached is not None:
+        return cached
+
+    raw = _fetch_litellm_catalog()
+    if not raw:
+        return {}
+
+    registry: dict[str, dict[str, Any]] = {}
+    for entry in raw:
+        model_id = entry.get("model_name") or entry.get("id") or entry.get("model") or ""
+        if not model_id:
+            continue
+        provider = (
+            entry.get("provider")
+            or entry.get("litellm_provider")
+            or _provider_from_litellm_id(model_id)
+        )
+        aliases = _litellm_alias_keys(model_id)
+        canonical = aliases[-1] if aliases else model_id.lower()
+        meta = {
+            "provider": provider.lower(),
+            "family": canonical.rsplit("-", 1)[0] if "-" in canonical else canonical,
+            "deprecated": entry.get("deprecated", False),
+            "source": "litellm",
+        }
+        for alias in aliases:
+            if alias not in registry:
+                registry[alias] = meta
+    _save_cached("litellm_models.json", registry)
+    return registry
+
+
+_litellm_registry: dict[str, dict[str, Any]] | None = None
+
+
+def _get_live_registry() -> dict[str, dict[str, Any]]:
+    global _litellm_registry
+    if _litellm_registry is None:
+        _litellm_registry = _build_litellm_registry()
+    return _litellm_registry
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 -- HuggingFace Hub  (open-weight models, 1M+)
+# ---------------------------------------------------------------------------
+
+_hf_cache: dict[str, dict[str, Any] | None] = {}
+
+
+def _is_hf_model_id(model_id: str) -> bool:
+    """Return True if model_id looks like a HuggingFace Hub slug (org/name)."""
+    return bool(_HF_SLUG_RE.match(model_id))
+
+
+def _query_hf_hub(model_id: str) -> dict[str, Any] | None:
+    """Look up a single model on HuggingFace Hub. Returns metadata or None."""
+    if model_id in _hf_cache:
+        return _hf_cache[model_id]
+
+    cache_name = "hf_hub_models.json"
+    disk = _load_cached(cache_name)
+    if disk and model_id in disk:
+        _hf_cache[model_id] = disk[model_id]
+        return disk[model_id]
+
+    import httpx
+
+    try:
+        with httpx.Client(timeout=10) as client:
+            resp = client.get(f"{_HF_API_URL}/{model_id}")
+            if resp.status_code == 404:
+                _hf_cache[model_id] = None
+                return None
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception:
+        _LOGGER.debug("HuggingFace Hub lookup failed for %s", model_id, exc_info=True)
+        _hf_cache[model_id] = None
+        return None
+
+    org = model_id.split("/", 1)[0]
+    model_name_part = model_id.split("/", 1)[-1]
+    tags = data.get("tags", [])
+    pipeline_tag = data.get("pipeline_tag", "")
+
+    result: dict[str, Any] = {
+        "provider": org,
+        "family": model_name_part.rsplit("-", 1)[0] if "-" in model_name_part else model_name_part,
+        "deprecated": False,
+        "source": "huggingface",
+        "hf_id": model_id,
+        "pipeline_tag": pipeline_tag,
+        "license": data.get("cardData", {}).get("license", ""),
+        "downloads": data.get("downloads", 0),
+        "tags": tags[:10],
+    }
+
+    _hf_cache[model_id] = result
+    existing = _load_cached(cache_name) or {}
+    existing[model_id] = result
+    _save_cached(cache_name, existing)
+    return result
+
+
+BUILTIN_MODEL_REGISTRY: dict[str, dict[str, Any]] = {
+    r"^gpt-4o-\d{4}-\d{2}-\d{2}$": {
+        "provider": "openai",
+        "family": "gpt-4o",
+        "deprecated": False,
+    },
+    r"^gpt-4-\d{4}-\d{2}-\d{2}$": {
+        "provider": "openai",
+        "family": "gpt-4",
+        "deprecated": False,
+    },
+    r"^gpt-3\.5-turbo-\d{4}-\d{2}-\d{2}$": {
+        "provider": "openai",
+        "family": "gpt-3.5-turbo",
+        "deprecated": False,
+    },
+    r"^gpt-4o-mini$": {"provider": "openai", "family": "gpt-4o", "deprecated": False},
+    r"^gpt-4o$": {"provider": "openai", "family": "gpt-4o", "deprecated": False},
+    r"^gpt-4-turbo$": {"provider": "openai", "family": "gpt-4", "deprecated": False},
+    r"^gpt-4$": {"provider": "openai", "family": "gpt-4", "deprecated": False},
+    r"^gpt-3\.5-turbo$": {
+        "provider": "openai",
+        "family": "gpt-3.5",
+        "deprecated": False,
+    },
+    r"^o1-pro$": {"provider": "openai", "family": "o1", "deprecated": False},
+    r"^o1-mini$": {"provider": "openai", "family": "o1", "deprecated": False},
+    r"^o1$": {"provider": "openai", "family": "o1", "deprecated": False},
+    r"^o3-mini$": {"provider": "openai", "family": "o3", "deprecated": False},
+    r"^o3$": {"provider": "openai", "family": "o3", "deprecated": False},
+    r"^o4-mini$": {"provider": "openai", "family": "o4", "deprecated": False},
+    r"^claude-3-5-sonnet-\d{8}$": {
+        "provider": "anthropic",
+        "family": "claude-3-5-sonnet",
+        "deprecated": False,
+    },
+    r"^claude-3-5-haiku-\d{8}$": {
+        "provider": "anthropic",
+        "family": "claude-3-5-haiku",
+        "deprecated": False,
+    },
+    r"^claude-3-opus-\d{8}$": {
+        "provider": "anthropic",
+        "family": "claude-3-opus",
+        "deprecated": False,
+    },
+    r"^claude-3-sonnet-\d{8}$": {
+        "provider": "anthropic",
+        "family": "claude-3-sonnet",
+        "deprecated": False,
+    },
+    r"^claude-3-haiku-\d{8}$": {
+        "provider": "anthropic",
+        "family": "claude-3-haiku",
+        "deprecated": False,
+    },
+    r"^claude-4-sonnet-\d{8}$": {
+        "provider": "anthropic",
+        "family": "claude-4-sonnet",
+        "deprecated": False,
+    },
+    r"^claude-4-opus-\d{8}$": {
+        "provider": "anthropic",
+        "family": "claude-4-opus",
+        "deprecated": False,
+    },
+    r"^claude-3-5-sonnet$": {
+        "provider": "anthropic",
+        "family": "claude-3-5-sonnet",
+        "deprecated": False,
+    },
+    r"^claude-3-5-haiku$": {
+        "provider": "anthropic",
+        "family": "claude-3-5-haiku",
+        "deprecated": False,
+    },
+    r"^claude-3-opus$": {
+        "provider": "anthropic",
+        "family": "claude-3-opus",
+        "deprecated": False,
+    },
+    r"^claude-3-sonnet$": {
+        "provider": "anthropic",
+        "family": "claude-3-sonnet",
+        "deprecated": False,
+    },
+    r"^claude-3-haiku$": {
+        "provider": "anthropic",
+        "family": "claude-3-haiku",
+        "deprecated": False,
+    },
+    r"^claude-4-sonnet$": {
+        "provider": "anthropic",
+        "family": "claude-4-sonnet",
+        "deprecated": False,
+    },
+    r"^claude-4-opus$": {
+        "provider": "anthropic",
+        "family": "claude-4-opus",
+        "deprecated": False,
+    },
+    r"^gemini-2\.5-pro$": {
+        "provider": "google",
+        "family": "gemini-2.5",
+        "deprecated": False,
+    },
+    r"^gemini-2\.0-flash$": {
+        "provider": "google",
+        "family": "gemini-2.0",
+        "deprecated": False,
+    },
+    r"^gemini-1\.5-flash$": {
+        "provider": "google",
+        "family": "gemini-1.5",
+        "deprecated": False,
+    },
+    r"^gemini-1\.5-pro$": {
+        "provider": "google",
+        "family": "gemini-1.5",
+        "deprecated": False,
+    },
+    r"^llama[-_]4": {"provider": "meta", "family": "llama-4", "deprecated": False},
+    r"^llama[-_]3\.3": {"provider": "meta", "family": "llama-3.3", "deprecated": False},
+    r"^llama[-_]3\.2": {"provider": "meta", "family": "llama-3.2", "deprecated": False},
+    r"^llama[-_]3\.1": {"provider": "meta", "family": "llama-3.1", "deprecated": False},
+    r"^llama[-_]3\b": {"provider": "meta", "family": "llama-3", "deprecated": False},
+    r"^llama[-_]2\b": {"provider": "meta", "family": "llama-2", "deprecated": False},
+    r"^mistral-7b": {
+        "provider": "mistral",
+        "family": "mistral-7b",
+        "deprecated": False,
+    },
+    r"^mistral-large": {
+        "provider": "mistral",
+        "family": "mistral-large",
+        "deprecated": False,
+    },
+    r"^mistral-medium": {
+        "provider": "mistral",
+        "family": "mistral-medium",
+        "deprecated": False,
+    },
+    r"^mistral-small": {
+        "provider": "mistral",
+        "family": "mistral-small",
+        "deprecated": False,
+    },
+    r"^mixtral": {"provider": "mistral", "family": "mixtral", "deprecated": False},
+    r"^codestral": {"provider": "mistral", "family": "codestral", "deprecated": False},
+    r"^pixtral": {"provider": "mistral", "family": "pixtral", "deprecated": False},
+    r"^phi-4\b": {"provider": "microsoft", "family": "phi-4", "deprecated": False},
+    r"^phi-3\b": {"provider": "microsoft", "family": "phi-3", "deprecated": False},
+    r"^qwen2\.5": {"provider": "qwen", "family": "qwen2.5", "deprecated": False},
+    r"^qwen2\b": {"provider": "qwen", "family": "qwen2", "deprecated": False},
+    r"^qwen\b": {"provider": "qwen", "family": "qwen", "deprecated": False},
+    r"^deepseek-r1": {
+        "provider": "deepseek",
+        "family": "deepseek-r1",
+        "deprecated": False,
+    },
+    r"^deepseek-v3": {
+        "provider": "deepseek",
+        "family": "deepseek-v3",
+        "deprecated": False,
+    },
+    r"^deepseek-v2": {
+        "provider": "deepseek",
+        "family": "deepseek-v2",
+        "deprecated": False,
+    },
+    r"^command-r-plus$": {
+        "provider": "cohere",
+        "family": "command-r-plus",
+        "deprecated": False,
+    },
+    r"^command-r$": {"provider": "cohere", "family": "command-r", "deprecated": False},
+}
+
+_COMPILED_REGISTRY: list[tuple[re.Pattern[str], dict[str, Any]]] = [
+    (re.compile(pat, re.IGNORECASE), meta)
+    for pat, meta in BUILTIN_MODEL_REGISTRY.items()
+]
+
+_PY_KWARG_RE = re.compile(
+    r"\b(?:model|model_name|deployment_name|model_id)\s*=\s*"
+    r"(?P<q>[\"'])(?P<val>[^\"'\\]*(?:\\.[^\"'\\]*)*)(?P=q)",
+    re.MULTILINE,
+)
+
+_PY_ASSIGN_RE = re.compile(
+    r"(?m)^\s*(?:model|model_name|MODEL|MODEL_NAME|LLM_MODEL)\s*=\s*"
+    r"(?P<q>[\"'])(?P<val>[^\"'\\]*(?:\\.[^\"'\\]*)*)(?P=q)",
+)
+
+_PY_CTOR_RE = re.compile(
+    r"\b(?:ChatOpenAI|ChatAnthropic|ChatGoogleGenerativeAI|AzureChatOpenAI|"
+    r"OpenAI|Anthropic|GenerativeModel)\s*\("
+    r"[^)]*?\bmodel\s*=\s*(?P<q>[\"'])(?P<val>[^\"'\\]*(?:\\.[^\"'\\]*)*)(?P=q)",
+    re.DOTALL,
+)
+
+_ENV_MODEL_RE = re.compile(
+    r"(?m)^\s*(?:MODEL|OPENAI_MODEL|LLM_MODEL|ANTHROPIC_MODEL)\s*=\s*"
+    r"(?:[\"']([^\"']+)[\"']|([^\s#]+))",
+)
+
+_TOML_HEADER_RE = re.compile(r"^\s*\[([^\]]+)\]\s*$")
+_TOML_KV_RE = re.compile(
+    r"^\s*(?:model|model_name|model_id|deployment_name)\s*=\s*"
+    r"(?:[\"']([^\"']+)[\"']|([^\s#]+))",
+)
+
+_JSON_KEY_HINT = frozenset({"model", "model_name", "model_id", "deployment_name"})
+
+_SKIP_STRINGS = frozenset(
+    {
+        "",
+        "true",
+        "false",
+        "null",
+        "none",
+        "auto",
+        "default",
+    }
+)
+
+
+def _model_card_url(model_name: str, provider: str, meta: Optional[dict[str, Any]] = None) -> str:
+    if meta and meta.get("source") == "huggingface" and meta.get("hf_id"):
+        return f"https://huggingface.co/{meta['hf_id']}"
+    p = provider.lower()
+    if p in ("meta", "mistral", "qwen", "deepseek", "microsoft"):
+        return f"https://huggingface.co/models?search={quote_plus(model_name)}"
+    if p == "openai":
+        return "https://platform.openai.com/docs/models"
+    if p == "anthropic":
+        return "https://docs.anthropic.com/en/docs/about-claude/models"
+    if p == "google":
+        return "https://ai.google.dev/gemini-api/docs/models/gemini"
+    if p == "cohere":
+        return "https://docs.cohere.com/docs/models"
+    return f"https://huggingface.co/models?search={quote_plus(model_name)}"
+
+
+def _line_number(text: str, pos: int) -> int:
+    return text.count("\n", 0, pos) + 1
+
+
+def _normalize_candidate(raw: str) -> str:
+    s = raw.strip().strip('"').strip("'")
+    if s.startswith("${") or "{{" in s:
+        return ""
+    return s
+
+
+def _is_plausible_model_id(s: str) -> bool:
+    if len(s) < 2 or len(s) > 256:
+        return False
+    low = s.lower()
+    if low in _SKIP_STRINGS or low.startswith("${"):
+        return False
+    if not re.search(r"[a-zA-Z]", s):
+        return False
+    return True
+
+
+def _registry_lookup(model_id: str) -> Optional[dict[str, Any]]:
+    key = model_id.strip()
+
+    # Tier 1: LiteLLM commercial API catalog
+    live = _get_live_registry()
+    hit = live.get(key.lower())
+    if hit:
+        return dict(hit)
+
+    # Tier 2 (offline): builtin regex patterns
+    for pat, meta in _COMPILED_REGISTRY:
+        if pat.search(key):
+            return dict(meta)
+
+    # Tier 3: HuggingFace Hub for org/model-name slugs
+    if _is_hf_model_id(key):
+        hf = _query_hf_hub(key)
+        if hf:
+            return dict(hf)
+
+    return None
+
+
+def _build_pathspec(patterns: list[str]) -> Optional[PathSpec]:
+    if not patterns:
+        return None
+    return PathSpec.from_lines("gitwildmatch", patterns)
+
+
+def _iter_files(context: ScanContext) -> Iterator[tuple[Path, str]]:
+    spec = _build_pathspec(context.exclude_patterns)
+    for scan_root in context.paths:
+        root = Path(scan_root)
+        if not root.exists():
+            continue
+        if root.is_file():
+            rel = root.name
+            if spec and spec.match_file(rel):
+                continue
+            yield root, rel
+            continue
+        base = root.resolve()
+        for f in root.rglob("*"):
+            if not f.is_file():
+                continue
+            try:
+                rel = f.resolve().relative_to(base).as_posix()
+            except ValueError:
+                rel = f.as_posix()
+            if spec and spec.match_file(rel):
+                continue
+            yield f, rel
+
+
+def _line_for_value(text: str, value: str) -> int:
+    if not value:
+        return 0
+    idx = text.find(value)
+    if idx < 0:
+        return 0
+    return _line_number(text, idx)
+
+
+def _walk_mapping(
+    obj: Any,
+    text: str,
+    out: list[tuple[str, int]],
+    depth: int,
+) -> None:
+    if depth > 64:
+        return
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            lk = str(k).lower()
+            if (
+                lk in _JSON_KEY_HINT
+                and isinstance(v, str)
+                and _is_plausible_model_id(v)
+            ):
+                out.append((v, _line_for_value(text, v)))
+            _walk_mapping(v, text, out, depth + 1)
+    elif isinstance(obj, list):
+        for item in obj:
+            _walk_mapping(item, text, out, depth + 1)
+
+
+def _extract_yaml_models(text: str) -> list[tuple[str, int]]:
+    found: list[tuple[str, int]] = []
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return found
+    if data is None:
+        return found
+    _walk_mapping(data, text, found, 0)
+    return found
+
+
+def _extract_json_models(text: str) -> list[tuple[str, int]]:
+    found: list[tuple[str, int]] = []
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return found
+    _walk_mapping(data, text, found, 0)
+    return found
+
+
+def _extract_toml_tool_models(text: str) -> list[tuple[str, int]]:
+    found: list[tuple[str, int]] = []
+    in_tool = False
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        m = _TOML_HEADER_RE.match(line)
+        if m:
+            in_tool = m.group(1).strip().lower().startswith("tool.")
+            continue
+        if not in_tool:
+            continue
+        km = _TOML_KV_RE.match(line)
+        if km:
+            val = km.group(1) or km.group(2) or ""
+            if _is_plausible_model_id(val):
+                found.append((val, line_no))
+    return found
+
+
+def _extract_env_models(text: str) -> list[tuple[str, int]]:
+    found: list[tuple[str, int]] = []
+    for m in _ENV_MODEL_RE.finditer(text):
+        val = m.group(1) or m.group(2) or ""
+        val = _normalize_candidate(val)
+        if _is_plausible_model_id(val):
+            found.append((val, _line_number(text, m.start())))
+    return found
+
+
+def _extract_python_models(text: str) -> list[tuple[str, int]]:
+    found: list[tuple[str, int]] = []
+    for rx in (_PY_KWARG_RE, _PY_ASSIGN_RE, _PY_CTOR_RE):
+        for m in rx.finditer(text):
+            raw = m.group("val")
+            s = _normalize_candidate(raw)
+            if not _is_plausible_model_id(s):
+                continue
+            found.append((s, _line_number(text, m.start())))
+    return found
+
+
+def _make_component(
+    model_name: str,
+    file_path: str,
+    line_number: int,
+    method: str,
+    meta: Optional[dict[str, Any]],
+) -> AIComponent:
+    if meta:
+        provider = str(meta["provider"])
+        family = str(meta["family"])
+        deprecated = bool(meta.get("deprecated", False))
+        confidence = 1.0
+        url = _model_card_url(model_name, provider, meta)
+        source = meta.get("source", "builtin")
+        md: dict[str, Any] = {
+            "model_card_url": url,
+            "provider": provider,
+            "family": family,
+            "deprecated": deprecated,
+            "detection_method": method,
+            "registry_source": source,
+        }
+        if source == "huggingface":
+            for hf_key in ("hf_id", "pipeline_tag", "license", "downloads"):
+                if meta.get(hf_key):
+                    md[hf_key] = meta[hf_key]
+    else:
+        provider = "unknown"
+        confidence = 0.7
+        url = _model_card_url(model_name, provider)
+        md = {
+            "model_card_url": url,
+            "provider": provider,
+            "family": "unknown",
+            "deprecated": False,
+            "detection_method": method,
+            "registry_source": "none",
+        }
+    src = (
+        DetectionSource.CONFIG_FILE
+        if method in ("config_file", "env_var")
+        else DetectionSource.CODE_ANALYSIS
+    )
+    return AIComponent(
+        name=model_name,
+        component_type=AIComponentType.MODEL,
+        file_path=file_path,
+        line_number=line_number,
+        framework=provider,
+        detection_source=src,
+        confidence=confidence,
+        model_name=model_name,
+        metadata=md,
+    )
+
+
+class ModelDetector(BaseScanner):
+    name = "model_detector"
+
+    def supports(self, context: ScanContext) -> bool:
+        return any(Path(p).exists() for p in context.paths)
+
+    def scan(
+        self, context: ScanContext
+    ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+        components: list[AIComponent] = []
+        seen: set[tuple[str, int, str, str]] = set()
+
+        for fpath, _rel in _iter_files(context):
+            suffix = fpath.suffix.lower()
+            name_lower = fpath.name.lower()
+            try:
+                text = fpath.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+
+            extracted: list[tuple[str, int, str]] = []
+
+            if suffix == ".py":
+                for val, ln in _extract_python_models(text):
+                    extracted.append((val, ln, "string_literal"))
+            elif name_lower == ".env" or fpath.name.endswith(".env"):
+                for val, ln in _extract_env_models(text):
+                    extracted.append((val, ln, "env_var"))
+            elif suffix in (".yaml", ".yml"):
+                for val, ln in _extract_yaml_models(text):
+                    extracted.append((val, ln, "config_file"))
+            elif suffix == ".json":
+                for val, ln in _extract_json_models(text):
+                    extracted.append((val, ln, "config_file"))
+            elif suffix == ".toml":
+                for val, ln in _extract_toml_tool_models(text):
+                    extracted.append((val, ln, "config_file"))
+
+            fp_str = str(fpath)
+            for model_name, line_no, method in extracted:
+                key = (fp_str, line_no, model_name, method)
+                if key in seen:
+                    continue
+                seen.add(key)
+                reg = _registry_lookup(model_name)
+                components.append(
+                    _make_component(model_name, fp_str, line_no, method, reg)
+                )
+
+        return components, []

--- a/aibom/src/aibom/scanners/multi_language_scanner.py
+++ b/aibom/src/aibom/scanners/multi_language_scanner.py
@@ -1,0 +1,838 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from pathspec import PathSpec
+
+from ..models import AIComponent, ComponentRelationship, ScanContext
+from ..models.enums import AIComponentType, DetectionSource
+from .base import BaseScanner
+
+try:
+    from tree_sitter import Language as _TSLanguage
+    from tree_sitter import Parser as _TSParser
+except ImportError:
+    _TSLanguage = None  # type: ignore[misc, assignment]
+    _TSParser = None  # type: ignore[misc, assignment]
+
+_EXTENSION_TO_LANG: dict[str, str] = {
+    ".js": "jsts",
+    ".mjs": "jsts",
+    ".ts": "jsts",
+    ".tsx": "jsts",
+    ".jsx": "jsts",
+    ".java": "java",
+    ".go": "go",
+    ".rs": "rust",
+    ".rb": "ruby",
+    ".cs": "csharp",
+}
+
+_ECOSYSTEM_PACKAGES: dict[str, tuple[str, tuple[str, ...]]] = {
+    "jsts": (
+        "npm",
+        (
+            "openai",
+            "@langchain/core",
+            "@langchain/openai",
+            "@anthropic-ai/sdk",
+            "ai",
+            "@ai-sdk/openai",
+            "@google/generative-ai",
+            "@modelcontextprotocol/sdk",
+            "llamaindex",
+            "chromadb",
+        ),
+    ),
+    "java": (
+        "maven",
+        (
+            "dev.langchain4j",
+            "com.azure.ai.openai",
+            "com.google.cloud.aiplatform",
+            "io.github.sashirestela.simpleopenai",
+        ),
+    ),
+    "go": (
+        "go",
+        (
+            "github.com/sashabaranov/go-openai",
+            "github.com/anthropics/anthropic-sdk-go",
+            "github.com/tmc/langchaingo",
+        ),
+    ),
+    "rust": (
+        "cargo",
+        (
+            "async_openai",
+            "llm",
+            "candle_core",
+            "candle_nn",
+            "burn",
+        ),
+    ),
+    "ruby": (
+        "rubygems",
+        (
+            "ruby-openai",
+            "langchainrb",
+        ),
+    ),
+    "csharp": (
+        "nuget",
+        (
+            "Azure.AI.OpenAI",
+            "Microsoft.SemanticKernel",
+            "Microsoft.ML",
+        ),
+    ),
+}
+
+_SKIP_MODEL_STRINGS = frozenset(
+    {
+        "",
+        "true",
+        "false",
+        "null",
+        "none",
+        "auto",
+        "default",
+        "undefined",
+    }
+)
+
+
+def _build_pathspec(patterns: list[str]) -> Optional[PathSpec]:
+    if not patterns:
+        return None
+    return PathSpec.from_lines("gitwildmatch", patterns)
+
+
+def _line_at(text: str, pos: int) -> int:
+    return text.count("\n", 0, pos) + 1
+
+
+def _normalize_model_literal(raw: str) -> str:
+    s = raw.strip().strip('"').strip("'")
+    if s.startswith("${") or "{{" in s:
+        return ""
+    return s
+
+
+def _is_plausible_model_id(s: str) -> bool:
+    if len(s) < 2 or len(s) > 256:
+        return False
+    low = s.lower()
+    if low in _SKIP_MODEL_STRINGS or low.startswith("${"):
+        return False
+    if not re.search(r"[a-zA-Z]", s):
+        return False
+    return True
+
+
+def _longest_prefix_match(path: str, packages: tuple[str, ...]) -> Optional[str]:
+    best: Optional[str] = None
+    for p in packages:
+        if path == p or path.startswith(p + "/") or path.startswith(p + "."):
+            if best is None or len(p) > len(best):
+                best = p
+    return best
+
+
+def _match_known_package(
+    spec: str, packages: tuple[str, ...]
+) -> Optional[str]:
+    s = spec.strip().strip('"').strip("'").rstrip(";")
+    if not s:
+        return None
+    for p in sorted(packages, key=len, reverse=True):
+        if s == p:
+            return p
+        if p.startswith("@") or "/" in p or "." in p:
+            if s.startswith(p) and (len(s) == len(p) or s[len(p)] in "/."):
+                return p
+        elif s.startswith(p + ".") or s == p:
+            return p
+    return _longest_prefix_match(s.replace("\\", "/"), packages)
+
+
+def _js_ts_alt(packages: tuple[str, ...]) -> str:
+    return "|".join(re.escape(p) for p in sorted(packages, key=len, reverse=True))
+
+
+def _compile_js_ts_patterns(packages: tuple[str, ...]) -> list[re.Pattern[str]]:
+    alt = _js_ts_alt(packages)
+    return [
+        re.compile(rf'require\s*\(\s*["\'](?P<pkg>{alt})["\']', re.MULTILINE),
+        re.compile(
+            rf"""import\s+(?:[\w{{}},\s*]+\s+from\s+)?["\'](?P<pkg>{alt})["']""",
+            re.MULTILINE,
+        ),
+        re.compile(rf"""from\s+["\'](?P<pkg>{alt})["']""", re.MULTILINE),
+        re.compile(r"\bnew\s+OpenAI\s*\(", re.MULTILINE),
+        re.compile(r"\bChatOpenAI\s*\(", re.MULTILINE),
+        re.compile(
+            r"""(?P<key>\bmodel\b)\s*[:=]\s*["'](?P<val>[^"']+)["']""",
+            re.MULTILINE,
+        ),
+    ]
+
+
+def _compile_java_patterns(packages: tuple[str, ...]) -> list[re.Pattern[str]]:
+    pats: list[re.Pattern[str]] = []
+    for p in packages:
+        pats.append(
+            re.compile(
+                rf"import\s+(?P<pkg>{re.escape(p)}(?:\.\w+|\.\*)?)\s*;",
+                re.MULTILINE,
+            )
+        )
+    pats.extend(
+        [
+            re.compile(
+                r"""(?P<key>\bmodel\b|\bModel\b)\s*[:=]\s*["'](?P<val>[^"']+)["']""",
+                re.MULTILINE,
+            ),
+            re.compile(
+                r"\bnew\s+(?:OpenAIClient|ChatCompletionsClient|ChatClient)\s*\(",
+                re.MULTILINE,
+            ),
+        ]
+    )
+    return pats
+
+
+def _compile_go_patterns(packages: tuple[str, ...]) -> str:
+    return "|".join(re.escape(p) for p in sorted(packages, key=len, reverse=True))
+
+
+def _compile_rust_patterns(packages: tuple[str, ...]) -> list[re.Pattern[str]]:
+    alt = "|".join(re.escape(p) for p in sorted(packages, key=len, reverse=True))
+    return [
+        re.compile(rf"\buse\s+(?P<pkg>{alt})::", re.MULTILINE),
+        re.compile(
+            r"""(?P<key>\bmodel\b)\s*[:=]\s*["'](?P<val>[^"']+)["']""",
+            re.MULTILINE,
+        ),
+    ]
+
+
+def _compile_ruby_patterns(packages: tuple[str, ...]) -> list[re.Pattern[str]]:
+    alt = "|".join(re.escape(p) for p in packages)
+    return [
+        re.compile(rf'require\s+["\'](?P<pkg>{alt})["\']', re.MULTILINE),
+        re.compile(
+            r"""(?P<key>\bmodel\b)\s*[:=]\s*["'](?P<val>[^"']+)["']""",
+            re.MULTILINE,
+        ),
+    ]
+
+
+def _compile_csharp_patterns(packages: tuple[str, ...]) -> list[re.Pattern[str]]:
+    pats: list[re.Pattern[str]] = []
+    for p in packages:
+        pats.append(
+            re.compile(rf"using\s+(?P<pkg>{re.escape(p)})\s*;", re.MULTILINE),
+        )
+    pats.extend(
+        [
+            re.compile(
+                r"""(?P<key>\bModel\b|\bmodel\b)\s*=\s*["'](?P<val>[^"']+)["']""",
+                re.MULTILINE,
+            ),
+            re.compile(r'\.model\s*\(\s*["\'](?P<val>[^"\']+)["\']', re.MULTILINE),
+        ]
+    )
+    return pats
+
+
+_AGENT_RE = re.compile(r"\bnew\s+Agent\s*\(", re.MULTILINE)
+_TOOL_RES = [
+    re.compile(r"\bnew\s+\w*Tool\s*\(", re.MULTILINE),
+    re.compile(r"@tool\s*\(", re.MULTILINE),
+    re.compile(r"\bcreateTool\s*\(", re.MULTILINE),
+    re.compile(r"\bFunctionTool\s*\(", re.MULTILINE),
+]
+
+_MODEL_GENERIC_RES = [
+    re.compile(
+        r"""\.model\s*\(\s*["'](?P<val>[^"']+)["']""",
+        re.MULTILINE,
+    ),
+    re.compile(
+        r"""(?P<key>\bmodel\b|\bModel\b)\s*[:=]\s*["'](?P<val>[^"']+)["']""",
+        re.MULTILINE,
+    ),
+]
+
+_GO_ALT = _compile_go_patterns(_ECOSYSTEM_PACKAGES["go"][1])
+
+_REGEX_BY_LANG: dict[str, list[re.Pattern[str]]] = {
+    "jsts": _compile_js_ts_patterns(_ECOSYSTEM_PACKAGES["jsts"][1]),
+    "java": _compile_java_patterns(_ECOSYSTEM_PACKAGES["java"][1]),
+    "go": [],
+    "rust": _compile_rust_patterns(_ECOSYSTEM_PACKAGES["rust"][1]),
+    "ruby": _compile_ruby_patterns(_ECOSYSTEM_PACKAGES["ruby"][1]),
+    "csharp": _compile_csharp_patterns(_ECOSYSTEM_PACKAGES["csharp"][1]),
+}
+
+_GO_MODEL_RE = re.compile(
+    r"""(?P<key>\bmodel\b)\s*[:=]\s*["'](?P<val>[^"']+)["']""",
+    re.MULTILINE,
+)
+
+
+def _go_import_strings(text: str) -> list[tuple[int, str]]:
+    out: list[tuple[int, str]] = []
+    _, packages = _ECOSYSTEM_PACKAGES["go"]
+    for m in re.finditer(rf'import\s+"(?P<pkg>{_GO_ALT})"', text, re.MULTILINE):
+        matched = _match_known_package(m.group("pkg"), packages)
+        if matched:
+            out.append((_line_at(text, m.start()), matched))
+    for m in re.finditer(r"import\s*\((?P<block>[\s\S]*?)\)", text):
+        block = m.group("block")
+        base = m.start("block")
+        for sm in re.finditer(rf'"(?P<pkg>{_GO_ALT})"', block):
+            matched = _match_known_package(sm.group("pkg"), packages)
+            if matched:
+                pos = base + sm.start("pkg")
+                out.append((_line_at(text, pos), matched))
+    return out
+
+
+def _load_ts_language_factory(ext: str) -> Optional[Callable[[], Any]]:
+    if _TSLanguage is None:
+        return None
+    e = ext.lower()
+    if e in (".ts", ".tsx"):
+        try:
+            import tree_sitter_typescript as tst  # type: ignore[import-untyped]
+
+            if e == ".tsx":
+                return tst.language_tsx  # type: ignore[attr-defined]
+            return tst.language_typescript  # type: ignore[attr-defined]
+        except ImportError:
+            return None
+    if e in (".js", ".mjs", ".jsx"):
+        try:
+            import tree_sitter_javascript as tsjs  # type: ignore[import-untyped]
+
+            return tsjs.language  # type: ignore[attr-defined]
+        except ImportError:
+            return None
+    try:
+        import tree_sitter_javascript as tsjs  # type: ignore[import-untyped]
+
+        return tsjs.language  # type: ignore[attr-defined]
+    except ImportError:
+        return None
+
+
+def _load_language_factory(lang: str, ext: str) -> Optional[Callable[[], Any]]:
+    if _TSLanguage is None:
+        return None
+    if lang == "jsts":
+        return _load_ts_language_factory(ext)
+    mod_map = {
+        "java": ("tree_sitter_java", "language"),
+        "go": ("tree_sitter_go", "language"),
+        "rust": ("tree_sitter_rust", "language"),
+        "ruby": ("tree_sitter_ruby", "language"),
+        "csharp": ("tree_sitter_c_sharp", "language"),
+    }
+    if lang not in mod_map:
+        return None
+    mod_name, attr = mod_map[lang]
+    try:
+        mod = __import__(mod_name, fromlist=[attr])
+    except ImportError:
+        return None
+    fn = getattr(mod, attr, None)
+    return fn if callable(fn) else None
+
+
+_parsers: dict[tuple[str, str], Any] = {}
+
+
+def _parser_for(lang: str, ext: str) -> Optional[Any]:
+    if _TSParser is None or _TSLanguage is None:
+        return None
+    key = (lang, ext)
+    if key in _parsers:
+        return _parsers[key]
+    factory = _load_language_factory(lang, ext)
+    if factory is None:
+        _parsers[key] = None
+        return None
+    try:
+        lang_obj = _TSLanguage(factory())
+        p = _TSParser(lang_obj)
+        _parsers[key] = p
+        return p
+    except Exception:
+        _parsers[key] = None
+        return None
+
+
+def _node_text(source: bytes, start: int, end: int) -> str:
+    return source[start:end].decode("utf-8", errors="replace")
+
+
+def _walk_ts_imports_js_like(
+    node: Any, source: bytes, packages: tuple[str, ...], out: list[tuple[int, str]]
+) -> None:
+    dec = source.decode("utf-8", errors="replace")
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        t = n.type
+        if t == "import_statement":
+            for c in n.children:
+                if c.type == "string":
+                    for sc in c.children:
+                        if sc.type == "string_fragment":
+                            raw = _node_text(source, sc.start_byte, sc.end_byte)
+                            m = _match_known_package(raw, packages)
+                            if m:
+                                out.append((_line_at(dec, sc.start_byte), m))
+        elif t == "call_expression":
+            fn = (
+                n.child_by_field_name("function")
+                if hasattr(n, "child_by_field_name")
+                else None
+            )
+            if fn is None and n.children:
+                fn = n.children[0]
+            if fn is not None and _node_text(source, fn.start_byte, fn.end_byte) == "require":
+                args = (
+                    n.child_by_field_name("arguments")
+                    if hasattr(n, "child_by_field_name")
+                    else None
+                )
+                if args is None and len(n.children) > 1:
+                    args = n.children[1]
+                if args is not None:
+                    for ac in getattr(args, "children", []) or []:
+                        if ac.type == "string":
+                            for sc in ac.children:
+                                if sc.type == "string_fragment":
+                                    raw = _node_text(source, sc.start_byte, sc.end_byte)
+                                    matched = _match_known_package(raw, packages)
+                                    if matched:
+                                        out.append((_line_at(dec, sc.start_byte), matched))
+        for c in reversed(n.children):
+            stack.append(c)
+
+
+def _walk_java_imports(
+    node: Any, source: bytes, packages: tuple[str, ...], out: list[tuple[int, str]]
+) -> None:
+    dec = source.decode("utf-8", errors="replace")
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if n.type == "import_declaration":
+            frag = _node_text(source, n.start_byte, n.end_byte)
+            m = re.search(
+                r"import\s+(?:static\s+)?([\w.]+)\s*;",
+                frag,
+            )
+            if m:
+                matched = _match_known_package(m.group(1), packages)
+                if matched:
+                    out.append((_line_at(dec, n.start_byte), matched))
+        for c in reversed(n.children):
+            stack.append(c)
+
+
+def _walk_go_imports(
+    node: Any, source: bytes, packages: tuple[str, ...], out: list[tuple[int, str]]
+) -> None:
+    dec = source.decode("utf-8", errors="replace")
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if n.type == "import_spec":
+            path_node = (
+                n.child_by_field_name("path")
+                if hasattr(n, "child_by_field_name")
+                else None
+            )
+            if path_node is None:
+                for c in n.children:
+                    if c.type == "interpreted_string_literal":
+                        path_node = c
+                        break
+            if path_node is not None:
+                raw = _node_text(source, path_node.start_byte, path_node.end_byte).strip(
+                    '"'
+                )
+                matched = _match_known_package(raw, packages)
+                if matched:
+                    out.append((_line_at(dec, path_node.start_byte), matched))
+        for c in reversed(n.children):
+            stack.append(c)
+
+
+def _walk_rust_uses(
+    node: Any, source: bytes, packages: tuple[str, ...], out: list[tuple[int, str]]
+) -> None:
+    dec = source.decode("utf-8", errors="replace")
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if n.type == "use_declaration":
+            frag = _node_text(source, n.start_byte, n.end_byte)
+            m = re.match(r"\s*use\s+([\w:]+)", frag)
+            if m:
+                path = m.group(1).split("::")[0].removeprefix("crate::")
+                matched = _match_known_package(path, packages)
+                if matched:
+                    out.append((_line_at(dec, n.start_byte), matched))
+        for c in reversed(n.children):
+            stack.append(c)
+
+
+def _walk_ruby_requires(
+    node: Any, source: bytes, packages: tuple[str, ...], out: list[tuple[int, str]]
+) -> None:
+    dec = source.decode("utf-8", errors="replace")
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if n.type == "call":
+            fn = (
+                n.child_by_field_name("method")
+                if hasattr(n, "child_by_field_name")
+                else None
+            )
+            if fn is None and n.children:
+                fn = n.children[0]
+            if fn is not None and _node_text(source, fn.start_byte, fn.end_byte) == "require":
+                args = (
+                    n.child_by_field_name("arguments")
+                    if hasattr(n, "child_by_field_name")
+                    else None
+                )
+                if args is None and len(n.children) > 1:
+                    args = n.children[1]
+                if args is not None:
+                    for ac in getattr(args, "children", []) or []:
+                        if ac.type == "string":
+                            for sc in ac.children:
+                                if sc.type in ("string_content", "string_fragment"):
+                                    raw = _node_text(source, sc.start_byte, sc.end_byte)
+                                    matched = _match_known_package(raw, packages)
+                                    if matched:
+                                        out.append((_line_at(dec, sc.start_byte), matched))
+        for c in reversed(n.children):
+            stack.append(c)
+
+
+def _walk_csharp_usings(
+    node: Any, source: bytes, packages: tuple[str, ...], out: list[tuple[int, str]]
+) -> None:
+    dec = source.decode("utf-8", errors="replace")
+    stack = [node]
+    while stack:
+        n = stack.pop()
+        if n.type == "using_directive":
+            name = (
+                n.child_by_field_name("name")
+                if hasattr(n, "child_by_field_name")
+                else None
+            )
+            if name is not None:
+                raw = _node_text(source, name.start_byte, name.end_byte)
+                matched = _match_known_package(raw, packages)
+                if matched:
+                    out.append((_line_at(dec, name.start_byte), matched))
+        for c in reversed(n.children):
+            stack.append(c)
+
+
+def _tree_sitter_imports(
+    lang: str, ext: str, text: str, packages: tuple[str, ...]
+) -> list[tuple[int, str]]:
+    parser = _parser_for(lang, ext)
+    if parser is None:
+        return []
+    source = text.encode("utf-8")
+    try:
+        tree = parser.parse(source)
+    except Exception:
+        return []
+    root = tree.root_node
+    out: list[tuple[int, str]] = []
+    if lang == "jsts":
+        _walk_ts_imports_js_like(root, source, packages, out)
+    elif lang == "java":
+        _walk_java_imports(root, source, packages, out)
+    elif lang == "go":
+        _walk_go_imports(root, source, packages, out)
+    elif lang == "rust":
+        _walk_rust_uses(root, source, packages, out)
+    elif lang == "ruby":
+        _walk_ruby_requires(root, source, packages, out)
+    elif lang == "csharp":
+        _walk_csharp_usings(root, source, packages, out)
+    return out
+
+
+def _tree_sitter_model_strings(lang: str, ext: str, text: str) -> list[tuple[int, str]]:
+    parser = _parser_for(lang, ext)
+    if parser is None:
+        return []
+    source = text.encode("utf-8")
+    try:
+        tree = parser.parse(source)
+    except Exception:
+        return []
+    dec = source.decode("utf-8", errors="replace")
+    out: list[tuple[int, str]] = []
+    stack = [tree.root_node]
+    string_types = frozenset(
+        {
+            "string",
+            "string_literal",
+            "interpreted_string_literal",
+            "verbatim_string_literal",
+        }
+    )
+    while stack:
+        n = stack.pop()
+        if n.type in string_types:
+            raw = _node_text(source, n.start_byte, n.end_byte)
+            inner = raw.strip('"\'`')
+            if _is_plausible_model_id(inner):
+                prefix = dec[max(0, n.start_byte - 48) : n.start_byte]
+                if re.search(
+                    r"(?:\bmodel\b|\bModel\b)\s*[:=]\s*$|\.model\s*\(\s*$",
+                    prefix,
+                    re.MULTILINE,
+                ):
+                    out.append((_line_at(dec, n.start_byte), inner))
+        for c in reversed(n.children):
+            stack.append(c)
+    return out
+
+
+def _regex_scan_file(
+    path: Path,
+    rel: str,
+    lang: str,
+    text: str,
+) -> list[AIComponent]:
+    components: list[AIComponent] = []
+    seen: set[tuple[int, str, str]] = set()
+    ecosystem, packages = _ECOSYSTEM_PACKAGES[lang]
+    patterns = _REGEX_BY_LANG[lang]
+
+    def add_dep(line: int, pkg: str) -> None:
+        key = (line, "dep", pkg)
+        if key in seen:
+            return
+        seen.add(key)
+        components.append(
+            AIComponent(
+                name=pkg,
+                component_type=AIComponentType.DEPENDENCY,
+                file_path=rel,
+                line_number=line,
+                framework=ecosystem,
+                detection_source=DetectionSource.CODE_ANALYSIS,
+                confidence=0.85,
+                metadata={
+                    "ecosystem": ecosystem,
+                    "package": pkg,
+                    "scanner": "multi_language_scanner",
+                },
+            )
+        )
+
+    def add_model(line: int, model_id: str) -> None:
+        key = (line, "model", model_id)
+        if key in seen:
+            return
+        seen.add(key)
+        components.append(
+            AIComponent(
+                name=model_id,
+                component_type=AIComponentType.MODEL,
+                file_path=rel,
+                line_number=line,
+                framework=ecosystem,
+                detection_source=DetectionSource.CODE_ANALYSIS,
+                confidence=0.75,
+                model_name=model_id,
+                metadata={"scanner": "multi_language_scanner"},
+            )
+        )
+
+    def add_agent(line: int) -> None:
+        key = (line, "agent", "Agent")
+        if key in seen:
+            return
+        seen.add(key)
+        components.append(
+            AIComponent(
+                name="Agent",
+                component_type=AIComponentType.AGENT,
+                file_path=rel,
+                line_number=line,
+                framework=ecosystem,
+                detection_source=DetectionSource.CODE_ANALYSIS,
+                confidence=0.7,
+                metadata={"scanner": "multi_language_scanner"},
+            )
+        )
+
+    def add_tool(line: int, hint: str) -> None:
+        key = (line, "tool", hint)
+        if key in seen:
+            return
+        seen.add(key)
+        components.append(
+            AIComponent(
+                name=hint,
+                component_type=AIComponentType.TOOL,
+                file_path=rel,
+                line_number=line,
+                framework=ecosystem,
+                detection_source=DetectionSource.CODE_ANALYSIS,
+                confidence=0.65,
+                metadata={"scanner": "multi_language_scanner"},
+            )
+        )
+
+    for pat in patterns:
+        for m in pat.finditer(text):
+            line = _line_at(text, m.start())
+            gd = m.groupdict()
+            if gd.get("val"):
+                val = _normalize_model_literal(gd["val"])
+                if _is_plausible_model_id(val):
+                    add_model(line, val)
+                continue
+            if gd.get("pkg"):
+                matched = _match_known_package(gd["pkg"], packages)
+                if matched:
+                    add_dep(line, matched)
+                continue
+            g0 = m.group(0)
+            if "OpenAI" in g0 or "ChatOpenAI" in g0:
+                add_dep(line, "openai")
+            elif (
+                "OpenAIClient" in g0
+                or "ChatCompletionsClient" in g0
+                or "ChatClient" in g0
+            ):
+                add_dep(line, "com.azure.ai.openai")
+
+    if lang == "go":
+        for line, pkg in _go_import_strings(text):
+            add_dep(line, pkg)
+        for m in _GO_MODEL_RE.finditer(text):
+            if m.group("val"):
+                val = _normalize_model_literal(m.group("val"))
+                if _is_plausible_model_id(val):
+                    add_model(_line_at(text, m.start()), val)
+
+    for pat in _MODEL_GENERIC_RES:
+        for m in pat.finditer(text):
+            gd = m.groupdict()
+            if gd.get("val"):
+                val = _normalize_model_literal(gd["val"])
+                if _is_plausible_model_id(val):
+                    add_model(_line_at(text, m.start()), val)
+
+    for m in _AGENT_RE.finditer(text):
+        add_agent(_line_at(text, m.start()))
+
+    for i, tr in enumerate(_TOOL_RES):
+        for m in tr.finditer(text):
+            add_tool(_line_at(text, m.start()), f"tool_pattern_{i}")
+
+    for line, pkg in _tree_sitter_imports(lang, path.suffix, text, packages):
+        add_dep(line, pkg)
+
+    for line, mid in _tree_sitter_model_strings(lang, path.suffix, text):
+        norm = _normalize_model_literal(mid)
+        if _is_plausible_model_id(norm):
+            add_model(line, norm)
+
+    return components
+
+
+def _iter_scan_files(context: ScanContext) -> list[tuple[Path, str, str]]:
+    spec = _build_pathspec(context.exclude_patterns)
+    out: list[tuple[Path, str, str]] = []
+    for scan_root in context.paths:
+        root = Path(scan_root)
+        if not root.exists():
+            continue
+        if root.is_file():
+            if root.suffix.lower() == ".py":
+                continue
+            lang = _EXTENSION_TO_LANG.get(root.suffix.lower())
+            if lang is None:
+                continue
+            rel = root.name
+            if spec and spec.match_file(rel):
+                continue
+            out.append((root.resolve(), rel, lang))
+            continue
+        base = root.resolve()
+        for f in root.rglob("*"):
+            if not f.is_file():
+                continue
+            if f.suffix.lower() == ".py":
+                continue
+            lang = _EXTENSION_TO_LANG.get(f.suffix.lower())
+            if lang is None:
+                continue
+            try:
+                rel = f.resolve().relative_to(base).as_posix()
+            except ValueError:
+                rel = f.as_posix()
+            if spec and spec.match_file(rel):
+                continue
+            out.append((f.resolve(), rel, lang))
+    return out
+
+
+class MultiLanguageScanner(BaseScanner):
+    name = "multi_language_scanner"
+
+    def supports(self, context: ScanContext) -> bool:
+        return bool(_iter_scan_files(context))
+
+    def scan(
+        self, context: ScanContext
+    ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+        components: list[AIComponent] = []
+        for path, rel, lang in _iter_scan_files(context):
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            components.extend(_regex_scan_file(path, rel, lang, text))
+        return components, []

--- a/aibom/src/aibom/scanners/secret_detector.py
+++ b/aibom/src/aibom/scanners/secret_detector.py
@@ -1,0 +1,460 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from pathspec import PathSpec
+
+from ..models import AIComponent, ComponentRelationship, ScanContext
+from ..models.enums import AIComponentType, DetectionSource, Severity
+from .base import BaseScanner
+
+_LOGGER = logging.getLogger(__name__)
+
+try:
+    from detect_secrets import settings as _detect_secrets_settings  # noqa: F401
+    from detect_secrets.core.scan import scan_file as _ds_scan_file
+
+    _HAS_DETECT_SECRETS = True
+except ImportError:
+    _HAS_DETECT_SECRETS = False
+    _ds_scan_file = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class AIKeyPattern:
+    regex: re.Pattern[str]
+    name: str
+    severity: Severity
+    confidence: float
+    line_predicate: Optional[Callable[[str], bool]] = None
+
+
+def _line_has_cohere(line: str) -> bool:
+    return "cohere" in line.lower()
+
+
+def _line_has_together(line: str) -> bool:
+    return "together" in line.lower()
+
+
+def _line_has_mistral(line: str) -> bool:
+    return "mistral" in line.lower()
+
+
+def _line_has_azure_openai(line: str) -> bool:
+    low = line.lower()
+    return "azure" in low and "openai" in low
+
+
+AI_KEY_PATTERNS: list[AIKeyPattern] = [
+    AIKeyPattern(
+        re.compile(r"\bsk-(?!ant-)[a-zA-Z0-9]{20,}\b"),
+        "openai_api_key",
+        Severity.HIGH,
+        0.88,
+    ),
+    AIKeyPattern(
+        re.compile(r"\bsk-ant-[a-zA-Z0-9-]{20,}\b"),
+        "anthropic_api_key",
+        Severity.HIGH,
+        0.9,
+    ),
+    AIKeyPattern(
+        re.compile(r"\bhf_[a-zA-Z0-9]{20,}\b"),
+        "huggingface_api_key",
+        Severity.HIGH,
+        0.88,
+    ),
+    AIKeyPattern(
+        re.compile(r"\b[a-zA-Z0-9]{40}\b"),
+        "cohere_api_key",
+        Severity.MEDIUM,
+        0.42,
+        _line_has_cohere,
+    ),
+    AIKeyPattern(
+        re.compile(r"\bAIza[a-zA-Z0-9_-]{35}\b"),
+        "google_ai_api_key",
+        Severity.HIGH,
+        0.87,
+    ),
+    AIKeyPattern(
+        re.compile(r"\br8_[a-zA-Z0-9]{40}\b"),
+        "replicate_api_token",
+        Severity.HIGH,
+        0.9,
+    ),
+    AIKeyPattern(
+        re.compile(r"\b[a-fA-F0-9]{64}\b"),
+        "together_api_key",
+        Severity.MEDIUM,
+        0.48,
+        _line_has_together,
+    ),
+    AIKeyPattern(
+        re.compile(r"\b[a-zA-Z0-9]{32}\b"),
+        "mistral_api_key",
+        Severity.MEDIUM,
+        0.45,
+        _line_has_mistral,
+    ),
+    AIKeyPattern(
+        re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+        "aws_access_key_id",
+        Severity.HIGH,
+        0.92,
+    ),
+    AIKeyPattern(
+        re.compile(r"\b[a-fA-F0-9]{32}\b"),
+        "azure_openai_key",
+        Severity.MEDIUM,
+        0.5,
+        _line_has_azure_openai,
+    ),
+]
+
+
+_SKIP_NAME_SUFFIXES = (".pyc", ".lock", ".min.js")
+_SKIP_DIR_NAMES = frozenset({"node_modules", ".git"})
+
+
+def _slugify_type(label: str) -> str:
+    s = re.sub(r"[^a-zA-Z0-9]+", "_", label.strip().lower()).strip("_")
+    return s or "secret"
+
+
+def _path_should_skip(rel_posix: str, name: str) -> bool:
+    parts = rel_posix.split("/")
+    if any(p in _SKIP_DIR_NAMES for p in parts):
+        return True
+    low = name.lower()
+    if low.endswith(_SKIP_NAME_SUFFIXES):
+        return True
+    return False
+
+
+def _load_exclude_spec(context: ScanContext) -> Optional[PathSpec]:
+    if not context.exclude_patterns:
+        return None
+    return PathSpec.from_lines("gitwildmatch", context.exclude_patterns)
+
+
+def _is_excluded(abs_file: Path, root: Path, spec: Optional[PathSpec]) -> bool:
+    if not spec:
+        return False
+    try:
+        rel = abs_file.relative_to(root).as_posix()
+    except ValueError:
+        rel = abs_file.as_posix()
+    return spec.match_file(rel)
+
+
+def _iter_scan_files(context: ScanContext) -> Iterator[tuple[Path, Path]]:
+    spec = _load_exclude_spec(context)
+    for root_str in context.paths:
+        root = Path(root_str).resolve()
+        if root.is_file():
+            if _path_should_skip(root.name, root.name):
+                continue
+            if _is_excluded(root, root.parent, spec):
+                continue
+            yield root, root.parent
+            continue
+        if not root.is_dir():
+            continue
+        for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+            dp = Path(dirpath)
+            rel_root = dp.relative_to(root).as_posix() if dp != root else ""
+            dirnames[:] = [
+                d
+                for d in dirnames
+                if d not in _SKIP_DIR_NAMES
+                and not _path_should_skip(
+                    "/".join(filter(None, [rel_root, d])), d
+                )
+            ]
+            for fn in filenames:
+                file_path = dp / fn
+                rel = file_path.relative_to(root).as_posix()
+                if _path_should_skip(rel, fn):
+                    continue
+                if _is_excluded(file_path, root, spec):
+                    continue
+                yield file_path, root
+
+
+def _read_text_lines(path: Path) -> Optional[list[str]]:
+    try:
+        raw = path.read_bytes()
+    except OSError as e:
+        _LOGGER.debug("Unreadable file %s: %s", path, e)
+        return None
+    if b"\x00" in raw[:8192]:
+        return None
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+    return text.splitlines()
+
+
+def _regex_scan_line(
+    line: str, line_number: int, file_path: str, out: dict[tuple[str, int], AIComponent]
+) -> None:
+    for pat in AI_KEY_PATTERNS:
+        pred = pat.line_predicate
+        if pred is not None and not pred(line):
+            continue
+        if not pat.regex.search(line):
+            continue
+        comp = AIComponent(
+            name=pat.name,
+            component_type=AIComponentType.SECRET,
+            file_path=file_path,
+            line_number=line_number,
+            detection_source=DetectionSource.CODE_ANALYSIS,
+            confidence=pat.confidence,
+            description=f"Potential {pat.name} detected",
+            text=None,
+            metadata={
+                "secret_type": pat.name,
+                "detection_method": "regex",
+            },
+        )
+        _merge_component(out, comp)
+
+
+def _merge_component(bucket: dict[tuple[str, int], AIComponent], comp: AIComponent) -> None:
+    key = (comp.file_path, comp.line_number)
+    prev = bucket.get(key)
+    if prev is None or comp.confidence > prev.confidence:
+        bucket[key] = comp
+
+
+def _detect_secrets_scan_file(abs_path: Path, out: dict[tuple[str, int], AIComponent]) -> None:
+    if not _HAS_DETECT_SECRETS or _ds_scan_file is None:
+        return
+    try:
+        for secret in _ds_scan_file(str(abs_path)):
+            stype = _slugify_type(secret.type)
+            line_no = int(secret.line_number or 0) or 1
+            file_path = str(abs_path)
+            comp = AIComponent(
+                name=stype,
+                component_type=AIComponentType.SECRET,
+                file_path=file_path,
+                line_number=line_no,
+                detection_source=DetectionSource.CODE_ANALYSIS,
+                confidence=0.72,
+                description=f"Potential {stype} detected",
+                text=None,
+                metadata={
+                    "secret_type": stype,
+                    "detection_method": "detect_secrets",
+                },
+            )
+            _merge_component(out, comp)
+    except Exception:
+        _LOGGER.debug("detect_secrets failed for %s", abs_path, exc_info=True)
+
+
+def _run_gitleaks(source: Path, out: dict[tuple[str, int], AIComponent]) -> None:
+    if not shutil.which("gitleaks"):
+        return
+    report_path: Optional[str] = None
+    raw = ""
+    try:
+        fd, report_path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        subprocess.run(
+            [
+                "gitleaks",
+                "detect",
+                "--source",
+                str(source),
+                "--report-format",
+                "json",
+                "--report-path",
+                report_path,
+                "--no-git",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+        raw = Path(report_path).read_text(encoding="utf-8")
+    except Exception:
+        _LOGGER.debug("gitleaks failed for %s", source, exc_info=True)
+        return
+    finally:
+        if report_path:
+            try:
+                Path(report_path).unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    try:
+        findings: Any = json.loads(raw)
+    except json.JSONDecodeError:
+        return
+    if not isinstance(findings, list):
+        return
+    for item in findings:
+        if not isinstance(item, dict):
+            continue
+        file_path = item.get("File") or item.get("file")
+        line = item.get("StartLine") or item.get("Line") or item.get("line")
+        rule = item.get("RuleID") or item.get("Description") or item.get("reason") or "secret"
+        if not file_path or line is None:
+            continue
+        try:
+            line_no = int(line)
+        except (TypeError, ValueError):
+            continue
+        stype = _slugify_type(str(rule))
+        abs_path = str(Path(str(file_path)).resolve())
+        comp = AIComponent(
+            name=stype,
+            component_type=AIComponentType.SECRET,
+            file_path=abs_path,
+            line_number=line_no,
+            detection_source=DetectionSource.CODE_ANALYSIS,
+            confidence=0.65,
+            description=f"Potential {stype} detected",
+            text=None,
+            metadata={
+                "secret_type": stype,
+                "detection_method": "gitleaks",
+            },
+        )
+        _merge_component(out, comp)
+
+
+def _run_trufflehog(source: Path, out: dict[tuple[str, int], AIComponent]) -> None:
+    if not shutil.which("trufflehog"):
+        return
+    try:
+        r = subprocess.run(
+            ["trufflehog", "filesystem", str(source), "--json", "--no-update"],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+        text = r.stdout or ""
+    except Exception:
+        _LOGGER.debug("trufflehog failed for %s", source, exc_info=True)
+        return
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            item: Any = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(item, dict):
+            continue
+        det = item.get("DetectorName") or item.get("detector_name") or "secret"
+        stype = _slugify_type(str(det))
+        meta = item.get("SourceMetadata") or {}
+        if isinstance(meta, dict):
+            data = meta.get("Data") or meta
+        else:
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+        file_path = data.get("path") or data.get("filename") or data.get("File")
+        line_no = data.get("line") or data.get("Line")
+        if not file_path:
+            continue
+        try:
+            ln = int(line_no) if line_no is not None else 1
+        except (TypeError, ValueError):
+            ln = 1
+        abs_path = str(Path(str(file_path)).resolve())
+        comp = AIComponent(
+            name=stype,
+            component_type=AIComponentType.SECRET,
+            file_path=abs_path,
+            line_number=ln,
+            detection_source=DetectionSource.CODE_ANALYSIS,
+            confidence=0.65,
+            description=f"Potential {stype} detected",
+            text=None,
+            metadata={
+                "secret_type": stype,
+                "detection_method": "trufflehog",
+            },
+        )
+        _merge_component(out, comp)
+
+
+class SecretDetector(BaseScanner):
+    name = "secret_detector"
+
+    def supports(self, context: ScanContext) -> bool:
+        return True
+
+    def scan(
+        self, context: ScanContext
+    ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+        bucket: dict[tuple[str, int], AIComponent] = {}
+        seen_files: set[Path] = set()
+
+        for file_path, _root in _iter_scan_files(context):
+            resolved = file_path.resolve()
+            if resolved in seen_files:
+                continue
+            seen_files.add(resolved)
+            fp_str = str(resolved)
+
+            lines = _read_text_lines(resolved)
+            if lines is None:
+                continue
+            for i, line in enumerate(lines, start=1):
+                _regex_scan_line(line, i, fp_str, bucket)
+
+            if _HAS_DETECT_SECRETS:
+                _detect_secrets_scan_file(resolved, bucket)
+
+        for root_str in context.paths:
+            src = Path(root_str).resolve()
+            if src.exists():
+                try:
+                    _run_gitleaks(src, bucket)
+                except Exception:
+                    _LOGGER.debug("gitleaks wrapper error", exc_info=True)
+                try:
+                    _run_trufflehog(src, bucket)
+                except Exception:
+                    _LOGGER.debug("trufflehog wrapper error", exc_info=True)
+
+        return list(bucket.values()), []

--- a/aibom/src/aibom/scanners/shadow_ai_detector.py
+++ b/aibom/src/aibom/scanners/shadow_ai_detector.py
@@ -1,0 +1,286 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import Optional
+
+from ..models import AIComponent, ComponentRelationship, ScanContext
+from ..models.enums import AIComponentType, DetectionSource
+from .base import BaseScanner
+from .dependency_scanner import AI_PACKAGES, DependencyScanner, _iter_scan_paths
+
+_LANGCHAIN = frozenset(
+    {"langchain", "langchain-core", "langchain-community", "langchain-openai"},
+)
+_AUTOGEN = frozenset({"autogen", "autogen-agentchat"})
+_LLAMA_INDEX = frozenset({"llama-index", "llama-index-core"})
+
+
+def _build_module_to_pypi() -> dict[str, frozenset[str]]:
+    out: dict[str, frozenset[str]] = {}
+    pypi = AI_PACKAGES["pypi"]
+
+    def add(module: str, pkgs: frozenset[str]) -> None:
+        out[module] = pkgs
+
+    for mod in (
+        "langchain",
+        "langchain_core",
+        "langchain_community",
+        "langchain_openai",
+    ):
+        add(mod, _LANGCHAIN)
+    for mod in ("autogen", "autogen_agentchat"):
+        add(mod, _AUTOGEN)
+    add("tf", frozenset({"tensorflow"}))
+    add("google.generativeai", frozenset({"google-generativeai"}))
+    add("google.cloud.aiplatform", frozenset({"google-cloud-aiplatform"}))
+    add("pinecone", frozenset({"pinecone-client"}))
+    add("llama_index", _LLAMA_INDEX)
+    add("llama_index.core", frozenset({"llama-index-core"}))
+    add("llama_index_core", frozenset({"llama-index-core"}))
+
+    grouped = _LANGCHAIN | _AUTOGEN | _LLAMA_INDEX
+    for pkg in pypi:
+        if pkg in grouped:
+            continue
+        if pkg in (
+            "google-generativeai",
+            "google-cloud-aiplatform",
+            "pinecone-client",
+        ):
+            continue
+        root = pkg.replace("-", "_")
+        if root in ("llama_index", "llama_index_core"):
+            continue
+        if root not in out:
+            add(root, frozenset({pkg}))
+        else:
+            prev = out[root]
+            out[root] = prev | frozenset({pkg})
+
+    return out
+
+
+_MODULE_TO_PYPI = _build_module_to_pypi()
+
+_IMPORTLIB_MOD = re.compile(
+    r"""importlib\.import_module\s*\(\s*["']([^"']+)["']""",
+)
+_IMPORT_BUILTIN_RE = re.compile(r"""__import__\s*\(\s*["']([^"']+)["']""")
+
+
+def _pypi_display_name(spec: str, pkgs: frozenset[str]) -> str:
+    spec = spec.strip()
+    if len(pkgs) == 1:
+        return next(iter(pkgs))
+    if pkgs == _LANGCHAIN:
+        root = spec.split(".")[0]
+        inferred = root.replace("_", "-")
+        if inferred in pkgs:
+            return inferred
+        return "langchain"
+    if pkgs == _AUTOGEN:
+        root = spec.split(".")[0]
+        inferred = root.replace("_", "-")
+        if inferred in pkgs:
+            return inferred
+        return "autogen"
+    if pkgs == _LLAMA_INDEX:
+        root = spec.split(".")[0]
+        if root == "llama_index_core" or ".core" in spec:
+            return "llama-index-core"
+        return "llama-index"
+    return min(pkgs)
+
+
+def _satisfying_pypi_packages(module_spec: str) -> Optional[frozenset[str]]:
+    s = module_spec.strip()
+    if s in _MODULE_TO_PYPI:
+        return _MODULE_TO_PYPI[s]
+    for prefix, pkgs in (
+        ("google.generativeai", _MODULE_TO_PYPI["google.generativeai"]),
+        ("google.cloud.aiplatform", _MODULE_TO_PYPI["google.cloud.aiplatform"]),
+    ):
+        if s == prefix or s.startswith(prefix + "."):
+            return pkgs
+    root = s.split(".")[0]
+    if root == "tf":
+        return _MODULE_TO_PYPI.get("tf")
+    return _MODULE_TO_PYPI.get(root)
+
+
+def _is_declared(declared: set[str], pkgs: frozenset[str]) -> bool:
+    return bool(declared.intersection(pkgs))
+
+
+def _string_from_expr(node: ast.expr) -> Optional[str]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+class _ImportCollector(ast.NodeVisitor):
+    def __init__(self, line_texts: list[str]) -> None:
+        self._lines = line_texts
+        self.hits: list[tuple[int, str, str]] = []
+
+    def _record(self, lineno: int, module_spec: str, snippet: str) -> None:
+        pkgs = _satisfying_pypi_packages(module_spec)
+        if pkgs is None:
+            return
+        self.hits.append((lineno, module_spec, snippet))
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            spec = alias.name
+            line = self._lines[node.lineno - 1] if node.lineno else ""
+            self._record(node.lineno, spec, line.strip())
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.level and node.level > 0:
+            self.generic_visit(node)
+            return
+        if not node.module:
+            self.generic_visit(node)
+            return
+        line = self._lines[node.lineno - 1] if node.lineno else ""
+        snippet = line.strip()
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            cand = f"{node.module}.{alias.name}"
+            if _satisfying_pypi_packages(cand) is not None:
+                self._record(node.lineno, cand, snippet)
+            elif _satisfying_pypi_packages(node.module) is not None:
+                self._record(node.lineno, node.module, snippet)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        fn = node.func
+        target: Optional[str] = None
+        if isinstance(fn, ast.Attribute):
+            if (
+                isinstance(fn.value, ast.Name)
+                and fn.value.id == "importlib"
+                and fn.attr == "import_module"
+                and node.args
+            ):
+                target = _string_from_expr(node.args[0])
+        elif isinstance(fn, ast.Name) and fn.id == "__import__" and node.args:
+            target = _string_from_expr(node.args[0])
+        if target is not None and node.lineno:
+            line = self._lines[node.lineno - 1]
+            self._record(node.lineno, target, line.strip())
+        self.generic_visit(node)
+
+
+def _regex_dynamic_hits(
+    text: str, line_texts: list[str]
+) -> list[tuple[int, str, str]]:
+    hits: list[tuple[int, str, str]] = []
+    for i, line in enumerate(line_texts, start=1):
+        for pat in (_IMPORTLIB_MOD, _IMPORT_BUILTIN_RE):
+            for m in pat.finditer(line):
+                spec = m.group(1)
+                if _satisfying_pypi_packages(spec) is not None:
+                    hits.append((i, spec, line.strip()))
+    return hits
+
+
+def _collect_py_imports(path: Path) -> list[tuple[int, str, str]]:
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    lines = raw.splitlines()
+    try:
+        tree = ast.parse(raw)
+    except SyntaxError:
+        tree = None
+    hits: list[tuple[int, str, str]] = []
+    if tree is not None:
+        col = _ImportCollector(lines)
+        col.visit(tree)
+        hits.extend(col.hits)
+    hits.extend(_regex_dynamic_hits(raw, lines))
+    seen: set[tuple[int, str]] = set()
+    out: list[tuple[int, str, str]] = []
+    for lineno, spec, snip in hits:
+        key = (lineno, spec)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append((lineno, spec, snip))
+    return out
+
+
+class ShadowAIDetector(BaseScanner):
+    name = "shadow_ai_detector"
+
+    def supports(self, context: ScanContext) -> bool:
+        return True
+
+    def scan(
+        self, context: ScanContext
+    ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+        dep = DependencyScanner()
+        declared_components, _ = dep.scan(context)
+        declared: set[str] = set()
+        for c in declared_components:
+            if c.metadata.get("ecosystem") == "pypi":
+                declared.add(c.name.strip().lower())
+
+        findings: list[AIComponent] = []
+        seen: set[tuple[str, int, str]] = set()
+        for path in _iter_scan_paths(context):
+            if path.suffix != ".py":
+                continue
+            for lineno, mod_spec, snippet in _collect_py_imports(path):
+                pkgs = _satisfying_pypi_packages(mod_spec)
+                if pkgs is None:
+                    continue
+                if _is_declared(declared, pkgs):
+                    continue
+                pkg_name = _pypi_display_name(mod_spec, pkgs)
+                key = (str(path.resolve()), lineno, pkg_name)
+                if key in seen:
+                    continue
+                seen.add(key)
+                findings.append(
+                    AIComponent(
+                        name=pkg_name,
+                        component_type=AIComponentType.DEPENDENCY,
+                        file_path=str(path.resolve()),
+                        line_number=lineno,
+                        detection_source=DetectionSource.CODE_ANALYSIS,
+                        description=(
+                            f"Undeclared AI dependency: {pkg_name} imported in code "
+                            "but not in dependency manifests"
+                        ),
+                        metadata={
+                            "shadow_ai": True,
+                            "import_found": snippet,
+                            "declared_in_manifests": False,
+                        },
+                    ),
+                )
+        return findings, []

--- a/aibom/src/aibom/scanners/skill_detector.py
+++ b/aibom/src/aibom/scanners/skill_detector.py
@@ -1,0 +1,362 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from pathspec import PathSpec
+
+from ..models import AIComponent, ComponentRelationship, ScanContext
+from ..models.enums import AIComponentType, DetectionSource
+from .base import BaseScanner
+
+_LOGGER = logging.getLogger(__name__)
+
+_TRIGGER_STARTS = (
+    "use when",
+    "activate when",
+    "trigger when",
+    "invoke when",
+    "should be used when",
+)
+
+
+def _load_exclude_spec(patterns: list[str]) -> Optional[PathSpec]:
+    if not patterns:
+        return None
+    return PathSpec.from_lines("gitwildmatch", patterns)
+
+
+def _is_excluded(file_path: Path, root: Path, spec: Optional[PathSpec]) -> bool:
+    if not spec:
+        return False
+    try:
+        rel = file_path.relative_to(root).as_posix()
+    except ValueError:
+        rel = file_path.as_posix()
+    return spec.match_file(rel)
+
+
+def _list_files_in_skill_dir(
+    skill_dir: Path, scan_root: Path, spec: Optional[PathSpec]
+) -> list[str]:
+    out: list[str] = []
+    if not skill_dir.is_dir():
+        return out
+    for p in skill_dir.rglob("*"):
+        if not p.is_file():
+            continue
+        if _is_excluded(p, scan_root, spec):
+            continue
+        try:
+            out.append(p.relative_to(skill_dir).as_posix())
+        except ValueError:
+            out.append(p.name)
+    return sorted(out)
+
+
+def _parse_skill_markdown(text: str) -> tuple[Optional[str], Optional[str], list[str]]:
+    lines = text.splitlines()
+    title: Optional[str] = None
+    title_idx = -1
+    for i, line in enumerate(lines):
+        if line.startswith("# "):
+            title = line[2:].strip()
+            title_idx = i
+            break
+    triggers: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        low = stripped.lower()
+        if any(low.startswith(p) for p in _TRIGGER_STARTS):
+            triggers.append(stripped)
+    desc: Optional[str] = None
+    if title_idx >= 0:
+        i = title_idx + 1
+        while i < len(lines) and not lines[i].strip():
+            i += 1
+        parts: list[str] = []
+        while i < len(lines):
+            line = lines[i]
+            if not line.strip():
+                break
+            if line.startswith("#"):
+                break
+            parts.append(line.strip())
+            i += 1
+        if parts:
+            raw = " ".join(parts)
+            desc = raw if len(raw) <= 200 else raw[:197] + "..."
+    return title, desc, triggers
+
+
+def _read_skill_doc(path: Path) -> tuple[Optional[str], Optional[str], list[str]]:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None, None, []
+    return _parse_skill_markdown(text)
+
+
+def _run_optional_skill_scanner(paths: list[str]) -> None:
+    try:
+        from skill_scanner import SkillScanner
+    except ImportError:
+        return
+    try:
+        scanner = SkillScanner()
+        batch = getattr(scanner, "analyze_paths", None)
+        if callable(batch):
+            batch(paths)
+            return
+        one = getattr(scanner, "analyze_path", None)
+        if callable(one):
+            for p in paths:
+                one(p)
+            return
+        fallback = getattr(scanner, "analyze", None)
+        if callable(fallback):
+            for p in paths:
+                fallback(p)
+    except Exception:
+        _LOGGER.debug("skill_scanner.SkillScanner failed", exc_info=True)
+
+
+def _component_for_skill_md(
+    skill_md: Path,
+    skill_format: str,
+    scan_root: Path,
+    spec: Optional[PathSpec],
+    seen: set[str],
+) -> Optional[AIComponent]:
+    key = str(skill_md.resolve())
+    if key in seen:
+        return None
+    seen.add(key)
+    skill_dir = skill_md.parent
+    title, desc, triggers = _read_skill_doc(skill_md)
+    name = title or skill_dir.name
+    files = _list_files_in_skill_dir(skill_dir, scan_root, spec)
+    meta: dict[str, Any] = {
+        "trigger_patterns": triggers,
+        "file_count": len(files),
+        "files": files,
+    }
+    return AIComponent(
+        name=name,
+        component_type=AIComponentType.SKILL,
+        file_path=str(skill_md.resolve()),
+        skill_format=skill_format,
+        description=desc,
+        detection_source=DetectionSource.CONFIG_FILE,
+        metadata=meta,
+    )
+
+
+def _component_for_plugin_dir(
+    plugin_dir: Path,
+    skill_format: str,
+    scan_root: Path,
+    spec: Optional[PathSpec],
+    seen: set[str],
+) -> Optional[AIComponent]:
+    key = str(plugin_dir.resolve())
+    if key in seen:
+        return None
+    seen.add(key)
+    skill_md = plugin_dir / "SKILL.md"
+    title: Optional[str] = None
+    desc: Optional[str] = None
+    triggers: list[str] = []
+    if skill_md.is_file() and not _is_excluded(skill_md, scan_root, spec):
+        title, desc, triggers = _read_skill_doc(skill_md)
+    name = title or plugin_dir.name
+    files = _list_files_in_skill_dir(plugin_dir, scan_root, spec)
+    fp = str(skill_md.resolve()) if skill_md.is_file() else str(plugin_dir.resolve())
+    meta: dict[str, Any] = {
+        "trigger_patterns": triggers,
+        "file_count": len(files),
+        "files": files,
+    }
+    return AIComponent(
+        name=name,
+        component_type=AIComponentType.SKILL,
+        file_path=fp,
+        skill_format=skill_format,
+        description=desc,
+        detection_source=DetectionSource.CONFIG_FILE,
+        metadata=meta,
+    )
+
+
+def _component_for_single_file(
+    path: Path,
+    skill_format: str,
+    scan_root: Path,
+    spec: Optional[PathSpec],
+    seen: set[str],
+) -> Optional[AIComponent]:
+    key = str(path.resolve())
+    if key in seen:
+        return None
+    if _is_excluded(path, scan_root, spec):
+        return None
+    seen.add(key)
+    title, desc, triggers = _read_skill_doc(path)
+    name = title or path.stem
+    meta: dict[str, Any] = {
+        "trigger_patterns": triggers,
+        "file_count": 1,
+        "files": [path.name],
+    }
+    return AIComponent(
+        name=name,
+        component_type=AIComponentType.SKILL,
+        file_path=str(path.resolve()),
+        skill_format=skill_format,
+        description=desc,
+        detection_source=DetectionSource.CONFIG_FILE,
+        metadata=meta,
+    )
+
+
+def _collect_from_root(
+    root: Path,
+    spec: Optional[PathSpec],
+    seen: set[str],
+    components: list[AIComponent],
+    scan_roots: list[str],
+) -> None:
+    scan_root = root.resolve()
+    if root.is_file():
+        name = root.name.lower()
+        if name == "agents.md" or name == ".agents.md":
+            c = _component_for_single_file(
+                root, "agents_md", scan_root, spec, seen
+            )
+            if c:
+                components.append(c)
+                scan_roots.append(str(root.resolve()))
+        elif root.name == "copilot-instructions.md":
+            c = _component_for_single_file(
+                root, "copilot", scan_root, spec, seen
+            )
+            if c:
+                components.append(c)
+                scan_roots.append(str(root.resolve()))
+        return
+
+    if not root.is_dir():
+        return
+
+    for skill_md in root.glob("**/.cursor/skills/*/SKILL.md"):
+        if _is_excluded(skill_md, scan_root, spec):
+            continue
+        c = _component_for_skill_md(
+            skill_md, "cursor", scan_root, spec, seen
+        )
+        if c:
+            components.append(c)
+            scan_roots.append(str(skill_md.parent.resolve()))
+
+    for skill_md in root.glob("**/.codex/skills/*/SKILL.md"):
+        if _is_excluded(skill_md, scan_root, spec):
+            continue
+        c = _component_for_skill_md(
+            skill_md, "codex", scan_root, spec, seen
+        )
+        if c:
+            components.append(c)
+            scan_roots.append(str(skill_md.parent.resolve()))
+
+    for plugins in root.glob("**/.claude/plugins"):
+        if not plugins.is_dir() or _is_excluded(plugins, scan_root, spec):
+            continue
+        for child in plugins.iterdir():
+            if not child.is_dir() or _is_excluded(child, scan_root, spec):
+                continue
+            c = _component_for_plugin_dir(
+                child, "claude", scan_root, spec, seen
+            )
+            if c:
+                components.append(c)
+                scan_roots.append(str(child.resolve()))
+
+    for devin in root.glob("**/.devin"):
+        if not devin.is_dir() or _is_excluded(devin, scan_root, spec):
+            continue
+        for child in devin.iterdir():
+            if not child.is_dir() or _is_excluded(child, scan_root, spec):
+                continue
+            c = _component_for_plugin_dir(
+                child, "devin", scan_root, spec, seen
+            )
+            if c:
+                components.append(c)
+                scan_roots.append(str(child.resolve()))
+
+    for copilot in root.glob("**/.github/copilot-instructions.md"):
+        c = _component_for_single_file(
+            copilot, "copilot", scan_root, spec, seen
+        )
+        if c:
+            components.append(c)
+            scan_roots.append(str(copilot.resolve()))
+
+    for agents in root.glob("**/AGENTS.md"):
+        c = _component_for_single_file(
+            agents, "agents_md", scan_root, spec, seen
+        )
+        if c:
+            components.append(c)
+            scan_roots.append(str(agents.resolve()))
+
+    for agents in root.glob("**/.agents.md"):
+        c = _component_for_single_file(
+            agents, "agents_md", scan_root, spec, seen
+        )
+        if c:
+            components.append(c)
+            scan_roots.append(str(agents.resolve()))
+
+
+class SkillDetector(BaseScanner):
+    name = "skill_detector"
+
+    def supports(self, context: ScanContext) -> bool:
+        return True
+
+    def scan(
+        self, context: ScanContext
+    ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+        spec = _load_exclude_spec(context.exclude_patterns)
+        components: list[AIComponent] = []
+        seen: set[str] = set()
+        scan_roots: list[str] = []
+
+        for raw in context.paths:
+            root = Path(raw).expanduser()
+            if not root.exists():
+                continue
+            _collect_from_root(root, spec, seen, components, scan_roots)
+
+        if scan_roots:
+            _run_optional_skill_scanner(sorted(set(scan_roots)))
+
+        return components, []

--- a/aibom/src/aibom/scanners/vuln_scanner.py
+++ b/aibom/src/aibom/scanners/vuln_scanner.py
@@ -1,0 +1,579 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+from abc import ABC, abstractmethod
+from typing import Any, Optional
+
+import httpx
+from pydantic import BaseModel
+
+from ..models import AIComponent, ComponentRelationship, ScanContext
+from ..models.enums import AIComponentType, DetectionSource, Severity
+from .base import BaseScanner
+from .dependency_scanner import DependencyScanner
+
+_LOGGER = logging.getLogger(__name__)
+
+vuln_provider_registry: list[type["BaseVulnProvider"]] = []
+
+_OSV_ECOSYSTEM: dict[str, str] = {
+    "pypi": "PyPI",
+    "npm": "npm",
+    "go": "Go",
+    "maven": "Maven",
+    "cargo": "crates.io",
+    "crates.io": "crates.io",
+    "rubygems": "RubyGems",
+    "nuget": "NuGet",
+}
+
+_DISPLAY_ECOSYSTEM: dict[str, str] = {
+    "pypi": "PyPI",
+    "npm": "npm",
+    "go": "Go",
+    "maven": "Maven",
+    "cargo": "crates.io",
+    "rubygems": "RubyGems",
+    "nuget": "NuGet",
+}
+
+_SEVERITY_WEIGHTS: dict[Severity, int] = {
+    Severity.CRITICAL: 25,
+    Severity.HIGH: 20,
+    Severity.MEDIUM: 10,
+    Severity.LOW: 5,
+    Severity.INFO: 1,
+}
+
+
+class Vulnerability(BaseModel):
+    id: str
+    summary: str
+    severity: Severity
+    cvss_score: float = 0.0
+    affected_package: str
+    affected_version: str
+    fixed_version: str = ""
+    source: str
+    url: str = ""
+
+
+class PackageRef(BaseModel):
+    name: str
+    version: str
+    ecosystem: str
+
+
+def _package_ref_key(ref: PackageRef) -> str:
+    return f"{ref.ecosystem}:{ref.name}@{ref.version}"
+
+
+def _normalize_internal_ecosystem(raw: str) -> str:
+    return raw.strip().lower()
+
+
+def _to_display_ecosystem(internal: str) -> str:
+    return _DISPLAY_ECOSYSTEM.get(_normalize_internal_ecosystem(internal), internal)
+
+
+def _to_osv_ecosystem(ecosystem: str) -> Optional[str]:
+    eco = _normalize_internal_ecosystem(ecosystem)
+    if eco in _OSV_ECOSYSTEM:
+        return _OSV_ECOSYSTEM[eco]
+    if ecosystem in _OSV_ECOSYSTEM.values():
+        return ecosystem
+    return _OSV_ECOSYSTEM.get(eco)
+
+
+def _parse_severity_label(label: str) -> Severity:
+    s = label.strip().lower()
+    if s in ("critical", "crit"):
+        return Severity.CRITICAL
+    if s in ("high",):
+        return Severity.HIGH
+    if s in ("medium", "med", "moderate"):
+        return Severity.MEDIUM
+    if s in ("low",):
+        return Severity.LOW
+    return Severity.INFO
+
+
+def _max_severity(a: Severity, b: Severity) -> Severity:
+    return a if a.numeric >= b.numeric else b
+
+
+def _osv_fixed_version(vuln: dict[str, Any]) -> str:
+    for aff in vuln.get("affected") or []:
+        if not isinstance(aff, dict):
+            continue
+        for r in aff.get("ranges") or []:
+            if not isinstance(r, dict):
+                continue
+            for ev in r.get("events") or []:
+                if isinstance(ev, dict) and "fixed" in ev:
+                    fx = ev["fixed"]
+                    if fx is not None:
+                        return str(fx)
+    return ""
+
+
+def _osv_severity_and_score(vuln: dict[str, Any]) -> tuple[Severity, float]:
+    best: Severity = Severity.INFO
+    score = 0.0
+    for entry in vuln.get("severity") or []:
+        if not isinstance(entry, dict):
+            continue
+        raw_score = entry.get("score")
+        if raw_score is not None:
+            try:
+                sc = float(str(raw_score).split()[0])
+                score = max(score, sc)
+                if sc >= 9.0:
+                    best = _max_severity(best, Severity.CRITICAL)
+                elif sc >= 7.0:
+                    best = _max_severity(best, Severity.HIGH)
+                elif sc >= 4.0:
+                    best = _max_severity(best, Severity.MEDIUM)
+                elif sc > 0:
+                    best = _max_severity(best, Severity.LOW)
+            except (TypeError, ValueError):
+                continue
+    if best == Severity.INFO and vuln.get("database_specific"):
+        ds = vuln["database_specific"]
+        if isinstance(ds, dict):
+            sev = ds.get("severity") or ds.get("cvss_severity")
+            if isinstance(sev, str):
+                best = _max_severity(best, _parse_severity_label(sev))
+    return best, score
+
+
+def _osv_references(vuln: dict[str, Any]) -> str:
+    for ref in vuln.get("references") or []:
+        if isinstance(ref, dict):
+            u = ref.get("url")
+            if isinstance(u, str) and u:
+                return u
+    return ""
+
+
+def _grype_severity(v: dict[str, Any]) -> tuple[Severity, float]:
+    label = v.get("severity")
+    if isinstance(label, str):
+        return _parse_severity_label(label), 0.0
+    cvss = v.get("cvss")
+    if isinstance(cvss, list) and cvss:
+        first = cvss[0]
+        if isinstance(first, dict):
+            m = first.get("metrics")
+            if isinstance(m, dict):
+                bm = m.get("baseMetrics")
+                if isinstance(bm, dict):
+                    b = bm.get("baseScore")
+                    if b is not None:
+                        try:
+                            sc = float(b)
+                            return _parse_severity_label(
+                                str(bm.get("baseSeverity", "MEDIUM"))
+                            ), sc
+                        except (TypeError, ValueError):
+                            pass
+    return Severity.INFO, 0.0
+
+
+def _grype_fixed_version(v: dict[str, Any]) -> str:
+    fix = v.get("fix")
+    if isinstance(fix, dict):
+        versions = fix.get("versions")
+        if isinstance(versions, list) and versions:
+            return str(versions[0])
+    return ""
+
+
+def _grype_url(v: dict[str, Any]) -> str:
+    urls = v.get("urls")
+    if isinstance(urls, list) and urls:
+        u = urls[0]
+        if isinstance(u, str):
+            return u
+    return ""
+
+
+def _grype_type_to_ecosystem(type_name: str) -> str:
+    t = type_name.lower()
+    mapping = {
+        "python": "PyPI",
+        "npm": "npm",
+        "go-module": "Go",
+        "go": "Go",
+        "java-archive": "Maven",
+        "jenkins-plugin": "Maven",
+        "rust-crate": "crates.io",
+        "ruby-gem": "RubyGems",
+        "dotnet": "NuGet",
+    }
+    return mapping.get(t, type_name)
+
+
+class BaseVulnProvider(ABC):
+    name: str = ""
+    supported_ecosystems: set[str] = set()
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        if cls.name:
+            vuln_provider_registry.append(cls)
+
+    @abstractmethod
+    def query(self, package: str, version: str, ecosystem: str) -> list[Vulnerability]:
+        ...
+
+    @abstractmethod
+    def batch_query(
+        self, packages: list[PackageRef]
+    ) -> dict[str, list[Vulnerability]]:
+        ...
+
+
+class OsvProvider(BaseVulnProvider):
+    name = "osv"
+    supported_ecosystems = {
+        "PyPI",
+        "npm",
+        "Go",
+        "Maven",
+        "crates.io",
+        "RubyGems",
+        "NuGet",
+    }
+    _BATCH_URL = "https://api.osv.dev/v1/querybatch"
+
+    def query(self, package: str, version: str, ecosystem: str) -> list[Vulnerability]:
+        ref = PackageRef(name=package, version=version, ecosystem=ecosystem)
+        return self.batch_query([ref]).get(_package_ref_key(ref), [])
+
+    def batch_query(
+        self, packages: list[PackageRef]
+    ) -> dict[str, list[Vulnerability]]:
+        result: dict[str, list[Vulnerability]] = {}
+        query_entries: list[tuple[str, PackageRef]] = []
+        queries: list[dict[str, Any]] = []
+        for ref in packages:
+            osv_eco = _to_osv_ecosystem(ref.ecosystem)
+            if not osv_eco:
+                continue
+            key = _package_ref_key(ref)
+            query_entries.append((key, ref))
+            queries.append(
+                {
+                    "package": {"name": ref.name, "ecosystem": osv_eco},
+                    "version": ref.version,
+                },
+            )
+        if not queries:
+            return result
+        try:
+            with httpx.Client(timeout=60.0) as client:
+                resp = client.post(self._BATCH_URL, json={"queries": queries})
+                resp.raise_for_status()
+                data = resp.json()
+        except (httpx.HTTPError, json.JSONDecodeError) as e:
+            _LOGGER.warning("OSV batch query failed: %s", e)
+            return result
+        results = data.get("results") or []
+        for i, block in enumerate(results):
+            if i >= len(query_entries):
+                break
+            key, ref = query_entries[i]
+            vulns: list[Vulnerability] = []
+            for vuln in block.get("vulns") or []:
+                if not isinstance(vuln, dict):
+                    continue
+                vid = str(vuln.get("id", ""))
+                if not vid:
+                    continue
+                sev, cvss = _osv_severity_and_score(vuln)
+                details = vuln.get("summary") or vuln.get("details") or ""
+                vulns.append(
+                    Vulnerability(
+                        id=vid,
+                        summary=str(details)[:2000],
+                        severity=sev,
+                        cvss_score=cvss,
+                        affected_package=ref.name,
+                        affected_version=ref.version,
+                        fixed_version=_osv_fixed_version(vuln),
+                        source="osv",
+                        url=_osv_references(vuln),
+                    ),
+                )
+            result[key] = vulns
+        return result
+
+
+class GrypeProvider(BaseVulnProvider):
+    name = "grype"
+    supported_ecosystems = set(OsvProvider.supported_ecosystems)
+
+    def __init__(self, sbom_path: str) -> None:
+        self._sbom_path = sbom_path
+
+    def query(self, package: str, version: str, ecosystem: str) -> list[Vulnerability]:
+        ref = PackageRef(name=package, version=version, ecosystem=ecosystem)
+        return self.batch_query([ref]).get(_package_ref_key(ref), [])
+
+    def batch_query(
+        self, packages: list[PackageRef]
+    ) -> dict[str, list[Vulnerability]]:
+        result: dict[str, list[Vulnerability]] = {
+            _package_ref_key(p): [] for p in packages
+        }
+        if not shutil.which("grype"):
+            return result
+        try:
+            proc = subprocess.run(
+                ["grype", f"sbom:{self._sbom_path}", "-o", "json"],
+                capture_output=True,
+                text=True,
+                timeout=300,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as e:
+            _LOGGER.warning("Grype execution failed: %s", e)
+            return result
+        if proc.returncode != 0:
+            _LOGGER.warning("Grype exited %s: %s", proc.returncode, proc.stderr[:500])
+            return result
+        try:
+            data = json.loads(proc.stdout)
+        except json.JSONDecodeError as e:
+            _LOGGER.warning("Grype JSON parse error: %s", e)
+            return result
+        want = {_package_ref_key(p): p for p in packages}
+        for match in data.get("matches") or []:
+            if not isinstance(match, dict):
+                continue
+            vuln = match.get("vulnerability")
+            art = match.get("artifact")
+            if not isinstance(vuln, dict) or not isinstance(art, dict):
+                continue
+            name = str(art.get("name") or "")
+            version = str(art.get("version") or "")
+            eco = _grype_type_to_ecosystem(str(art.get("type") or ""))
+            ref = PackageRef(name=name, version=version, ecosystem=eco)
+            key = _package_ref_key(ref)
+            if key not in want:
+                continue
+            vid = str(vuln.get("id") or "")
+            if not vid:
+                continue
+            sev, cvss = _grype_severity(vuln)
+            result[key].append(
+                Vulnerability(
+                    id=vid,
+                    summary=str(vuln.get("description") or vid)[:2000],
+                    severity=sev,
+                    cvss_score=cvss,
+                    affected_package=name,
+                    affected_version=version,
+                    fixed_version=_grype_fixed_version(vuln),
+                    source="grype",
+                    url=_grype_url(vuln),
+                ),
+            )
+        return result
+
+
+def _components_to_package_refs(
+    components: list[AIComponent],
+) -> tuple[list[PackageRef], dict[str, AIComponent]]:
+    refs: list[PackageRef] = []
+    by_key: dict[str, AIComponent] = {}
+    for comp in components:
+        internal = comp.metadata.get("ecosystem")
+        if not isinstance(internal, str):
+            continue
+        ver = comp.sdk_version
+        if not ver:
+            spec = comp.metadata.get("version_spec")
+            ver = str(spec).strip() if spec else "*"
+        if not ver:
+            ver = "*"
+        eco = _to_display_ecosystem(internal)
+        ref = PackageRef(name=comp.name, version=ver, ecosystem=eco)
+        key = _package_ref_key(ref)
+        if key not in by_key:
+            by_key[key] = comp
+            refs.append(ref)
+    return refs, by_key
+
+
+def _component_from_config_dict(item: dict[str, Any]) -> AIComponent:
+    name = str(item["name"])
+    raw_eco = str(item.get("ecosystem", "pypi"))
+    ver = str(item.get("version") or item.get("sdk_version") or "*")
+    return AIComponent(
+        name=name,
+        component_type=AIComponentType.DEPENDENCY,
+        file_path=str(item.get("file_path", "")),
+        line_number=int(item.get("line_number", 0) or 0),
+        sdk_version=ver if ver != "*" else None,
+        detection_source=DetectionSource.DEPENDENCY_MANIFEST,
+        metadata={
+            "ecosystem": _normalize_internal_ecosystem(raw_eco),
+            "version_spec": str(item.get("version_spec", ver)),
+            "manifest": str(item.get("manifest", "")),
+        },
+    )
+
+
+def _resolve_packages(
+    context: ScanContext,
+) -> tuple[list[PackageRef], dict[str, AIComponent]]:
+    raw = context.config.get("detected_packages") or []
+    by_key: dict[str, PackageRef] = {}
+    comp_by_key: dict[str, AIComponent] = {}
+
+    if raw:
+        for item in raw:
+            if isinstance(item, AIComponent):
+                if item.component_type != AIComponentType.DEPENDENCY:
+                    continue
+                refs_one, cmap = _components_to_package_refs([item])
+                for r in refs_one:
+                    k = _package_ref_key(r)
+                    if k not in by_key:
+                        by_key[k] = r
+                        comp_by_key[k] = cmap[k]
+            elif isinstance(item, PackageRef):
+                comp = AIComponent(
+                    name=item.name,
+                    component_type=AIComponentType.DEPENDENCY,
+                    file_path="",
+                    line_number=0,
+                    sdk_version=item.version if item.version != "*" else None,
+                    detection_source=DetectionSource.DEPENDENCY_MANIFEST,
+                    metadata={
+                        "ecosystem": _normalize_internal_ecosystem(item.ecosystem),
+                        "version_spec": item.version,
+                    },
+                )
+                k = _package_ref_key(item)
+                if k not in by_key:
+                    by_key[k] = item
+                    comp_by_key[k] = comp
+            elif isinstance(item, dict) and item.get("name"):
+                comp = _component_from_config_dict(item)
+                refs_one, cmap = _components_to_package_refs([comp])
+                for r in refs_one:
+                    k = _package_ref_key(r)
+                    if k not in by_key:
+                        by_key[k] = r
+                        comp_by_key[k] = cmap[k]
+        return list(by_key.values()), comp_by_key
+
+    dep = DependencyScanner()
+    comps, _ = dep.scan(context)
+    return _components_to_package_refs(comps)
+
+
+class VulnScanner(BaseScanner):
+    name = "vuln_scanner"
+
+    def supports(self, context: ScanContext) -> bool:
+        if not context.paths:
+            return False
+        if context.config.get("dependencies") is False:
+            return False
+        return True
+
+    def scan(
+        self, context: ScanContext
+    ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+        refs, key_to_comp = _resolve_packages(context)
+        if not refs:
+            return [], []
+
+        providers: list[BaseVulnProvider] = [OsvProvider()]
+        sbom_path = context.config.get("sbom_path") or context.config.get(
+            "cyclonedx_sbom"
+        )
+        if isinstance(sbom_path, str) and sbom_path.strip() and shutil.which("grype"):
+            providers.append(GrypeProvider(sbom_path.strip()))
+
+        merged: dict[str, list[Vulnerability]] = {}
+        for prov in providers:
+            batch = prov.batch_query(refs)
+            for k, vulns in batch.items():
+                merged.setdefault(k, []).extend(vulns)
+
+        out: list[AIComponent] = []
+        for ref in refs:
+            key = _package_ref_key(ref)
+            base = key_to_comp.get(key)
+            vulns = merged.get(key, [])
+            if not vulns:
+                continue
+            max_sev = Severity.INFO
+            for v in vulns:
+                max_sev = _max_severity(max_sev, v.severity)
+            weight = _SEVERITY_WEIGHTS.get(max_sev, 1)
+            desc = f"{len(vulns)} known vulnerabilities in {ref.name} {ref.version}"
+            if base:
+                meta = dict(base.metadata)
+                file_path = base.file_path
+                line_no = base.line_number
+                det_src = base.detection_source
+                name = base.name
+                sdk_ver = base.sdk_version
+                framework = base.framework
+            else:
+                meta = {
+                    "ecosystem": _normalize_internal_ecosystem(ref.ecosystem),
+                    "version_spec": ref.version,
+                }
+                file_path = ""
+                line_no = 0
+                det_src = DetectionSource.API
+                name = ref.name
+                sdk_ver = ref.version if ref.version != "*" else None
+                framework = ""
+            meta["vulnerabilities"] = [v.model_dump(mode="json") for v in vulns]
+            meta["risk_flag"] = {
+                "flag": f"vulnerable_dependency:{ref.name}",
+                "severity": max_sev.value,
+                "weight": weight,
+                "description": desc,
+            }
+            out.append(
+                AIComponent(
+                    name=name,
+                    component_type=AIComponentType.DEPENDENCY,
+                    file_path=file_path,
+                    line_number=line_no,
+                    framework=framework,
+                    detection_source=det_src,
+                    description=desc,
+                    sdk_version=sdk_ver,
+                    metadata=meta,
+                ),
+            )
+        return out, []

--- a/aibom/tests/conftest.py
+++ b/aibom/tests/conftest.py
@@ -1,0 +1,38 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from aibom.models import ScanContext
+from aibom.scanners.base import BaseScanner
+
+
+def run_scanner(
+    scanner_class: type[BaseScanner],
+    tmp_path: Path,
+    files: dict[str, str],
+    config: dict[str, Any] | None = None,
+) -> tuple[list[Any], list[Any]]:
+    """Write *files* into *tmp_path* and run a scanner against it."""
+    for rel, content in files.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    ctx = ScanContext(paths=[str(tmp_path)], config=config or {})
+    return scanner_class().scan(ctx)

--- a/aibom/tests/test_config_scanner.py
+++ b/aibom/tests/test_config_scanner.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aibom.models import AIComponentType
+from aibom.scanners.config_scanner import ConfigScanner
+
+from .conftest import run_scanner
+
+
+class TestConfigScanner:
+    def test_docker_compose_ollama_image(self, tmp_path: Path) -> None:
+        yml = "services:\n  llm:\n    image: ollama/ollama:latest\n"
+        comps, rels = run_scanner(ConfigScanner, tmp_path, {"docker-compose.yml": yml})
+        assert rels == []
+        models = [c for c in comps if c.component_type == AIComponentType.MODEL]
+        assert models
+        assert any("ollama" in (c.model_name or "").lower() for c in models)
+
+    def test_dockerfile_from_vllm_base_image(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            ConfigScanner, tmp_path, {"Dockerfile": "FROM vllm/vllm-openai:latest\n"}
+        )
+        assert any(
+            c.component_type == AIComponentType.MODEL
+            and c.model_name
+            and "vllm" in c.model_name.lower()
+            for c in comps
+        )
+
+    def test_env_model_vars_not_secrets(self, tmp_path: Path) -> None:
+        env = "OPENAI_MODEL=gpt-4o\nLLM_NAME=meta-llama/Llama-3.2-1B\n"
+        comps, _ = run_scanner(ConfigScanner, tmp_path, {".env": env})
+        secrets = [c for c in comps if c.component_type == AIComponentType.SECRET]
+        assert secrets == []
+        models = [c for c in comps if c.component_type == AIComponentType.MODEL]
+        assert {c.metadata.get("env_var") for c in models if c.metadata.get("env_var")} >= {
+            "OPENAI_MODEL",
+            "LLM_NAME",
+        }
+
+    def test_crewai_yaml_agents(self, tmp_path: Path) -> None:
+        cfg = "agents:\n  - name: Researcher\n    role: analyst\n"
+        comps, _ = run_scanner(ConfigScanner, tmp_path, {"crewai.yaml": cfg})
+        agents = [c for c in comps if c.component_type == AIComponentType.AGENT]
+        assert any("Researcher" in c.name or "researcher" in c.name.lower() for c in agents)
+        crew_named = [c for c in agents if "crewai_agent" in c.name]
+        assert crew_named
+        assert all(c.framework == "crewai" for c in crew_named)
+
+    def test_langgraph_json_model_string(self, tmp_path: Path) -> None:
+        j = '{"graphs": {"app": "./graph.py"}, "assistant_model": "gpt-4o-mini"}'
+        comps, _ = run_scanner(ConfigScanner, tmp_path, {"langgraph.json": j})
+        models = [c for c in comps if c.component_type == AIComponentType.MODEL]
+        assert any(c.model_name and "gpt-4o-mini" in c.model_name for c in models)
+        assert any(c.framework == "langgraph" for c in models)

--- a/aibom/tests/test_dependency_scanner.py
+++ b/aibom/tests/test_dependency_scanner.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aibom.scanners.dependency_scanner import DependencyScanner
+
+from .conftest import run_scanner
+
+
+class TestDependencyScanner:
+    def test_parse_requirements_txt_ai_packages(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            DependencyScanner,
+            tmp_path,
+            {"requirements.txt": "openai>=1.0\nlangchain-core==0.2.0\n"},
+        )
+        names = {c.name for c in comps}
+        assert "openai" in names
+        assert "langchain-core" in names
+
+    def test_parse_package_json_ai_packages(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            DependencyScanner,
+            tmp_path,
+            {
+                "package.json": json.dumps(
+                    {"dependencies": {"openai": "4.28.0", "@langchain/core": "0.2.0"}},
+                    indent=2,
+                ),
+            },
+        )
+        names = {c.name for c in comps}
+        assert "openai" in names
+        assert "@langchain/core" in names
+
+    def test_parse_pyproject_toml_dependencies(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            DependencyScanner,
+            tmp_path,
+            {
+                "pyproject.toml": (
+                    "[project.dependencies]\n"
+                    '"openai>=1.0"\n'
+                    '"anthropic>=0.18"\n'
+                ),
+            },
+        )
+        names = {c.name for c in comps}
+        assert "openai" in names
+        assert "anthropic" in names
+
+    def test_parse_go_mod_ai_packages(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            DependencyScanner,
+            tmp_path,
+            {
+                "go.mod": (
+                    "module example.com/x\ngo 1.22\nrequire (\n"
+                    "\tgithub.com/sashabaranov/go-openai v1.17.9\n)\n"
+                ),
+            },
+        )
+        assert any(
+            "go-openai" in c.name or c.name == "github.com/sashabaranov/go-openai"
+            for c in comps
+        )
+
+    def test_parse_cargo_toml_ai_packages(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            DependencyScanner,
+            tmp_path,
+            {
+                "Cargo.toml": (
+                    "[package]\nname = \"demo\"\n\n[dependencies]\n"
+                    'async-openai = "0.28"\n'
+                ),
+            },
+        )
+        names = {c.name for c in comps}
+        assert "async-openai" in names
+
+    def test_ignores_non_ai_packages(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            DependencyScanner,
+            tmp_path,
+            {
+                "requirements.txt": "requests>=2.0\n",
+                "package.json": json.dumps({"dependencies": {"lodash": "4.17.21"}}),
+            },
+        )
+        names = {c.name for c in comps}
+        assert "requests" not in names
+        assert "lodash" not in names

--- a/aibom/tests/test_kb_enrichment_scanner.py
+++ b/aibom/tests/test_kb_enrichment_scanner.py
@@ -1,0 +1,333 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the KB Enrichment Scanner.
+
+These tests exercise the scanner's filtering, matching tiers, framework
+disambiguation, and graceful fallback behaviour.  Tests that hit the live
+DuckDB KB (from ``~/.aibom/catalogs/``) are marked ``integration`` so they
+can be skipped in CI where the KB may not be present.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from aibom.models import AIComponentType, DetectionSource, ScanContext
+from aibom.scanners.kb_enrichment_scanner import (
+    ALLOWED_CONCEPTS,
+    KBEnrichmentScanner,
+    _extract_class_segment,
+    _frameworks_related,
+    _match_observation,
+    _resolve_kb_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestExtractClassSegment:
+    def test_simple_dotted(self):
+        assert _extract_class_segment("langchain_openai.ChatOpenAI") == "ChatOpenAI"
+
+    def test_factory_method(self):
+        assert _extract_class_segment("langchain_community.vectorstores.FAISS.from_texts") == "FAISS"
+
+    def test_deep_method_chain(self):
+        assert _extract_class_segment("openai.OpenAI.chat.completions.create") == "OpenAI"
+
+    def test_single_name(self):
+        assert _extract_class_segment("ChatOpenAI") is None
+
+    def test_all_lowercase(self):
+        assert _extract_class_segment("foo.bar.baz") is None
+
+    def test_module_only(self):
+        assert _extract_class_segment("crewai.agent") is None
+
+
+class TestFrameworksRelated:
+    def test_same_family(self):
+        assert _frameworks_related("langchain_openai", "langchain_community") is True
+
+    def test_exact_match(self):
+        assert _frameworks_related("crewai", "crewai") is True
+
+    def test_unrelated(self):
+        assert _frameworks_related("openai", "langchain_community") is False
+
+    def test_empty_module(self):
+        assert _frameworks_related("", "langchain_community") is True
+
+    def test_empty_framework(self):
+        assert _frameworks_related("openai", "") is True
+
+
+class TestMatchObservation:
+    """Unit tests for _match_observation with a fake kb_by_id."""
+
+    @pytest.fixture()
+    def sample_kb(self) -> dict[str, dict[str, Any]]:
+        return {
+            "langchain_openai.ChatOpenAI": {
+                "id": "langchain_openai.ChatOpenAI",
+                "concept": "model",
+                "framework": "langchain_openai",
+            },
+            "langchain_community.vectorstores.faiss.FAISS": {
+                "id": "langchain_community.vectorstores.faiss.FAISS",
+                "concept": "datastore",
+                "framework": "langchain_community",
+            },
+            "crewai.Agent": {
+                "id": "crewai.Agent",
+                "concept": "agent",
+                "framework": "crewai",
+            },
+        }
+
+    def test_tier1_exact(self, sample_kb: dict):
+        result = _match_observation("crewai.Agent", sample_kb, {"crewai"})
+        assert result is not None
+        assert result["concept"] == "agent"
+
+    def test_tier2_suffix(self, sample_kb: dict):
+        result = _match_observation(
+            "ChatOpenAI",
+            {"langchain_openai.ChatOpenAI": sample_kb["langchain_openai.ChatOpenAI"]},
+            {"langchain_openai"},
+        )
+        assert result is not None
+        assert result["concept"] == "model"
+
+    def test_tier3_class_segment(self, sample_kb: dict):
+        result = _match_observation(
+            "langchain_community.vectorstores.FAISS.from_texts",
+            sample_kb,
+            {"langchain_community"},
+        )
+        assert result is not None
+        assert result["concept"] == "datastore"
+
+    def test_no_match(self, sample_kb: dict):
+        result = _match_observation("totally.Unknown", sample_kb, set())
+        assert result is None
+
+    def test_tier3_rejects_unrelated_framework(self):
+        kb = {
+            "langchain_community.llms.openai.OpenAI": {
+                "id": "langchain_community.llms.openai.OpenAI",
+                "concept": "model",
+                "framework": "langchain_community",
+            },
+        }
+        result = _match_observation("openai.OpenAI", kb, {"openai"})
+        assert result is None
+
+    def test_tier3_lowercase_short_name_skipped(self):
+        kb = {
+            "crewai.cli.cli.ToolCommand.create": {
+                "id": "crewai.cli.cli.ToolCommand.create",
+                "concept": "tool",
+                "framework": "crewai",
+            },
+        }
+        result = _match_observation(
+            "openai.OpenAI.chat.completions.create", kb, {"openai"}
+        )
+        # "create" is lowercase, but class segment "OpenAI" is uppercase.
+        # However, the framework check should reject because openai != crewai.
+        assert result is None
+
+
+class TestAllowedConcepts:
+    def test_expected_concepts(self):
+        assert "agent" in ALLOWED_CONCEPTS
+        assert "model" in ALLOWED_CONCEPTS
+        assert "tool" in ALLOWED_CONCEPTS
+        assert "datastore" in ALLOWED_CONCEPTS
+        assert "embedding" in ALLOWED_CONCEPTS
+        assert "prompt" in ALLOWED_CONCEPTS
+        assert "memory" in ALLOWED_CONCEPTS
+        assert "retriever" in ALLOWED_CONCEPTS
+
+    def test_other_excluded(self):
+        assert "other" not in ALLOWED_CONCEPTS
+
+
+# ---------------------------------------------------------------------------
+# Scanner-level tests (KB presence required)
+# ---------------------------------------------------------------------------
+
+
+def _kb_available() -> bool:
+    ctx = ScanContext(paths=["/tmp"])
+    return _resolve_kb_path(ctx) is not None
+
+
+@pytest.mark.skipif(not _kb_available(), reason="No KB DuckDB installed")
+class TestKBEnrichmentScannerIntegration:
+    """Integration tests that exercise the scanner against the real KB."""
+
+    def test_supports_with_kb(self, tmp_path: Path):
+        ctx = ScanContext(paths=[str(tmp_path)])
+        assert KBEnrichmentScanner().supports(ctx) is True
+
+    def test_empty_directory(self, tmp_path: Path):
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, rels = KBEnrichmentScanner().scan(ctx)
+        assert comps == []
+        assert rels == []
+
+    def test_detects_model_usage(self, tmp_path: Path):
+        (tmp_path / "app.py").write_text(
+            "from langchain_openai import ChatOpenAI\n"
+            "llm = ChatOpenAI(model='gpt-4o')\n"
+        )
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, _ = KBEnrichmentScanner().scan(ctx)
+        models = [c for c in comps if c.component_type == AIComponentType.MODEL]
+        assert len(models) >= 1
+        assert models[0].kb_concept == "model"
+        assert models[0].detection_source == DetectionSource.KB_ENRICHMENT
+
+    def test_detects_tool_decorator(self, tmp_path: Path):
+        (tmp_path / "tools.py").write_text(
+            "from langchain_core.tools import tool\n"
+            "@tool\n"
+            "def greet(name: str) -> str:\n"
+            "    return f'Hello {name}'\n"
+        )
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, _ = KBEnrichmentScanner().scan(ctx)
+        tools = [c for c in comps if c.component_type == AIComponentType.TOOL]
+        assert len(tools) >= 1
+        assert tools[0].name == "greet"
+
+    def test_detects_agent(self, tmp_path: Path):
+        (tmp_path / "graph.py").write_text(
+            "from langgraph.graph import StateGraph\n"
+            "graph = StateGraph()\n"
+        )
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, _ = KBEnrichmentScanner().scan(ctx)
+        agents = [c for c in comps if c.component_type == AIComponentType.AGENT]
+        assert len(agents) >= 1
+        assert any("StateGraph" in a.name for a in agents)
+
+    def test_detects_embedding(self, tmp_path: Path):
+        (tmp_path / "embed.py").write_text(
+            "from langchain_openai import OpenAIEmbeddings\n"
+            "embeddings = OpenAIEmbeddings()\n"
+        )
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, _ = KBEnrichmentScanner().scan(ctx)
+        embeddings = [c for c in comps if c.component_type == AIComponentType.EMBEDDING]
+        assert len(embeddings) >= 1
+
+    def test_detects_vector_store(self, tmp_path: Path):
+        (tmp_path / "store.py").write_text(
+            "from langchain_community.vectorstores import FAISS\n"
+            "from langchain_openai import OpenAIEmbeddings\n"
+            "vs = FAISS.from_texts(['hello'], OpenAIEmbeddings())\n"
+        )
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, _ = KBEnrichmentScanner().scan(ctx)
+        stores = [c for c in comps if c.component_type == AIComponentType.VECTOR_STORE]
+        assert len(stores) >= 1
+
+    def test_filters_other_concept(self, tmp_path: Path):
+        (tmp_path / "client.py").write_text(
+            "import openai\n"
+            "client = openai.OpenAI()\n"
+        )
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, _ = KBEnrichmentScanner().scan(ctx)
+        # openai.OpenAI has concept=other in KB → should be filtered out
+        assert all(c.kb_concept != "other" for c in comps)
+
+    def test_method_call_noise_suppressed(self, tmp_path: Path):
+        (tmp_path / "app.py").write_text(
+            "import openai\n"
+            "client = openai.OpenAI()\n"
+            "resp = client.chat.completions.create(model='gpt-4o')\n"
+        )
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, _ = KBEnrichmentScanner().scan(ctx)
+        # The completions.create call should not be emitted as a component
+        names = [c.name for c in comps]
+        assert not any("create" in n for n in names)
+
+    def test_dedup_same_line(self, tmp_path: Path):
+        (tmp_path / "app.py").write_text(
+            "from crewai import Agent\n"
+            "a = Agent(role='r')\n"
+        )
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, _ = KBEnrichmentScanner().scan(ctx)
+        line_2 = [c for c in comps if c.line_number == 2]
+        assert len(line_2) <= 1
+
+    def test_skips_non_python_files(self, tmp_path: Path):
+        (tmp_path / "config.yaml").write_text("agent: true\n")
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, _ = KBEnrichmentScanner().scan(ctx)
+        assert comps == []
+
+    def test_multiple_files(self, tmp_path: Path):
+        (tmp_path / "a.py").write_text(
+            "from crewai import Agent\n"
+            "a = Agent(role='r')\n"
+        )
+        (tmp_path / "b.py").write_text(
+            "from langgraph.graph import StateGraph\n"
+            "g = StateGraph()\n"
+        )
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, _ = KBEnrichmentScanner().scan(ctx)
+        files = {c.file_path for c in comps}
+        assert len(files) == 2
+
+
+class TestKBEnrichmentScannerNoKB:
+    """Tests for graceful behaviour when no KB is installed."""
+
+    def test_supports_false_without_kb(self, tmp_path: Path):
+        ctx = ScanContext(paths=[str(tmp_path)])
+        with patch(
+            "aibom.scanners.kb_enrichment_scanner._resolve_kb_path", return_value=None
+        ):
+            assert KBEnrichmentScanner().supports(ctx) is False
+
+    def test_scan_returns_empty_without_kb(self, tmp_path: Path):
+        (tmp_path / "app.py").write_text(
+            "from langchain_openai import ChatOpenAI\n"
+            "llm = ChatOpenAI(model='gpt-4')\n"
+        )
+        ctx = ScanContext(paths=[str(tmp_path)])
+        with patch(
+            "aibom.scanners.kb_enrichment_scanner._resolve_kb_path", return_value=None
+        ):
+            comps, rels = KBEnrichmentScanner().scan(ctx)
+            assert comps == []
+            assert rels == []

--- a/aibom/tests/test_mcp_detector.py
+++ b/aibom/tests/test_mcp_detector.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aibom.models import AIComponentType
+from aibom.scanners.mcp_detector import McpDetector
+
+from .conftest import run_scanner
+
+
+class TestMcpDetector:
+    def test_detects_mcp_server_from_mcp_json(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            McpDetector,
+            tmp_path,
+            {
+                "mcp.json": json.dumps(
+                    {
+                        "mcpServers": {
+                            "fetch": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-fetch"]},
+                        },
+                    },
+                ),
+            },
+        )
+        names = {c.name for c in comps if c.component_type == AIComponentType.MCP_SERVER}
+        assert "fetch" in names
+
+    def test_detects_mcp_server_from_claude_desktop_config(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            McpDetector,
+            tmp_path,
+            {
+                "claude_desktop_config.json": json.dumps(
+                    {
+                        "mcpServers": {
+                            "filesystem": {"command": "mcp-server-fs", "args": []},
+                        },
+                    },
+                ),
+            },
+        )
+        names = {c.name for c in comps if c.component_type == AIComponentType.MCP_SERVER}
+        assert "filesystem" in names
+
+    def test_detects_fastmcp_in_python(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            McpDetector,
+            tmp_path,
+            {"srv.py": "from mcp.server import Server\napp = FastMCP()\n"},
+        )
+        servers = [c for c in comps if c.component_type == AIComponentType.MCP_SERVER]
+        assert len(servers) == 1
+        assert "FastMCP" in servers[0].metadata.get("patterns", [])
+
+    def test_detects_mcp_client_in_python(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            McpDetector,
+            tmp_path,
+            {"cli.py": "from foo import MCPClient\nx = MCPClient()\n"},
+        )
+        clients = [c for c in comps if c.component_type == AIComponentType.MCP_CLIENT]
+        assert len(clients) == 1
+        assert "MCPClient" in clients[0].metadata.get("patterns", [])
+
+    def test_malformed_json_config_no_crash(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            McpDetector,
+            tmp_path,
+            {"mcp.json": "{ not valid json <<<"},
+        )
+        assert comps == []

--- a/aibom/tests/test_ml_lifecycle_detector.py
+++ b/aibom/tests/test_ml_lifecycle_detector.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aibom.models import AIComponentType
+from aibom.scanners.ml_lifecycle_detector import MLLifecycleDetector
+
+from .conftest import run_scanner
+
+
+class TestMLLifecycleDetector:
+    def test_dataset_load_dataset_imdb(self, tmp_path: Path) -> None:
+        code = 'from datasets import load_dataset\nds = load_dataset("imdb")\n'
+        comps, _ = run_scanner(MLLifecycleDetector, tmp_path, {"train.py": code})
+        assert any(c.component_type == AIComponentType.DATASET for c in comps)
+
+    def test_training_run_trainer_train(self, tmp_path: Path) -> None:
+        code = "from transformers import Trainer\nTrainer(model=m).train()\n"
+        comps, _ = run_scanner(MLLifecycleDetector, tmp_path, {"run.py": code})
+        assert any(c.component_type == AIComponentType.TRAINING_RUN for c in comps)
+
+    def test_hyperparameter_learning_rate(self, tmp_path: Path) -> None:
+        code = "args = dict(learning_rate=3e-5)\n"
+        comps, _ = run_scanner(MLLifecycleDetector, tmp_path, {"hp.py": code})
+        hps = [c for c in comps if c.component_type == AIComponentType.HYPERPARAMETER]
+        assert any(c.hyperparameters.get("learning_rate") == 3e-5 for c in hps)
+
+    def test_model_artifact_safetensors_reference(self, tmp_path: Path) -> None:
+        code = 'weights_uri = "s3://bucket/models/w/.safetensors"\n'
+        comps, _ = run_scanner(MLLifecycleDetector, tmp_path, {"paths.py": code})
+        assert any(c.component_type == AIComponentType.MODEL_ARTIFACT for c in comps)
+
+    def test_experiment_tracker_wandb(self, tmp_path: Path) -> None:
+        code = "import wandb\nwandb.init(project='p')\nwandb.log({'loss': 0.1})\n"
+        comps, _ = run_scanner(MLLifecycleDetector, tmp_path, {"track.py": code})
+        assert any(c.component_type == AIComponentType.EXPERIMENT_TRACKER for c in comps)
+
+    def test_model_registry_mlflow_register(self, tmp_path: Path) -> None:
+        code = "import mlflow\nmlflow.register_model('runs:/x/model', 'ProdModel')\n"
+        comps, _ = run_scanner(MLLifecycleDetector, tmp_path, {"reg.py": code})
+        assert any(c.component_type == AIComponentType.MODEL_REGISTRY for c in comps)
+
+    def test_data_versioning_dvc_yaml(self, tmp_path: Path) -> None:
+        yml = "stages:\n  prepare:\n    cmd: python prep.py\n"
+        comps, _ = run_scanner(MLLifecycleDetector, tmp_path, {"dvc.yaml": yml})
+        assert any(c.component_type == AIComponentType.DATA_VERSIONING for c in comps)
+
+    def test_ml_pipeline_dsl_decorator(self, tmp_path: Path) -> None:
+        code = "from kfp import dsl\n\n@dsl.pipeline(name='p')\ndef p():\n    pass\n"
+        comps, _ = run_scanner(MLLifecycleDetector, tmp_path, {"pipe.py": code})
+        assert any(c.component_type == AIComponentType.ML_PIPELINE for c in comps)

--- a/aibom/tests/test_model_detector.py
+++ b/aibom/tests/test_model_detector.py
@@ -1,0 +1,271 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from aibom.scanners.model_detector import ModelDetector, _litellm_alias_keys
+
+from .conftest import run_scanner
+
+
+class TestLiteLLMAliasKeys:
+    """Unit tests for _litellm_alias_keys normalization."""
+
+    @pytest.mark.parametrize(
+        "raw_id, expected_aliases",
+        [
+            # Plain vendor-native: just lowercase
+            ("gpt-4o", ["gpt-4o"]),
+            # Slash-prefixed Azure: strip prefix, strip date
+            (
+                "azure/gpt-4o-2024-08-06",
+                ["azure/gpt-4o-2024-08-06", "gpt-4o-2024-08-06", "gpt-4o"],
+            ),
+            # Multi-segment Azure: strip to final segment, strip date
+            (
+                "azure/eu/gpt-4o-2024-11-20",
+                ["azure/eu/gpt-4o-2024-11-20", "gpt-4o-2024-11-20", "gpt-4o"],
+            ),
+            # Bedrock ARN: dot-separated provider, version suffix
+            (
+                "anthropic.claude-3-5-sonnet-20241022-v2:0",
+                [
+                    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+                    "claude-3-5-sonnet-20241022-v2:0",
+                    "claude-3-5-sonnet-20241022-v2",
+                    "claude-3-5-sonnet",
+                ],
+            ),
+            # Region-prefixed Bedrock ARN
+            (
+                "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+                [
+                    "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+                    "anthropic.claude-3-7-sonnet-20250219-v1:0",
+                    "claude-3-7-sonnet-20250219-v1:0",
+                    "claude-3-7-sonnet-20250219-v1",
+                    "claude-3-7-sonnet",
+                ],
+            ),
+            # Fine-tune prefix
+            (
+                "ft:gpt-4o-2024-08-06",
+                ["ft:gpt-4o-2024-08-06", "gpt-4o-2024-08-06", "gpt-4o"],
+            ),
+            # No date suffix to strip: stays as-is
+            ("gemini-2.5-pro", ["gemini-2.5-pro"]),
+            # Date without -vN
+            (
+                "claude-4-opus-20250514",
+                ["claude-4-opus-20250514", "claude-4-opus"],
+            ),
+        ],
+    )
+    def test_alias_generation(self, raw_id: str, expected_aliases: list[str]) -> None:
+        result = _litellm_alias_keys(raw_id)
+        for alias in expected_aliases:
+            assert alias in result, f"{alias!r} not in {result}"
+
+
+class TestModelDetector:
+    def test_detects_model_kwarg_gpt4o_in_python(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            ModelDetector,
+            tmp_path,
+            {"app.py": 'resp = client.chat(model="gpt-4o", messages=[])\n'},
+        )
+        assert len(comps) == 1
+        assert comps[0].model_name == "gpt-4o"
+        assert comps[0].confidence == 1.0
+        assert comps[0].metadata.get("provider") == "openai"
+
+    def test_detects_model_in_env_file(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            ModelDetector,
+            tmp_path,
+            {".env": "MODEL=claude-3-5-sonnet\n"},
+        )
+        assert len(comps) == 1
+        assert comps[0].model_name == "claude-3-5-sonnet"
+        assert comps[0].metadata.get("provider") == "anthropic"
+
+    def test_detects_model_in_yaml_config(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            ModelDetector,
+            tmp_path,
+            {"config.yaml": "llm:\n  model: gemini-1.5-pro\n"},
+        )
+        assert len(comps) == 1
+        assert comps[0].model_name == "gemini-1.5-pro"
+        assert comps[0].metadata.get("provider") == "google"
+
+    def test_unknown_model_lower_confidence(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            ModelDetector,
+            tmp_path,
+            {"app.py": 'x = foo(model="totally-unknown-custom-llm-id", y=1)\n'},
+        )
+        assert len(comps) == 1
+        assert comps[0].model_name == "totally-unknown-custom-llm-id"
+        assert comps[0].confidence == 0.7
+        assert comps[0].metadata.get("provider") == "unknown"
+
+    def test_model_card_url_open_vs_closed(self, tmp_path: Path) -> None:
+        closed, _ = run_scanner(
+            ModelDetector,
+            tmp_path / "closed",
+            {"a.py": 'model="gpt-4o"\n'},
+        )
+        open_meta, _ = run_scanner(
+            ModelDetector,
+            tmp_path / "open",
+            {"b.py": 'model="llama-3.1-8b-instruct"\n'},
+        )
+        assert closed[0].metadata["model_card_url"].startswith("https://platform.openai.com")
+        assert "huggingface.co" in open_meta[0].metadata["model_card_url"]
+
+    def test_no_false_positive_on_skip_strings(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            ModelDetector,
+            tmp_path,
+            {"app.py": 'call(model="auto")\nMODEL_NAME = "default"\n'},
+        )
+        assert comps == []
+
+    def test_litellm_catalog_used_when_available(self, tmp_path: Path) -> None:
+        fake_registry = {
+            "brand-new-model-2026": {
+                "provider": "newco",
+                "family": "brand-new-model",
+                "deprecated": False,
+            }
+        }
+        with patch("aibom.scanners.model_detector._get_live_registry", return_value=fake_registry):
+            comps, _ = run_scanner(
+                ModelDetector,
+                tmp_path,
+                {"app.py": 'x = chat(model="brand-new-model-2026")\n'},
+            )
+        assert len(comps) == 1
+        assert comps[0].confidence == 1.0
+        assert comps[0].metadata["provider"] == "newco"
+
+    def test_builtin_fallback_when_live_empty(self, tmp_path: Path) -> None:
+        with patch("aibom.scanners.model_detector._get_live_registry", return_value={}):
+            comps, _ = run_scanner(
+                ModelDetector,
+                tmp_path,
+                {"app.py": 'model="gpt-4o"\n'},
+            )
+        assert len(comps) == 1
+        assert comps[0].metadata["provider"] == "openai"
+
+    def test_hf_hub_lookup_for_org_slash_model(self, tmp_path: Path) -> None:
+        fake_hf = {
+            "provider": "meta-llama",
+            "family": "Llama-3.1-8B",
+            "deprecated": False,
+            "source": "huggingface",
+            "hf_id": "meta-llama/Llama-3.1-8B-Instruct",
+            "pipeline_tag": "text-generation",
+            "license": "llama3.1",
+            "downloads": 5000000,
+            "tags": ["llama", "text-generation"],
+        }
+        with (
+            patch("aibom.scanners.model_detector._get_live_registry", return_value={}),
+            patch("aibom.scanners.model_detector._query_hf_hub", return_value=fake_hf),
+        ):
+            comps, _ = run_scanner(
+                ModelDetector,
+                tmp_path,
+                {"app.py": 'model="meta-llama/Llama-3.1-8B-Instruct"\n'},
+            )
+        assert len(comps) == 1
+        assert comps[0].confidence == 1.0
+        assert comps[0].metadata["registry_source"] == "huggingface"
+        assert comps[0].metadata["hf_id"] == "meta-llama/Llama-3.1-8B-Instruct"
+        assert comps[0].metadata["model_card_url"] == "https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct"
+        assert comps[0].metadata["pipeline_tag"] == "text-generation"
+
+    def test_hf_hub_not_queried_for_plain_model_ids(self, tmp_path: Path) -> None:
+        with (
+            patch("aibom.scanners.model_detector._get_live_registry", return_value={}),
+            patch("aibom.scanners.model_detector._query_hf_hub") as mock_hf,
+        ):
+            run_scanner(
+                ModelDetector,
+                tmp_path,
+                {"app.py": 'model="gpt-4o"\n'},
+            )
+        mock_hf.assert_not_called()
+
+    def test_hf_hub_miss_returns_unknown(self, tmp_path: Path) -> None:
+        with (
+            patch("aibom.scanners.model_detector._get_live_registry", return_value={}),
+            patch("aibom.scanners.model_detector._query_hf_hub", return_value=None),
+        ):
+            comps, _ = run_scanner(
+                ModelDetector,
+                tmp_path,
+                {"app.py": 'model="someorg/nonexistent-model"\n'},
+            )
+        assert len(comps) == 1
+        assert comps[0].confidence == 0.7
+        assert comps[0].metadata["registry_source"] == "none"
+
+    def test_bedrock_arn_resolves_via_alias(self, tmp_path: Path) -> None:
+        meta = {"provider": "bedrock", "family": "claude-3-5-sonnet", "deprecated": False, "source": "litellm"}
+        fake_registry = {
+            "anthropic.claude-3-5-sonnet-20241022-v2:0": meta,
+            "claude-3-5-sonnet-20241022-v2:0": meta,
+            "claude-3-5-sonnet-20241022-v2": meta,
+            "claude-3-5-sonnet": meta,
+        }
+        with patch("aibom.scanners.model_detector._get_live_registry", return_value=fake_registry):
+            comps, _ = run_scanner(
+                ModelDetector,
+                tmp_path,
+                {"app.py": 'model="anthropic.claude-3-5-sonnet-20241022-v2:0"\n'},
+            )
+        assert len(comps) == 1
+        assert comps[0].confidence == 1.0
+        assert comps[0].metadata["registry_source"] == "litellm"
+
+    def test_shorthand_resolves_via_alias(self, tmp_path: Path) -> None:
+        meta = {"provider": "anthropic", "family": "claude-3-5-sonnet", "deprecated": False, "source": "litellm"}
+        fake_registry = {
+            "claude-3-5-sonnet-20241022": meta,
+            "claude-3-5-sonnet": meta,
+        }
+        with patch("aibom.scanners.model_detector._get_live_registry", return_value=fake_registry):
+            comps, _ = run_scanner(
+                ModelDetector,
+                tmp_path,
+                {".env": "MODEL=claude-3-5-sonnet\n"},
+            )
+        assert len(comps) == 1
+        assert comps[0].confidence == 1.0
+        assert comps[0].metadata["registry_source"] == "litellm"
+
+    def test_azure_prefixed_model_resolves(self, tmp_path: Path) -> None:
+        meta = {"provider": "azure", "family": "gpt-4o", "deprecated": False, "source": "litellm"}
+        fake_registry = {
+            "azure/gpt-4o-2024-08-06": meta,
+            "gpt-4o-2024-08-06": meta,
+            "gpt-4o": meta,
+        }
+        with patch("aibom.scanners.model_detector._get_live_registry", return_value=fake_registry):
+            comps, _ = run_scanner(
+                ModelDetector,
+                tmp_path,
+                {"config.yaml": "model: gpt-4o\n"},
+            )
+        assert len(comps) == 1
+        assert comps[0].confidence == 1.0

--- a/aibom/tests/test_multi_language_scanner.py
+++ b/aibom/tests/test_multi_language_scanner.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aibom.models.enums import AIComponentType
+from aibom.scanners.multi_language_scanner import MultiLanguageScanner
+
+from .conftest import run_scanner
+
+
+def test_typescript_openai_import(tmp_path: Path) -> None:
+    comps, rels = run_scanner(
+        MultiLanguageScanner, tmp_path, {"src/main.ts": 'import OpenAI from "openai"\n'}
+    )
+    assert rels == []
+    assert any(c.name == "openai" for c in comps if c.component_type == AIComponentType.DEPENDENCY)
+
+
+def test_javascript_model_literal(tmp_path: Path) -> None:
+    comps, _ = run_scanner(
+        MultiLanguageScanner, tmp_path, {"app.js": 'const cfg = { model: "gpt-4o" }\n'}
+    )
+    models = [c for c in comps if c.component_type == AIComponentType.MODEL]
+    assert any(c.model_name == "gpt-4o" for c in models)
+
+
+def test_go_openai_import(tmp_path: Path) -> None:
+    comps, _ = run_scanner(
+        MultiLanguageScanner,
+        tmp_path,
+        {"main.go": 'package main\nimport "github.com/sashabaranov/go-openai"\nfunc main() {}\n'},
+    )
+    assert any(
+        c.name == "github.com/sashabaranov/go-openai"
+        for c in comps
+        if c.component_type == AIComponentType.DEPENDENCY
+    )
+
+
+def test_rust_async_openai(tmp_path: Path) -> None:
+    comps, _ = run_scanner(
+        MultiLanguageScanner, tmp_path, {"src/lib.rs": "use async_openai::Client;\n"}
+    )
+    assert any(
+        c.name == "async_openai" for c in comps if c.component_type == AIComponentType.DEPENDENCY
+    )
+
+
+def test_csharp_semantic_kernel(tmp_path: Path) -> None:
+    comps, _ = run_scanner(
+        MultiLanguageScanner, tmp_path, {"Program.cs": "using Microsoft.SemanticKernel;\n"}
+    )
+    assert any(
+        c.name == "Microsoft.SemanticKernel"
+        for c in comps
+        if c.component_type == AIComponentType.DEPENDENCY
+    )
+
+
+def test_skips_python_files(tmp_path: Path) -> None:
+    comps, _ = run_scanner(
+        MultiLanguageScanner,
+        tmp_path,
+        {"app.py": 'import openai\nmodel = "gpt-4o"\n', "side.ts": 'import { foo } from "openai"\n'},
+    )
+    assert all(not c.file_path.endswith(".py") for c in comps)
+    assert any(c.file_path.endswith(".ts") for c in comps)

--- a/aibom/tests/test_secret_detector.py
+++ b/aibom/tests/test_secret_detector.py
@@ -1,0 +1,61 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aibom.scanners.secret_detector import SecretDetector
+
+from .conftest import run_scanner
+
+
+class TestSecretDetector:
+    def test_detects_openai_api_key_pattern(self, tmp_path: Path) -> None:
+        secret = "sk-abcdefghijklmnopqrstuvwxyz12"
+        comps, _ = run_scanner(
+            SecretDetector,
+            tmp_path,
+            {"keys.env": f"API_KEY={secret}\n"},
+        )
+        assert any(c.name == "openai_api_key" for c in comps)
+
+    def test_detects_anthropic_api_key_pattern(self, tmp_path: Path) -> None:
+        secret = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890AB"
+        comps, _ = run_scanner(
+            SecretDetector,
+            tmp_path,
+            {".env": f"KEY={secret}\n"},
+        )
+        assert any(c.name == "anthropic_api_key" for c in comps)
+
+    def test_detects_huggingface_token(self, tmp_path: Path) -> None:
+        secret = "hf_abcdefghijklmnopqrstuvwxyz12"
+        comps, _ = run_scanner(
+            SecretDetector,
+            tmp_path,
+            {"cfg.txt": f"token={secret}\n"},
+        )
+        assert any(c.name == "huggingface_api_key" for c in comps)
+
+    def test_detects_aws_access_key(self, tmp_path: Path) -> None:
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        comps, _ = run_scanner(
+            SecretDetector,
+            tmp_path,
+            {"infra.tf": f'key = "{secret}"\n'},
+        )
+        assert any(c.name == "aws_access_key_id" for c in comps)
+
+    def test_secret_value_not_in_component_serialization(self, tmp_path: Path) -> None:
+        secret = "sk-abcdefghijklmnopqrstuvwxyz12"
+        comps, _ = run_scanner(
+            SecretDetector,
+            tmp_path,
+            {"leak.py": f'x = "{secret}"\n'},
+        )
+        assert comps
+        blob = "".join(c.model_dump_json() for c in comps)
+        assert secret not in blob
+        assert all(c.text is None for c in comps)

--- a/aibom/tests/test_shadow_ai_detector.py
+++ b/aibom/tests/test_shadow_ai_detector.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aibom.scanners.shadow_ai_detector import ShadowAIDetector
+
+from .conftest import run_scanner
+
+
+def test_shadow_detects_openai_not_in_requirements(tmp_path: Path) -> None:
+    comps, rels = run_scanner(ShadowAIDetector, tmp_path, {"app.py": "import openai\n"})
+    assert rels == []
+    assert len(comps) == 1
+    assert comps[0].name == "openai"
+    assert comps[0].metadata.get("shadow_ai") is True
+
+
+def test_shadow_no_finding_when_openai_declared(tmp_path: Path) -> None:
+    comps, _ = run_scanner(
+        ShadowAIDetector,
+        tmp_path,
+        {"requirements.txt": "openai>=1.0.0\n", "app.py": "import openai\n"},
+    )
+    assert comps == []
+
+
+def test_shadow_detects_importlib_anthropic(tmp_path: Path) -> None:
+    comps, _ = run_scanner(
+        ShadowAIDetector,
+        tmp_path,
+        {"app.py": 'import importlib\nm = importlib.import_module("anthropic")\n'},
+    )
+    assert len(comps) == 1
+    assert comps[0].name == "anthropic"
+
+
+def test_shadow_langchain_core_without_manifest(tmp_path: Path) -> None:
+    comps, _ = run_scanner(
+        ShadowAIDetector,
+        tmp_path,
+        {"app.py": "from langchain_core.runnables import Runnable\n"},
+    )
+    assert len(comps) >= 1
+    names = {c.name for c in comps}
+    assert "langchain-core" in names or "langchain" in names

--- a/aibom/tests/test_skill_detector.py
+++ b/aibom/tests/test_skill_detector.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aibom.models import AIComponentType
+from aibom.scanners.skill_detector import SkillDetector
+
+from .conftest import run_scanner
+
+
+class TestSkillDetector:
+    def test_cursor_skill_skill_md(self, tmp_path: Path) -> None:
+        md = "# My Cursor Skill\n\nBody.\n"
+        comps, _ = run_scanner(
+            SkillDetector, tmp_path, {"proj/.cursor/skills/my-skill/SKILL.md": md}
+        )
+        assert len(comps) == 1
+        assert comps[0].skill_format == "cursor"
+        assert comps[0].component_type == AIComponentType.SKILL
+
+    def test_codex_skill_skill_md(self, tmp_path: Path) -> None:
+        md = "# Codex Helper\n\nDesc.\n"
+        comps, _ = run_scanner(
+            SkillDetector, tmp_path, {"proj/.codex/skills/my-skill/SKILL.md": md}
+        )
+        assert len(comps) == 1
+        assert comps[0].skill_format == "codex"
+
+    def test_agents_md_format(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            SkillDetector, tmp_path, {"AGENTS.md": "# Repo Agents\n\nRules here.\n"}
+        )
+        assert len(comps) == 1
+        assert comps[0].skill_format == "agents_md"
+        assert comps[0].name == "Repo Agents"
+
+    def test_skill_name_from_title_heading(self, tmp_path: Path) -> None:
+        md = "#   Parsed Title Here\n\nMore text.\n"
+        comps, _ = run_scanner(
+            SkillDetector, tmp_path, {"proj/.cursor/skills/x/SKILL.md": md}
+        )
+        assert comps[0].name == "Parsed Title Here"
+
+    def test_trigger_patterns_use_when(self, tmp_path: Path) -> None:
+        md = "# T\n\nUse when the user asks about testing.\nActivate when debugging fails.\n"
+        comps, _ = run_scanner(
+            SkillDetector, tmp_path, {"proj/.codex/skills/t/SKILL.md": md}
+        )
+        triggers = comps[0].metadata.get("trigger_patterns") or []
+        assert any("Use when" in t for t in triggers)
+        assert any("Activate when" in t for t in triggers)

--- a/aibom/tests/test_vuln_scanner.py
+++ b/aibom/tests/test_vuln_scanner.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aibom.models import ScanContext
+from aibom.models.enums import AIComponentType, Severity
+from aibom.scanners.vuln_scanner import OsvProvider, PackageRef, Vulnerability, VulnScanner
+
+
+def _httpx_client_cm(inner_client: MagicMock) -> MagicMock:
+    cm = MagicMock()
+    cm.__enter__.return_value = inner_client
+    cm.__exit__.return_value = None
+    return cm
+
+
+@pytest.fixture
+def osv_response_openai() -> dict:
+    return {
+        "results": [
+            {
+                "vulns": [
+                    {
+                        "id": "CVE-2024-1234",
+                        "summary": "Test vulnerability in openai",
+                        "severity": [{"type": "CVSS_V3", "score": "7.5"}],
+                        "affected": [
+                            {
+                                "package": {"name": "openai", "ecosystem": "PyPI"},
+                                "ranges": [{"events": [{"fixed": "1.3.0"}]}],
+                            }
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+
+
+def test_osv_provider_batch_query_payload_and_parse(osv_response_openai: dict) -> None:
+    inner = MagicMock()
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = osv_response_openai
+    inner.post.return_value = resp
+    ref = PackageRef(name="openai", version="1.0.0", ecosystem="PyPI")
+    with patch(
+        "aibom.scanners.vuln_scanner.httpx.Client",
+        return_value=_httpx_client_cm(inner),
+    ):
+        prov = OsvProvider()
+        out = prov.batch_query([ref])
+    inner.post.assert_called_once()
+    args, kwargs = inner.post.call_args
+    assert args[0] == "https://api.osv.dev/v1/querybatch"
+    key = "PyPI:openai@1.0.0"
+    assert key in out
+    v = out[key][0]
+    assert v.id == "CVE-2024-1234"
+    assert v.severity == Severity.HIGH
+    assert v.fixed_version == "1.3.0"
+
+
+@patch("aibom.scanners.vuln_scanner.httpx.Client")
+def test_vuln_scanner_uses_detected_packages(
+    mock_client_cls: MagicMock, osv_response_openai: dict, tmp_path: Path
+) -> None:
+    inner = MagicMock()
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = osv_response_openai
+    inner.post.return_value = resp
+    mock_client_cls.return_value = _httpx_client_cm(inner)
+    ctx = ScanContext(
+        paths=[str(tmp_path)],
+        config={"detected_packages": [{"name": "openai", "version": "1.0.0", "ecosystem": "pypi"}]},
+    )
+    comps, rels = VulnScanner().scan(ctx)
+    assert rels == []
+    assert len(comps) == 1
+    assert comps[0].name == "openai"
+    vulns = comps[0].metadata.get("vulnerabilities")
+    assert vulns and vulns[0]["id"] == "CVE-2024-1234"
+
+
+@patch("aibom.scanners.vuln_scanner.httpx.Client")
+def test_vuln_scanner_falls_back_to_dependency_scanner(
+    mock_client_cls: MagicMock, osv_response_openai: dict, tmp_path: Path
+) -> None:
+    inner = MagicMock()
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = osv_response_openai
+    inner.post.return_value = resp
+    mock_client_cls.return_value = _httpx_client_cm(inner)
+    (tmp_path / "requirements.txt").write_text("openai==1.0.0\n", encoding="utf-8")
+    comps, _ = VulnScanner().scan(ScanContext(paths=[str(tmp_path)], config={}))
+    assert len(comps) == 1
+    assert any(v["id"] == "CVE-2024-1234" for v in comps[0].metadata["vulnerabilities"])
+
+
+def test_vulnerability_model_dump_and_validate() -> None:
+    v = Vulnerability(
+        id="GHSA-abc", summary="x", severity=Severity.MEDIUM, cvss_score=5.0,
+        affected_package="pkg", affected_version="2.0.0", fixed_version="2.1.0",
+        source="osv", url="https://example.com",
+    )
+    data = v.model_dump(mode="json")
+    assert data["id"] == "GHSA-abc"
+    v2 = Vulnerability.model_validate(data)
+    assert v2 == v


### PR DESCRIPTION
## Summary

Implements Phase 2 of the AIBOM v2 plan: **11 specialized scanners** that replace the noisy v1 KB symbol matching with precise, actionable AI asset detection. This directly addresses the **highest-priority "signal over noise" problem** — the CLI now surfaces model names, agents, tools, MCP servers, secrets, and ML lifecycle components instead of hundreds of spurious symbol matches.

### New Scanners (11)

| Scanner | What it detects | Key capabilities |
|---|---|---|
| **ModelDetector** | AI model usage | 3-tier registry: LiteLLM API → builtin → HuggingFace Hub; alias normalization for Bedrock ARNs, Azure prefixes, date suffixes; model card linking |
| **McpDetector** | MCP servers & clients | Config files (`mcp.json`, `claude_desktop_config.json`), SDK patterns (`FastMCP`, `@server.tool`), optional `cisco-ai-mcp-scanner` integration |
| **SecretDetector** | Hardcoded AI API keys | Regex patterns for OpenAI/Anthropic/HuggingFace/AWS/Azure keys; optional `detect-secrets`/`gitleaks` integration; never emits raw values |
| **ShadowAIDetector** | Undeclared AI SDK usage | Compares AI SDK imports against declared dependencies to flag shadow AI |
| **DependencyScanner** | AI framework dependencies | 17 manifest formats (requirements.txt, package.json, go.mod, Cargo.toml, pom.xml, etc.) across 7 ecosystems |
| **MultiLanguageScanner** | Non-Python AI usage | JS/TS, Java, Go, Rust, Ruby, C# via regex + optional tree-sitter AST parsing |
| **ConfigScanner** | AI config files | `langgraph.json`, `crewai.yaml`, `dspy.toml`, Dockerfile, docker-compose, `.env` |
| **VulnScanner** | Known vulnerabilities | OSV.dev API (default) + optional Grype provider; attaches CVEs to dependency components |
| **SkillDetector** | Agent skill definitions | Cursor/Codex/Claude/Devin/Copilot skill directories and `AGENTS.md` files |
| **MLLifecycleDetector** | ML lifecycle components | 8 generic concepts: Dataset, Training Run, Hyperparameter, Model Artifact, Experiment Tracker, Model Registry, Data Versioning, ML Pipeline |
| **KBEnrichmentScanner** | Python API-level AI assets | Filtered DuckDB KB lookup with 3-tier matching (exact → qualified suffix → class-segment) and framework validation; detects agents, tools, vector stores, embeddings, retrievers, prompts, memory |

### CLI Changes

- `run_scanners()` is now the **default** analysis path (v2)
- Legacy KB symbol matching moved behind `--legacy-mode` flag
- New flags: `--fail-on` (risk severity gate), `--min-severity`, `--validate` (schema validation)
- v2 summary display groups findings by component type

### Before vs After (comprehensive_langchain_app.py)

| Metric | v1 Legacy | v2 New |
|---|---|---|
| Total components | 2 (tools only) | 60 |
| Concepts detected | 1 | 6 (model, embedding, tool, vector_store, prompt, dependency) |
| Model names surfaced | 0 | gpt-3.5-turbo, claude-3-sonnet, text-embedding-ada-002, etc. |
| False positives | High (hundreds of symbols) | Near zero (filtered by concept + framework validation) |

### Files Changed

- **11 new scanners** in `aibom/src/aibom/scanners/`
- **11 new test files** + shared `conftest.py` in `aibom/tests/`
- Modified `cli.py` (v2 wiring, new flags, v2 summary)
- Modified `scanners/__init__.py` (auto-registration of all 11 scanners)

## Test plan

- [x] All 313 tests pass (`uv run pytest tests/ -v`)
- [x] No lint errors
- [x] Short-alias imports (e.g., `from langchain.llms import OpenAI`) produce same detection quality as deep imports
- [x] KB enrichment scanner gracefully skips when no DuckDB KB is installed
- [x] `--legacy-mode` flag preserves backward compatibility with v1 behavior
- [ ] Reviewer: spot-check scanner output on a real AI project directory
- [ ] Reviewer: verify `--fail-on` exits with code 2 when threshold is breached


Made with [Cursor](https://cursor.com)