### PR TITLE
feat(aibom): Phase 4 — Tier 2 cross-ref resolution, ScanPipeline, cross-repo detection

### DIFF
--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -81,7 +81,20 @@ def create_aibom_agent(
         if llm_config.get("api_base"):
             init_kwargs["base_url"] = llm_config["api_base"]
 
-    model = init_chat_model(model_string, **init_kwargs)
+    model_id = model_string
+    if "/" in model_string:
+        provider_prefix, _, model_id = model_string.partition("/")
+        init_kwargs.setdefault("model_provider", provider_prefix)
+
+    try:
+        model = init_chat_model(model_id, **init_kwargs)
+    except ImportError as exc:
+        provider = init_kwargs.get("model_provider", "unknown")
+        raise ImportError(
+            f"Provider '{provider}' requires its LangChain integration package. "
+            f"Install it with: pip install langchain-{provider}\n"
+            f"Original error: {exc}"
+        ) from exc
     tools = build_tools()
 
     agent = create_deep_agent(

--- a/aibom/src/aibom/agentic/cross_repo.py
+++ b/aibom/src/aibom/agentic/cross_repo.py
@@ -1,0 +1,619 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-repo and IaC reasoning helpers for the agentic pipeline."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+
+from ..cross_ref import CrossRefIndex, EnvVarEntry, build_env_index, build_package_index
+from ..models import AIComponent
+from ..models.enums import AIComponentType
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "AIComponent",
+    "AIComponentType",
+    "CrossRepoSummaryArgs",
+    "ResolveEnvVarArgs",
+    "ResolveIaCRefArgs",
+    "build_cross_repo_tools",
+    "cross_repo_summary_tool",
+    "resolve_env_var_tool",
+    "resolve_iac_ref_tool",
+]
+
+_SKIP_DIR_NAMES = frozenset(
+    {"node_modules", ".git", ".venv", "venv", "__pycache__", ".tox"}
+)
+
+_TF_DEFAULT_STR = re.compile(
+    r"default\s*=\s*(\"([^\"\\]*(?:\\.[^\"\\]*)*)\"|'([^'\\]*(?:\\.[^'\\]*)*)')",
+    re.MULTILINE,
+)
+_TF_DEFAULT_HEREDOC = re.compile(r"default\s*=\s*<<[-\w]*\n([\s\S]*?)\n\s*[-\w]*", re.MULTILINE)
+_TF_LOCAL_ASSIGN_STR = re.compile(
+    r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(\"([^\"\\]*(?:\\.[^\"\\]*)*)\"|'([^'\\]*(?:\\.[^'\\]*)*)')",
+    re.MULTILINE,
+)
+_HELM_VALUES_REF = re.compile(
+    r"\{\{\s*\.Values\.([A-Za-z0-9_.-]+)\s*\}\}",
+    re.IGNORECASE,
+)
+_ARM_PARAM_REF = re.compile(r"parameters\s*\(\s*['\"]([^'\"]+)['\"]\s*\)", re.IGNORECASE)
+_ARM_RESOURCE_REF = re.compile(r"reference\s*\(\s*['\"]([^'\"]+)['\"]\s*\)", re.IGNORECASE)
+_PY_ENV_REFS = [
+    re.compile(r"os\.getenv\s*\(\s*['\"]([A-Za-z_][A-Za-z0-9_]*)['\"]"),
+    re.compile(r"os\.environ\.get\s*\(\s*['\"]([^'\"]+)['\"]"),
+    re.compile(r"os\.environ\s*\[\s*['\"]([^'\"]+)['\"]\s*\]"),
+]
+_JS_ENV_REFS = [
+    re.compile(r"process\.env\.([A-Za-z_][A-Za-z0-9_]*)"),
+    re.compile(r"process\.env\s*\[\s*['\"]([^'\"]+)['\"]\s*\]"),
+]
+_GO_ENV_REF = re.compile(r"os\.Getenv\s*\(\s*[\"]([^\"]+)[\"]\s*\)")
+
+
+class ResolveEnvVarArgs(BaseModel):
+    var_name: str = Field(description="Environment variable name to resolve")
+    scan_paths: list[str] = Field(description="Paths to search for env var definitions")
+
+
+class ResolveIaCRefArgs(BaseModel):
+    ref_expression: str = Field(
+        description="IaC reference expression (e.g., var.model_name, !Ref ModelParam)"
+    )
+    iac_type: str = Field(description="IaC type: terraform, cloudformation, arm, helm")
+    scan_paths: list[str] = Field(description="Paths to search")
+
+
+class CrossRepoSummaryArgs(BaseModel):
+    scan_paths: list[str] = Field(description="All repo paths being scanned")
+
+
+def _should_skip_path(path: Path) -> bool:
+    return any(p in _SKIP_DIR_NAMES for p in path.parts)
+
+
+def _iter_files(paths: list[str], suffixes: tuple[str, ...] | None = None) -> Iterator[Path]:
+    for root in paths:
+        base = Path(root)
+        if not base.exists():
+            continue
+        for p in base.rglob("*"):
+            if not p.is_file() or _should_skip_path(p):
+                continue
+            if suffixes is not None and not str(p).endswith(suffixes):
+                continue
+            yield p
+
+
+def _root_prefixes_for_file(file_path: str, roots: list[str]) -> list[str]:
+    fp = Path(file_path)
+    try:
+        fp_r = fp.resolve()
+    except OSError:
+        fp_r = fp
+    out: list[str] = []
+    for r in roots:
+        try:
+            br = Path(r).resolve()
+            fp_r.relative_to(br)
+            out.append(r)
+        except (OSError, ValueError):
+            continue
+    return out
+
+
+def _extract_tf_block_body(text: str, var_name: str) -> str | None:
+    token = f'variable "{var_name}"'
+    idx = text.find(token)
+    if idx < 0:
+        return None
+    brace = text.find("{", idx + len(token))
+    if brace < 0:
+        return None
+    depth = 0
+    i = brace
+    while i < len(text):
+        c = text[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace + 1 : i]
+        i += 1
+    return None
+
+
+def _first_string_default(block: str) -> str | None:
+    m = _TF_DEFAULT_STR.search(block)
+    if not m:
+        m2 = _TF_DEFAULT_HEREDOC.search(block)
+        if m2:
+            return m2.group(1).strip()
+        return None
+    inner = m.group(2) or m.group(3) or ""
+    return inner
+
+
+def _resolve_terraform_var(var_name: str, paths: list[str]) -> dict[str, Any]:
+    for path in _iter_files(paths, (".tf",)):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            _LOGGER.debug("read tf failed %s: %s", path, exc)
+            continue
+        body = _extract_tf_block_body(text, var_name)
+        if body is None:
+            continue
+        val = _first_string_default(body)
+        if val is not None:
+            return {
+                "resolved": True,
+                "value": val,
+                "source_file": str(path),
+                "source_type": "terraform_variable",
+            }
+    return {"resolved": False, "value": None, "source_file": None, "source_type": None}
+
+
+def _resolve_terraform_local(local_name: str, paths: list[str]) -> dict[str, Any]:
+    for path in _iter_files(paths, (".tf",)):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            _LOGGER.debug("read tf failed %s: %s", path, exc)
+            continue
+        for m in _TF_LOCAL_ASSIGN_STR.finditer(text):
+            name = m.group(1)
+            if name != local_name:
+                continue
+            raw = m.group(2) or m.group(3) or ""
+            return {
+                "resolved": True,
+                "value": raw,
+                "source_file": str(path),
+                "source_type": "terraform_local",
+            }
+    return {"resolved": False, "value": None, "source_file": None, "source_type": None}
+
+
+def _parse_cfn_template(path: Path) -> dict[str, Any] | None:
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    try:
+        if path.suffix.lower() == ".json":
+            data = json.loads(raw)
+        else:
+            data = yaml.safe_load(raw)
+    except (json.JSONDecodeError, yaml.YAMLError, UnicodeDecodeError):
+        return None
+    if not isinstance(data, Mapping):
+        return None
+    if (
+        "AWSTemplateFormatVersion" not in data
+        and "Transform" not in data
+        and "Resources" not in data
+    ):
+        return None
+    return dict(data)
+
+
+def _resolve_cfn_ref(logical_id: str, paths: list[str]) -> dict[str, Any]:
+    for path in _iter_files(paths, (".yaml", ".yml", ".json")):
+        tmpl = _parse_cfn_template(path)
+        if tmpl is None:
+            continue
+        params = tmpl.get("Parameters")
+        if isinstance(params, Mapping) and logical_id in params:
+            p = params[logical_id]
+            if isinstance(p, Mapping):
+                default = p.get("Default")
+                return {
+                    "resolved": default is not None,
+                    "value": default,
+                    "source_file": str(path),
+                    "source_type": "cloudformation_parameter",
+                    "logical_id": logical_id,
+                }
+        resources = tmpl.get("Resources")
+        if isinstance(resources, Mapping) and logical_id in resources:
+            r = resources[logical_id]
+            rtype = r.get("Type") if isinstance(r, Mapping) else None
+            return {
+                "resolved": True,
+                "value": None,
+                "resource_type": rtype,
+                "source_file": str(path),
+                "source_type": "cloudformation_resource",
+                "logical_id": logical_id,
+            }
+    return {
+        "resolved": False,
+        "value": None,
+        "source_file": None,
+        "source_type": None,
+        "logical_id": logical_id,
+    }
+
+
+def _navigate_values(obj: Any, parts: list[str]) -> Any:
+    cur: Any = obj
+    for part in parts:
+        if not part:
+            continue
+        if isinstance(cur, Mapping) and part in cur:
+            cur = cur[part]
+        else:
+            return None
+    return cur
+
+
+def _resolve_helm_value(key_path: str, paths: list[str]) -> dict[str, Any]:
+    parts = [p for p in key_path.split(".") if p]
+    for path in _iter_files(paths):
+        if path.name != "values.yaml":
+            continue
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, yaml.YAMLError, UnicodeDecodeError):
+            continue
+        val = _navigate_values(data, parts)
+        if val is not None:
+            return {
+                "resolved": True,
+                "value": val,
+                "source_file": str(path),
+                "source_type": "helm_values",
+            }
+    return {"resolved": False, "value": None, "source_file": None, "source_type": None}
+
+
+def _parse_arm_template(path: Path) -> dict[str, Any] | None:
+    if path.suffix.lower() != ".json":
+        return None
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(data, Mapping):
+        return None
+    schema = str(data.get("$schema", "")).lower()
+    keys = {k.lower() for k in data}
+    if "schema.management.azure.com" not in schema and "resources" not in keys:
+        return None
+    return dict(data)
+
+
+def _resolve_arm_parameter(param_name: str, paths: list[str]) -> dict[str, Any]:
+    for path in _iter_files(paths, (".json",)):
+        tmpl = _parse_arm_template(path)
+        if tmpl is None:
+            continue
+        params = tmpl.get("parameters")
+        if not isinstance(params, Mapping):
+            continue
+        block = params.get(param_name)
+        if isinstance(block, Mapping) and "defaultValue" in block:
+            return {
+                "resolved": True,
+                "value": block.get("defaultValue"),
+                "source_file": str(path),
+                "source_type": "arm_parameter",
+            }
+    return {"resolved": False, "value": None, "source_file": None, "source_type": None}
+
+
+def _resolve_arm_resource(resource_name: str, paths: list[str]) -> dict[str, Any]:
+    for path in _iter_files(paths, (".json",)):
+        tmpl = _parse_arm_template(path)
+        if tmpl is None:
+            continue
+        resources = tmpl.get("resources")
+        if isinstance(resources, list):
+            for res in resources:
+                if not isinstance(res, Mapping):
+                    continue
+                if res.get("name") == resource_name or res.get("name") == f"[{resource_name}]":
+                    return {
+                        "resolved": True,
+                        "value": res.get("type"),
+                        "source_file": str(path),
+                        "source_type": "arm_resource",
+                        "resource_name": resource_name,
+                    }
+        elif isinstance(resources, Mapping) and resource_name in resources:
+            res = resources[resource_name]
+            return {
+                "resolved": True,
+                "value": res.get("type") if isinstance(res, Mapping) else None,
+                "source_file": str(path),
+                "source_type": "arm_resource",
+                "resource_name": resource_name,
+            }
+    return {
+        "resolved": False,
+        "value": None,
+        "source_file": None,
+        "source_type": None,
+        "resource_name": resource_name,
+    }
+
+
+def _parse_cfn_logical_id(ref: str) -> str | None:
+    s = ref.strip()
+    m = re.match(r"!Ref\s+([A-Za-z0-9_-]+)", s)
+    if m:
+        return m.group(1)
+    m = re.match(r"Ref\s*:\s*([A-Za-z0-9_-]+)", s, re.IGNORECASE)
+    if m:
+        return m.group(1)
+    m = re.search(r"Fn::Ref\s*:\s*([A-Za-z0-9_-]+)", s)
+    if m:
+        return m.group(1)
+    m = re.search(r"\"Ref\"\s*:\s*\"([^\"]+)\"", s)
+    if m:
+        return m.group(1)
+    m = re.search(r"'Ref'\s*:\s*'([^']+)'", s)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _collect_code_env_refs(paths: list[str]) -> set[str]:
+    refs: set[str] = set()
+    exts = (
+        ".py",
+        ".pyw",
+        ".js",
+        ".jsx",
+        ".ts",
+        ".tsx",
+        ".mjs",
+        ".cjs",
+        ".go",
+    )
+    for path in _iter_files(paths):
+        if not str(path).endswith(exts):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if path.suffix == ".go":
+            for m in _GO_ENV_REF.finditer(text):
+                refs.add(m.group(1))
+            continue
+        if path.suffix in (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"):
+            for rx in _JS_ENV_REFS:
+                for m in rx.finditer(text):
+                    refs.add(m.group(1))
+            continue
+        for rx in _PY_ENV_REFS:
+            for m in rx.finditer(text):
+                refs.add(m.group(1))
+    return refs
+
+
+def resolve_env_var_tool(var_name: str, scan_paths: list[str]) -> str:
+    try:
+        index = build_env_index(scan_paths)
+        entries = index.env.get(var_name)
+        if not entries:
+            return json.dumps(
+                {
+                    "resolved": False,
+                    "var_name": var_name,
+                    "value": None,
+                    "source_file": None,
+                    "source_type": None,
+                    "message": "not found",
+                }
+            )
+        first: EnvVarEntry = entries[0]
+        alts = [
+            {
+                "value": e.value,
+                "source_file": e.source_path,
+                "source_type": e.source_type,
+            }
+            for e in entries[1:8]
+        ]
+        return json.dumps(
+            {
+                "resolved": True,
+                "var_name": var_name,
+                "value": first.value,
+                "source_file": first.source_path,
+                "source_type": first.source_type,
+                "alternates": alts,
+            }
+        )
+    except Exception as exc:
+        _LOGGER.exception("resolve_env_var_tool failed")
+        return json.dumps({"resolved": False, "error": str(exc), "var_name": var_name})
+
+
+def resolve_iac_ref_tool(ref_expression: str, iac_type: str, scan_paths: list[str]) -> str:
+    try:
+        kind = iac_type.strip().lower()
+        ref = ref_expression.strip()
+        if kind == "terraform":
+            if ref.startswith("var."):
+                var_n = ref[4:].strip()
+                out = _resolve_terraform_var(var_n, scan_paths)
+                return json.dumps(out)
+            if ref.startswith("local."):
+                loc_n = ref[6:].strip()
+                out = _resolve_terraform_local(loc_n, scan_paths)
+                return json.dumps(out)
+            if ref.startswith("module."):
+                return json.dumps(
+                    {
+                        "resolved": False,
+                        "reason": "module reference not deterministically resolvable",
+                        "ref_expression": ref,
+                        "iac_type": kind,
+                    }
+                )
+            return json.dumps(
+                {
+                    "resolved": False,
+                    "reason": "unsupported terraform reference shape",
+                    "ref_expression": ref,
+                    "message": "needs LLM reasoning",
+                }
+            )
+        if kind == "cloudformation":
+            lid = _parse_cfn_logical_id(ref)
+            if not lid and re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]*", ref):
+                lid = ref
+            if not lid:
+                return json.dumps(
+                    {
+                        "resolved": False,
+                        "reason": "could not parse logical id",
+                        "ref_expression": ref,
+                        "message": "needs LLM reasoning",
+                    }
+                )
+            out = _resolve_cfn_ref(lid, scan_paths)
+            return json.dumps(out)
+        if kind == "arm":
+            mp = _ARM_PARAM_REF.search(ref)
+            if mp:
+                out = _resolve_arm_parameter(mp.group(1), scan_paths)
+                return json.dumps(out)
+            mr = _ARM_RESOURCE_REF.search(ref)
+            if mr:
+                out = _resolve_arm_resource(mr.group(1), scan_paths)
+                return json.dumps(out)
+            return json.dumps(
+                {
+                    "resolved": False,
+                    "reason": "unrecognized ARM expression",
+                    "ref_expression": ref,
+                    "message": "needs LLM reasoning",
+                }
+            )
+        if kind == "helm":
+            m = _HELM_VALUES_REF.search(ref)
+            if m:
+                key_path = m.group(1)
+            else:
+                key_path = ref
+                if ref.lower().startswith(".values."):
+                    key_path = ref[8:].strip()
+            out = _resolve_helm_value(key_path, scan_paths)
+            if not out.get("resolved"):
+                out["message"] = "needs LLM reasoning"
+            return json.dumps(out)
+        return json.dumps(
+            {
+                "resolved": False,
+                "error": f"unknown iac_type: {iac_type}",
+                "ref_expression": ref,
+            }
+        )
+    except Exception as exc:
+        _LOGGER.exception("resolve_iac_ref_tool failed")
+        return json.dumps({"resolved": False, "error": str(exc), "ref_expression": ref_expression})
+
+
+def cross_repo_summary_tool(scan_paths: list[str]) -> str:
+    try:
+        env_index = build_env_index(scan_paths)
+        shared_env: list[dict[str, Any]] = []
+        for name, entries in env_index.env.items():
+            roots: set[str] = set()
+            for e in entries:
+                for rp in _root_prefixes_for_file(e.source_path, scan_paths):
+                    roots.add(rp)
+            if len(roots) > 1:
+                shared_env.append(
+                    {
+                        "name": name,
+                        "paths": sorted(roots),
+                        "definitions": len(entries),
+                    }
+                )
+        shared_env.sort(key=lambda x: x["name"])
+
+        pkg_roots: dict[str, set[str]] = {}
+        for root in scan_paths:
+            sub: CrossRefIndex = build_package_index([root])
+            for pkg in sub.packages:
+                pkg_roots.setdefault(pkg, set()).add(root)
+        shared_pkgs = sorted([p for p, rs in pkg_roots.items() if len(rs) > 1])
+
+        code_refs = _collect_code_env_refs(scan_paths)
+        defined = set(env_index.env.keys())
+        unresolved = sorted(code_refs - defined)
+
+        return json.dumps(
+            {
+                "shared_env_vars": shared_env,
+                "shared_packages": shared_pkgs,
+                "unresolved_env_var_refs": unresolved,
+            }
+        )
+    except Exception as exc:
+        _LOGGER.exception("cross_repo_summary_tool failed")
+        return json.dumps({"error": str(exc)})
+
+
+def build_cross_repo_tools() -> list:
+    """Return LangChain StructuredTool instances for cross-repo reasoning."""
+    try:
+        from langchain_core.tools import StructuredTool
+    except ImportError:
+        return []
+
+    return [
+        StructuredTool.from_function(
+            func=resolve_env_var_tool,
+            name="resolve_env_var",
+            description="Resolve an environment variable across all scanned repos",
+            args_schema=ResolveEnvVarArgs,
+        ),
+        StructuredTool.from_function(
+            func=resolve_iac_ref_tool,
+            name="resolve_iac_ref",
+            description="Resolve an IaC reference (Terraform var, CFn !Ref, etc.)",
+            args_schema=ResolveIaCRefArgs,
+        ),
+        StructuredTool.from_function(
+            func=cross_repo_summary_tool,
+            name="cross_repo_summary",
+            description="Get a summary of shared env vars and packages across repos",
+            args_schema=CrossRepoSummaryArgs,
+        ),
+    ]

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -852,10 +852,70 @@ def analyze(
         "--severity",
         help="Minimum severity of findings to include in the report.",
     ),
+    strict: bool = typer.Option(
+        False,
+        "--strict",
+        help="Only emit high-confidence detections; suppress items that need agentic reasoning.",
+    ),
     validate: bool = typer.Option(
         False,
         "--validate",
         help="Validate the output against the format's schema and report errors.",
+    ),
+    repos_file: Optional[Path] = typer.Option(
+        None,
+        "--repos-file",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        resolve_path=True,
+        help=(
+            "Path to a file listing repo paths or git URLs "
+            "(JSON array or newline-delimited text)."
+        ),
+    ),
+    discover_repos: bool = typer.Option(
+        False,
+        "--discover-repos",
+        help=(
+            "Treat each positional source as a parent directory and "
+            "auto-discover all git repositories underneath."
+        ),
+    ),
+    github_org: Optional[str] = typer.Option(
+        None,
+        "--github-org",
+        help="Discover and scan repos from a GitHub org/user.",
+        envvar="AIBOM_GITHUB_ORG",
+    ),
+    gitlab_group: Optional[str] = typer.Option(
+        None,
+        "--gitlab-group",
+        help="Discover and scan repos from a GitLab group.",
+        envvar="AIBOM_GITLAB_GROUP",
+    ),
+    bitbucket_project: Optional[str] = typer.Option(
+        None,
+        "--bitbucket-project",
+        help="Discover and scan repos from a Bitbucket workspace/project.",
+        envvar="AIBOM_BITBUCKET_PROJECT",
+    ),
+    platform_token: Optional[str] = typer.Option(
+        None,
+        "--platform-token",
+        help="Auth token for GitHub/GitLab/Bitbucket API access.",
+        envvar="AIBOM_PLATFORM_TOKEN",
+    ),
+    repo_name_filter: Optional[str] = typer.Option(
+        None,
+        "--repo-filter",
+        help="Filter discovered repos by name substring.",
+    ),
+    repo_topic_filter: Optional[str] = typer.Option(
+        None,
+        "--repo-topic",
+        help="Filter discovered repos by topic/tag.",
     ),
     legacy_mode: bool = typer.Option(
         False,
@@ -898,12 +958,8 @@ def analyze(
         logging.error(f"Invalid --severity value '{min_severity}'. Must be: critical, high, medium, low, info")
         raise typer.Exit(code=1)
     
-    # Validate LLM configuration if model extraction is requested
     llm_config = None
     if llm_model:
-        if not llm_api_base:
-            logging.error("--llm-api-base is required when --llm-model is specified.")
-            raise typer.Exit(code=1)
         llm_config = {
             "model": llm_model,
             "api_key": llm_api_key,
@@ -923,6 +979,57 @@ def analyze(
         except json.JSONDecodeError:
             logging.error(f"Could not decode JSON from {images_file}")
             raise typer.Exit(code=1)
+
+    if repos_file:
+        from .multi_repo import read_repos_file
+        sources_to_process.extend(read_repos_file(repos_file))
+
+    if discover_repos:
+        from .multi_repo import discover_repos as _discover
+        expanded: list[str] = []
+        for src in sources_to_process:
+            p = Path(src)
+            if p.is_dir() and not (p / ".git").exists():
+                repos = _discover(p)
+                if repos:
+                    console.print(
+                        f"  [dim]Discovered {len(repos)} repo(s) under {src}[/]"
+                    )
+                    expanded.extend(str(r) for r in repos)
+                else:
+                    expanded.append(src)
+            else:
+                expanded.append(src)
+        sources_to_process = expanded
+
+    _platform_pairs: list[tuple[str, str]] = []
+    if github_org:
+        _platform_pairs.append(("github", github_org))
+    if gitlab_group:
+        _platform_pairs.append(("gitlab", gitlab_group))
+    if bitbucket_project:
+        _platform_pairs.append(("bitbucket", bitbucket_project))
+
+    if _platform_pairs:
+        from .platform_adapters import get_adapter
+
+        for plat, ns in _platform_pairs:
+            try:
+                adapter = get_adapter(plat, token=platform_token)
+                repos = adapter.list_repos(
+                    ns,
+                    name_filter=repo_name_filter,
+                    topic_filter=repo_topic_filter,
+                )
+                console.print(
+                    f"  [dim]{plat}: discovered {len(repos)} repo(s) "
+                    f"in {ns}[/]"
+                )
+                sources_to_process.extend(r.clone_url for r in repos)
+            except Exception as exc:
+                console.print(
+                    f"[yellow]Warning: {plat} discovery failed: {exc}[/]"
+                )
 
     if not sources_to_process:
         logging.error("No sources provided. Please specify a path or an images file.")
@@ -954,13 +1061,35 @@ def analyze(
     if custom_catalog:
         explicit_config = load_custom_catalog(Path(custom_catalog))
 
+    clone_managers: list[Any] = []
+
     for source in sources_to_process:
         console.print(Panel.fit(f"Analyzing Source: {source}", style="bold cyan"))
         temp_dir = None
-        is_container = is_docker_image(source)
-        path_to_analyze = Path(source)
+        clone_ctx = None
+
+        from .multi_repo import is_git_url, ClonedRepo
+
+        if is_git_url(source):
+            try:
+                clone_ctx = ClonedRepo(source)
+                cloned_path = clone_ctx.__enter__()
+                clone_managers.append(clone_ctx)
+                path_to_analyze = cloned_path
+            except RuntimeError as exc:
+                console.print(f"[red]Clone failed:[/] {exc}")
+                continue
+            is_container = False
+        else:
+            is_container = is_docker_image(source)
+            path_to_analyze = Path(source)
+
         source_summary = {
-            "source_kind": "container" if is_container else "local-path",
+            "source_kind": (
+                "git-url" if clone_ctx
+                else "container" if is_container
+                else "local-path"
+            ),
             "status": "in_progress",
             "status_detail": None,
             "assets_discovered": 0,
@@ -1011,75 +1140,64 @@ def analyze(
             continue
 
         # -----------------------------------------------------------------
-        # v2 path: targeted detectors via run_scanners()
+        # v2 path: four-stage pipeline (scan → cross-ref → agentic → assemble)
         # -----------------------------------------------------------------
         if not legacy_mode:
-            from .models import ScanContext as V2ScanContext
-            from .scanners import run_scanners
+            from .scan_pipeline import ScanPipeline
 
             scan_path = str(path_to_analyze)
-            v2_ctx = V2ScanContext(
-                paths=[scan_path],
+            pipeline = ScanPipeline(
+                scan_paths=[scan_path],
                 output_format=output_format,
                 output_file=str(output_file) if output_file else None,
                 llm_config=llm_config,
                 kb_path=str(db_path) if db_path else None,
                 fail_on=fail_on_severity,
                 min_severity=severity_filter,
+                strict=strict,
             )
-            with console.status(f"[cyan]Scanning {source} (v2 detectors)"):
-                v2_components, v2_relationships = run_scanners(v2_ctx)
+            with console.status(f"[cyan]Scanning {source} (v2 pipeline)"):
+                result = pipeline.run()
 
-            # ---- Agentic enrichment (triggered when --llm-model is set) ----
-            agentic_risk_flags: list = []
-            if llm_config and v2_components:
-                try:
-                    from .agentic.agent import (
-                        AgenticEnrichmentError,
-                        run_agentic_enrichment,
-                    )
+            if llm_config and result.agentic_risk_flags:
+                console.print(
+                    f"  [magenta]Agentic enrichment added "
+                    f"{len(result.agentic_risk_flags)} risk flags[/]"
+                )
 
-                    model_str = llm_config["model"]
-                    with console.status(
-                        f"[magenta]Enriching {source} with agentic analysis "
-                        f"({model_str})"
-                    ):
-                        (
-                            v2_components,
-                            agentic_rels,
-                            agentic_risk_flags,
-                        ) = run_agentic_enrichment(
-                            model_string=model_str,
-                            deterministic_components=v2_components,
-                            deterministic_relationships=v2_relationships,
-                            scan_paths=[scan_path],
-                            llm_config=llm_config,
+            if result.external_deps:
+                escaping = [d for d in result.external_deps if d.escapes_root]
+                if escaping:
+                    lines = [
+                        f"[yellow bold]{len(escaping)} dependency(ies) reference "
+                        f"repos not included in this scan:[/]\n"
+                    ]
+                    for d in escaping[:10]:
+                        label = d.name or d.url_or_path
+                        lines.append(
+                            f"  • [bold]{label}[/] ({d.dep_type}) "
+                            f"from {Path(d.source_file).name}"
                         )
-                    v2_relationships = v2_relationships + agentic_rels
-                    console.print(
-                        f"  [magenta]Agentic enrichment added "
-                        f"{len(agentic_rels)} relationships, "
-                        f"{len(agentic_risk_flags)} risk flags[/]"
+                    if len(escaping) > 10:
+                        lines.append(f"  … and {len(escaping) - 10} more")
+                    lines.append(
+                        "\n[dim]Include these repos in your scan for "
+                        "better cross-reference resolution.[/]"
                     )
-                except ImportError:
-                    console.print(
-                        "[yellow]Warning: agentic enrichment with --llm-model "
-                        "requires 'cisco-aibom[agentic]'.  Install with: "
-                        "pip install 'cisco-aibom[agentic]'[/]"
-                    )
-                except Exception as exc:
-                    _LOGGER.warning("Agentic enrichment failed: %s", exc)
-                    console.print(
-                        f"[yellow]Warning: agentic enrichment failed: {exc}[/]"
-                    )
+                    console.print(Panel(
+                        "\n".join(lines),
+                        title="[bold]Missing Repositories[/]",
+                        border_style="yellow",
+                    ))
 
             all_analysis_outputs[source] = {
                 "_v2": True,
-                "components": v2_components,
-                "relationships": v2_relationships,
-                "_agentic_risk_flags": agentic_risk_flags,
+                "components": result.components,
+                "relationships": result.relationships,
+                "_agentic_risk_flags": result.agentic_risk_flags,
+                "_agentic_candidate_count": result.agentic_candidate_count,
             }
-            source_summary["assets_discovered"] = len(v2_components)
+            source_summary["assets_discovered"] = len(result.components)
             source_summary["last_generated_at"] = _utcnow_iso()
             if source_summary["status"] == "in_progress":
                 source_summary["status"] = "completed"
@@ -1335,6 +1453,29 @@ def analyze(
     else:  # plaintext
         _generate_plaintext_report(all_analysis_outputs, output_file)
 
+    for cm in clone_managers:
+        cm.__exit__(None, None, None)
+
+    total_agentic = sum(
+        v.get("_agentic_candidate_count", 0)
+        for v in all_analysis_outputs.values()
+        if isinstance(v, dict)
+    )
+    if total_agentic > 0 and not llm_config:
+        console.print()
+        console.print(
+            Panel.fit(
+                f"[yellow bold]{total_agentic} detection(s) need agentic reasoning[/]\n\n"
+                "These are ambiguous patterns (e.g., model names in IaC values,\n"
+                ".fit() calls without ML imports, generic Agent/Tool usage)\n"
+                "that require LLM reasoning to confirm or discard.\n\n"
+                "[green]Re-run with --llm-model <model> to resolve them.[/]\n"
+                "[dim]Use --strict to suppress these from the report.[/]",
+                title="[bold]Agentic Reasoning Recommended[/]",
+                border_style="yellow",
+            )
+        )
+
     if show_summary:
         _display_analysis_summary(all_analysis_outputs)
 
@@ -1486,6 +1627,8 @@ def kb_list_requests(
 
 def cli_entry_point() -> None:
     """Entry point for console_scripts."""
+    import sys
+    sys.setrecursionlimit(max(sys.getrecursionlimit(), 5000))
     app()
 
 

--- a/aibom/src/aibom/cross_ref.py
+++ b/aibom/src/aibom/cross_ref.py
@@ -1,0 +1,767 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .models.scan import AIComponent
+from .scanners.dependency_scanner import (
+    AI_PACKAGES,
+    _GO_REQUIRE,
+    _normalize_pypi_name,
+    _REQUIREMENT_NAME,
+)
+
+_ENV_SUBST = re.compile(r"\$\{([^}]+)\}")
+
+_COMPOSE_NAMES = frozenset(
+    {"docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"}
+)
+
+
+@dataclass
+class EnvVarEntry:
+    name: str
+    value: str
+    source_type: str
+    source_path: str = ""
+
+
+@dataclass
+class CrossRefIndex:
+    env: dict[str, list[EnvVarEntry]] = field(default_factory=dict)
+    packages: set[str] = field(default_factory=set)
+
+
+def _add_env(
+    index: CrossRefIndex,
+    name: str,
+    value: str,
+    source_type: str,
+    source_path: str,
+) -> None:
+    entry = EnvVarEntry(
+        name=name,
+        value=value,
+        source_type=source_type,
+        source_path=source_path,
+    )
+    index.env.setdefault(name, []).append(entry)
+
+
+def _strip_quotes(raw: str) -> str:
+    s = raw.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in "'\"":
+        return s[1:-1]
+    return s
+
+
+def _parse_dotenv(content: str, source_path: str, index: CrossRefIndex) -> None:
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, rest = line.partition("=")
+        key = key.strip()
+        val = _strip_quotes(rest)
+        _add_env(index, key, val, "dotenv", source_path)
+
+
+_TFVAR_ASSIGN = re.compile(
+    r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+?)\s*(?:#.*)?$"
+)
+
+
+def _parse_tfvars(content: str, source_path: str, index: CrossRefIndex) -> None:
+    for line in content.splitlines():
+        m = _TFVAR_ASSIGN.match(line)
+        if not m:
+            continue
+        key = m.group(1)
+        raw_val = m.group(2).strip()
+        if raw_val.startswith('"') and raw_val.endswith('"'):
+            val = _strip_quotes(raw_val)
+        elif raw_val.startswith("'") and raw_val.endswith("'"):
+            val = _strip_quotes(raw_val)
+        else:
+            val = raw_val.split("#", 1)[0].strip()
+        _add_env(index, key, val, "terraform-tfvars", source_path)
+
+
+def _walk_yaml_leaves(
+    obj: Any,
+    index: CrossRefIndex,
+    source_path: str,
+    source_type: str,
+) -> None:
+    if isinstance(obj, Mapping):
+        for k, v in obj.items():
+            if isinstance(v, (str, int, float, bool)) or v is None:
+                _add_env(index, str(k), "" if v is None else str(v), source_type, source_path)
+            elif isinstance(v, Mapping):
+                _walk_yaml_leaves(v, index, source_path, source_type)
+            elif isinstance(v, list):
+                for item in v:
+                    if isinstance(item, (str, int, float, bool)) or item is None:
+                        _add_env(
+                            index,
+                            str(k),
+                            "" if item is None else str(item),
+                            source_type,
+                            source_path,
+                        )
+                    else:
+                        _walk_yaml_leaves(item, index, source_path, source_type)
+
+
+def _parse_compose_env(
+    env_block: Any,
+    source_path: str,
+    index: CrossRefIndex,
+) -> None:
+    if env_block is None:
+        return
+    if isinstance(env_block, Mapping):
+        for k, v in env_block.items():
+            _add_env(
+                index,
+                str(k),
+                "" if v is None else str(v),
+                "docker-compose",
+                source_path,
+            )
+        return
+    if isinstance(env_block, list):
+        for item in env_block:
+            if not isinstance(item, str) or "=" not in item:
+                continue
+            ek, _, ev = item.partition("=")
+            _add_env(index, ek.strip(), ev.strip(), "docker-compose", source_path)
+
+
+def _parse_docker_compose(path: Path, index: CrossRefIndex) -> None:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError):
+        return
+    if not isinstance(data, Mapping):
+        return
+    services = data.get("services")
+    if not isinstance(services, Mapping):
+        return
+    rel = str(path)
+    for svc in services.values():
+        if not isinstance(svc, Mapping):
+            continue
+        _parse_compose_env(svc.get("environment"), rel, index)
+
+
+def _parse_k8s_configmap(path: Path, index: CrossRefIndex) -> None:
+    try:
+        docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError):
+        return
+    rel = str(path)
+    for doc in docs:
+        if not isinstance(doc, Mapping):
+            continue
+        if str(doc.get("kind", "")).lower() != "configmap":
+            continue
+        data = doc.get("data")
+        if not isinstance(data, Mapping):
+            continue
+        for k, v in data.items():
+            _add_env(
+                index,
+                str(k),
+                "" if v is None else str(v),
+                "k8s-configmap",
+                rel,
+            )
+
+
+def _parse_helm_values(path: Path, index: CrossRefIndex) -> None:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError):
+        return
+    _walk_yaml_leaves(data, index, str(path), "helm-values")
+
+
+def _scan_env_paths(paths: Iterable[str]) -> CrossRefIndex:
+    index = CrossRefIndex()
+    for root in paths:
+        base = Path(root)
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if not path.is_file():
+                continue
+            name = path.name
+            rel = str(path)
+            if name == ".env":
+                try:
+                    _parse_dotenv(path.read_text(encoding="utf-8"), rel, index)
+                except (OSError, UnicodeDecodeError):
+                    continue
+            elif name in _COMPOSE_NAMES:
+                _parse_docker_compose(path, index)
+            elif name == "terraform.tfvars" or name.endswith(".tfvars"):
+                try:
+                    _parse_tfvars(path.read_text(encoding="utf-8"), rel, index)
+                except (OSError, UnicodeDecodeError):
+                    continue
+            elif name == "values.yaml":
+                _parse_helm_values(path, index)
+            elif name.endswith((".yaml", ".yml")):
+                _parse_k8s_configmap(path, index)
+    return index
+
+
+def build_env_index(paths: Iterable[str]) -> CrossRefIndex:
+    return _scan_env_paths(paths)
+
+
+def _pypi_candidate_ai(name: str) -> bool:
+    norm = _normalize_pypi_name(name)
+    return norm in AI_PACKAGES["pypi"]
+
+
+def _npm_candidate_ai(name: str) -> bool:
+    return name in AI_PACKAGES["npm"]
+
+
+def _go_candidate_ai(module: str) -> bool:
+    if module in AI_PACKAGES["go"]:
+        return True
+    return module == "github.com/openai/openai-go"
+
+
+def _parse_requirements(content: str, index: CrossRefIndex) -> None:
+    for line in content.splitlines():
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        m = _REQUIREMENT_NAME.match(s)
+        if not m:
+            continue
+        raw_name = m.group(1)
+        if _pypi_candidate_ai(raw_name):
+            index.packages.add(_normalize_pypi_name(raw_name))
+
+
+def _parse_package_json(path: Path, index: CrossRefIndex) -> None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return
+    deps = data.get("dependencies")
+    if isinstance(deps, Mapping):
+        for name in deps:
+            if _npm_candidate_ai(name):
+                index.packages.add(name)
+    dev = data.get("devDependencies")
+    if isinstance(dev, Mapping):
+        for name in dev:
+            if _npm_candidate_ai(name):
+                index.packages.add(name)
+
+
+def _pyproject_dep_strings(project: Mapping[str, Any]) -> list[str]:
+    out: list[str] = []
+    deps = project.get("dependencies")
+    if isinstance(deps, list):
+        for item in deps:
+            if isinstance(item, str):
+                out.append(item)
+    opt = project.get("optional-dependencies")
+    if isinstance(opt, Mapping):
+        for group in opt.values():
+            if isinstance(group, list):
+                for item in group:
+                    if isinstance(item, str):
+                        out.append(item)
+    return out
+
+
+def _parse_pyproject(path: Path, index: CrossRefIndex) -> None:
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+        return
+    project = data.get("project")
+    if not isinstance(project, Mapping):
+        return
+    for spec in _pyproject_dep_strings(project):
+        m = _REQUIREMENT_NAME.match(spec.strip())
+        if not m:
+            continue
+        raw_name = m.group(1)
+        if _pypi_candidate_ai(raw_name):
+            index.packages.add(_normalize_pypi_name(raw_name))
+
+
+def _parse_go_mod(content: str, index: CrossRefIndex) -> None:
+    in_require = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("require ("):
+            in_require = True
+            continue
+        if in_require and stripped == ")":
+            in_require = False
+            continue
+        if in_require:
+            m = _GO_REQUIRE.match(stripped)
+            if m:
+                mod = m.group(1)
+                if _go_candidate_ai(mod):
+                    index.packages.add(mod)
+        else:
+            if stripped.startswith("require "):
+                rest = stripped[len("require ") :].strip()
+                m = _GO_REQUIRE.match(rest)
+                if m:
+                    mod = m.group(1)
+                    if _go_candidate_ai(mod):
+                        index.packages.add(mod)
+
+
+def _scan_package_paths(paths: Iterable[str]) -> CrossRefIndex:
+    index = CrossRefIndex()
+    for root in paths:
+        base = Path(root)
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if not path.is_file():
+                continue
+            name = path.name
+            if name == "requirements.txt":
+                try:
+                    _parse_requirements(path.read_text(encoding="utf-8"), index)
+                except (OSError, UnicodeDecodeError):
+                    continue
+            elif name == "package.json":
+                _parse_package_json(path, index)
+            elif name == "pyproject.toml":
+                _parse_pyproject(path, index)
+            elif name == "go.mod":
+                try:
+                    _parse_go_mod(path.read_text(encoding="utf-8"), index)
+                except (OSError, UnicodeDecodeError):
+                    continue
+    return index
+
+
+def build_package_index(paths: Iterable[str]) -> CrossRefIndex:
+    return _scan_package_paths(paths)
+
+
+def _env_lookup(index: CrossRefIndex, key: str) -> str | None:
+    entries = index.env.get(key)
+    if not entries:
+        return None
+    return entries[0].value
+
+
+def _substitute_placeholders(model_name: str, index: CrossRefIndex) -> str:
+    def repl(match: re.Match[str]) -> str:
+        k = match.group(1).strip()
+        v = _env_lookup(index, k)
+        return v if v is not None else match.group(0)
+
+    return _ENV_SUBST.sub(repl, model_name)
+
+
+def _try_registry(model_name: str) -> dict[str, Any] | None:
+    """Attempt registry lookup; returns None on import failure."""
+    try:
+        from .scanners.model_detector import _registry_lookup
+        return _registry_lookup(model_name)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def resolve_components(
+    components: Iterable[AIComponent],
+    env_index: CrossRefIndex,
+) -> list[AIComponent]:
+    out: list[AIComponent] = []
+    for c in components:
+        new_c = c
+        meta = dict(c.metadata) if c.metadata else {}
+
+        env_key = meta.get("env") or meta.get("config_key")
+        resolved_from: EnvVarEntry | None = None
+
+        if isinstance(env_key, str):
+            entries = env_index.env.get(env_key)
+            if entries:
+                resolved_from = entries[0]
+                val = resolved_from.value
+
+                provenance = {
+                    "resolved_from": resolved_from.source_type,
+                    "resolved_source_file": resolved_from.source_path,
+                    "resolved_env_var": env_key,
+                    "resolved_value": val,
+                }
+                meta.update(provenance)
+
+                if c.model_name is None and val:
+                    new_c = c.model_copy(update={
+                        "model_name": val,
+                        "metadata": meta,
+                    })
+            elif c.needs_agentic:
+                meta["unresolved_env_var"] = env_key
+                new_c = c.model_copy(update={
+                    "agentic_hint": (
+                        f"env var {env_key} used as {meta.get('env_context', 'unknown')}; "
+                        f"not found in any config source — may require "
+                        f"additional repos or runtime configuration"
+                    ),
+                    "metadata": meta,
+                })
+
+        mn = new_c.model_name
+        if isinstance(mn, str) and "${" in mn:
+            sub = _substitute_placeholders(mn, env_index)
+            if sub != mn:
+                meta_sub = dict(new_c.metadata) if new_c.metadata else {}
+                meta_sub["placeholder_resolved"] = True
+                new_c = new_c.model_copy(update={
+                    "model_name": sub,
+                    "metadata": meta_sub,
+                })
+                mn = sub
+
+        if resolved_from and mn and not _ENV_SUBST.search(mn):
+            reg_hit = _try_registry(mn)
+            if reg_hit:
+                reg_meta = dict(new_c.metadata) if new_c.metadata else {}
+                reg_meta["registry_source"] = reg_hit.get("source", "litellm")
+                reg_meta["provider"] = reg_hit.get("provider", "unknown")
+                new_c = new_c.model_copy(update={
+                    "confidence": max(new_c.confidence, 0.85),
+                    "needs_agentic": False,
+                    "agentic_hint": "",
+                    "metadata": reg_meta,
+                })
+            else:
+                agentic_meta = dict(new_c.metadata) if new_c.metadata else {}
+                agentic_meta["registry_source"] = "none"
+                new_c = new_c.model_copy(update={
+                    "confidence": max(new_c.confidence, 0.5),
+                    "needs_agentic": True,
+                    "agentic_hint": (
+                        f"Resolved '{mn}' from env var "
+                        f"{resolved_from.name} ({resolved_from.source_type}), "
+                        f"but not found in model registry"
+                    ),
+                    "metadata": agentic_meta,
+                })
+
+        out.append(new_c)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Cross-repo dependency detection
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ExternalRepoDep:
+    """A dependency that references code outside the current repository."""
+
+    name: str
+    source_file: str
+    dep_type: str  # "git", "path", "editable"
+    url_or_path: str
+    subdirectory: str = ""
+    branch: str = ""
+    tag: str = ""
+    escapes_root: bool = False
+
+
+_GIT_URL_RE = re.compile(
+    r"git\+(?:https?|ssh|git)://[^\s#]+|git@[^\s#:]+"
+)
+_POETRY_GIT_RE = re.compile(
+    r"""^\[tool\.poetry\.(?:dependencies|dev-dependencies|group\.\w+\.dependencies)\]""",
+    re.MULTILINE,
+)
+_UV_SOURCES_HEADER_RE = re.compile(
+    r"""^\[tool\.uv\.sources\]""", re.MULTILINE,
+)
+
+
+def _parse_poetry_git_deps(
+    data: dict[str, Any], source_path: str
+) -> list[ExternalRepoDep]:
+    """Extract Poetry git and path dependencies from parsed pyproject.toml."""
+    deps: list[ExternalRepoDep] = []
+    sections = [
+        data.get("tool", {}).get("poetry", {}).get("dependencies", {}),
+        data.get("tool", {}).get("poetry", {}).get("dev-dependencies", {}),
+    ]
+    groups = data.get("tool", {}).get("poetry", {}).get("group", {})
+    if isinstance(groups, Mapping):
+        for grp in groups.values():
+            if isinstance(grp, Mapping):
+                sections.append(grp.get("dependencies", {}))
+
+    for section in sections:
+        if not isinstance(section, Mapping):
+            continue
+        for pkg_name, spec in section.items():
+            if not isinstance(spec, Mapping):
+                continue
+            git_url = spec.get("git")
+            local_path = spec.get("path")
+            if git_url:
+                deps.append(ExternalRepoDep(
+                    name=pkg_name,
+                    source_file=source_path,
+                    dep_type="git",
+                    url_or_path=git_url,
+                    subdirectory=spec.get("subdirectory", ""),
+                    branch=spec.get("branch", ""),
+                    tag=spec.get("tag", spec.get("rev", "")),
+                ))
+            elif local_path:
+                deps.append(ExternalRepoDep(
+                    name=pkg_name,
+                    source_file=source_path,
+                    dep_type="path",
+                    url_or_path=local_path,
+                ))
+    return deps
+
+
+def _parse_uv_sources(
+    data: dict[str, Any], source_path: str
+) -> list[ExternalRepoDep]:
+    """Extract uv [tool.uv.sources] git and path references."""
+    deps: list[ExternalRepoDep] = []
+    sources = data.get("tool", {}).get("uv", {}).get("sources", {})
+    if not isinstance(sources, Mapping):
+        return deps
+    for pkg_name, spec in sources.items():
+        if not isinstance(spec, Mapping):
+            continue
+        git_url = spec.get("git")
+        local_path = spec.get("path")
+        if git_url:
+            deps.append(ExternalRepoDep(
+                name=pkg_name,
+                source_file=source_path,
+                dep_type="git",
+                url_or_path=git_url,
+                subdirectory=spec.get("subdirectory", ""),
+                branch=spec.get("branch", spec.get("rev", "")),
+                tag=spec.get("tag", ""),
+            ))
+        elif local_path:
+            deps.append(ExternalRepoDep(
+                name=pkg_name,
+                source_file=source_path,
+                dep_type="path",
+                url_or_path=local_path,
+            ))
+    return deps
+
+
+_REQ_GIT_RE = re.compile(
+    r"""^(?:-e\s+)?git\+(?P<url>https?://[^\s@#]+|ssh://[^\s@#]+|git@[^\s@#]+)"""
+    r"""(?:@(?P<ref>[^\s#]+))?"""
+    r"""(?:#egg=(?P<egg>[^\s&]+))?""",
+)
+_REQ_PATH_EDITABLE_RE = re.compile(
+    r"""^-e\s+(?P<path>[./][^\s]+)"""
+)
+
+
+def _parse_requirements_git(
+    content: str, source_path: str
+) -> list[ExternalRepoDep]:
+    deps: list[ExternalRepoDep] = []
+    for line in content.splitlines():
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        m = _REQ_GIT_RE.match(s)
+        if m:
+            deps.append(ExternalRepoDep(
+                name=m.group("egg") or "",
+                source_file=source_path,
+                dep_type="git",
+                url_or_path=m.group("url"),
+                branch=m.group("ref") or "",
+            ))
+            continue
+        m = _REQ_PATH_EDITABLE_RE.match(s)
+        if m:
+            deps.append(ExternalRepoDep(
+                name="",
+                source_file=source_path,
+                dep_type="editable",
+                url_or_path=m.group("path"),
+            ))
+    return deps
+
+
+def _parse_package_json_git(
+    data: dict[str, Any], source_path: str
+) -> list[ExternalRepoDep]:
+    deps: list[ExternalRepoDep] = []
+    for section_key in ("dependencies", "devDependencies"):
+        section = data.get(section_key)
+        if not isinstance(section, Mapping):
+            continue
+        for pkg_name, spec in section.items():
+            if not isinstance(spec, str):
+                continue
+            if spec.startswith("git+") or spec.startswith("github:"):
+                deps.append(ExternalRepoDep(
+                    name=pkg_name,
+                    source_file=source_path,
+                    dep_type="git",
+                    url_or_path=spec,
+                ))
+            elif spec.startswith("file:"):
+                deps.append(ExternalRepoDep(
+                    name=pkg_name,
+                    source_file=source_path,
+                    dep_type="path",
+                    url_or_path=spec[len("file:"):],
+                ))
+    return deps
+
+
+_GO_REPLACE_RE = re.compile(
+    r"""^replace\s+(\S+)\s+=>\s+(\S+)(?:\s+(\S+))?$""", re.MULTILINE
+)
+
+
+def _parse_go_mod_replace(
+    content: str, source_path: str
+) -> list[ExternalRepoDep]:
+    deps: list[ExternalRepoDep] = []
+    for m in _GO_REPLACE_RE.finditer(content):
+        original = m.group(1)
+        replacement = m.group(2)
+        if replacement.startswith("./") or replacement.startswith("../"):
+            deps.append(ExternalRepoDep(
+                name=original,
+                source_file=source_path,
+                dep_type="path",
+                url_or_path=replacement,
+            ))
+        elif not replacement.startswith("."):
+            deps.append(ExternalRepoDep(
+                name=original,
+                source_file=source_path,
+                dep_type="git",
+                url_or_path=replacement,
+            ))
+    return deps
+
+
+def _flag_escaping_paths(
+    deps: list[ExternalRepoDep], repo_roots: list[Path]
+) -> None:
+    """Set ``escapes_root=True`` for path deps that leave all repo roots."""
+    for dep in deps:
+        if dep.dep_type not in ("path", "editable"):
+            continue
+        dep_path = Path(dep.url_or_path)
+        if dep_path.is_absolute():
+            dep.escapes_root = True
+            continue
+        manifest_dir = Path(dep.source_file).parent
+        resolved = (manifest_dir / dep_path).resolve()
+        inside = False
+        for root in repo_roots:
+            try:
+                resolved.relative_to(root.resolve())
+                inside = True
+                break
+            except ValueError:
+                continue
+        if not inside:
+            dep.escapes_root = True
+
+
+def detect_external_repo_deps(paths: Iterable[str]) -> list[ExternalRepoDep]:
+    """Scan manifests under *paths* for cross-repo git/path dependencies."""
+    deps: list[ExternalRepoDep] = []
+    repo_roots = [Path(p) for p in paths]
+
+    for root_str in paths:
+        root = Path(root_str)
+        if not root.exists():
+            continue
+        for fpath in root.rglob("*"):
+            if not fpath.is_file():
+                continue
+            name = fpath.name
+            sp = str(fpath)
+
+            if name == "pyproject.toml":
+                try:
+                    data = tomllib.loads(fpath.read_text(encoding="utf-8"))
+                except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+                    continue
+                deps.extend(_parse_poetry_git_deps(data, sp))
+                deps.extend(_parse_uv_sources(data, sp))
+
+            elif name in ("requirements.txt", "requirements-dev.txt"):
+                try:
+                    content = fpath.read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError):
+                    continue
+                deps.extend(_parse_requirements_git(content, sp))
+
+            elif name == "package.json":
+                try:
+                    data = json.loads(fpath.read_text(encoding="utf-8"))
+                except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+                    continue
+                deps.extend(_parse_package_json_git(data, sp))
+
+            elif name == "go.mod":
+                try:
+                    content = fpath.read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError):
+                    continue
+                deps.extend(_parse_go_mod_replace(content, sp))
+
+    _flag_escaping_paths(deps, repo_roots)
+    return deps

--- a/aibom/src/aibom/dep_graph.py
+++ b/aibom/src/aibom/dep_graph.py
@@ -1,0 +1,189 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .cross_ref import CrossRefIndex
+from .models import AIComponent, ComponentRelationship
+from .models.enums import AIComponentType, RelationshipType
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class RepoNode:
+    """A repository in the dependency graph."""
+
+    path: str
+    name: str
+    components: list[AIComponent] = field(default_factory=list)
+    packages: set[str] = field(default_factory=set)
+    env_vars_defined: set[str] = field(default_factory=set)
+    env_vars_referenced: set[str] = field(default_factory=set)
+
+
+@dataclass
+class RepoEdge:
+    """A directed edge between two repos."""
+
+    source_repo: str
+    target_repo: str
+    edge_type: str  # "shared_package", "env_var_flow", "api_contract", "config_ref"
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+class DependencyGraph:
+    """Cross-repo dependency graph builder."""
+
+    def __init__(self) -> None:
+        self._repos: dict[str, RepoNode] = {}
+        self._edges: list[RepoEdge] = []
+
+    def add_repo(
+        self,
+        path: str,
+        components: list[AIComponent],
+        cross_ref: CrossRefIndex | None = None,
+    ) -> None:
+        """Register a repo and its scan results."""
+        name = Path(path).name
+        node = RepoNode(path=path, name=name, components=list(components))
+
+        for c in components:
+            if c.component_type == AIComponentType.DEPENDENCY:
+                node.packages.add(c.name)
+
+        for c in components:
+            env = c.metadata.get("env") or c.metadata.get("config_key")
+            if isinstance(env, str):
+                node.env_vars_referenced.add(env)
+
+        if cross_ref:
+            root = Path(path).resolve()
+            for var_name, entries in cross_ref.env.items():
+                for entry in entries:
+                    try:
+                        src = Path(entry.source_path).resolve()
+                    except OSError:
+                        _LOGGER.debug(
+                            "Skipping env entry with unreadable path: %s",
+                            entry.source_path,
+                        )
+                        continue
+                    if src.is_relative_to(root):
+                        node.env_vars_defined.add(var_name)
+
+        self._repos[path] = node
+
+    def build(self) -> list[RepoEdge]:
+        """Compute edges between repos."""
+        self._edges = []
+        self._find_shared_packages()
+        self._find_env_var_flows()
+        return list(self._edges)
+
+    def _find_shared_packages(self) -> None:
+        """Find packages used by multiple repos."""
+        pkg_repos: dict[str, list[str]] = defaultdict(list)
+        for path, node in self._repos.items():
+            for pkg in node.packages:
+                pkg_repos[pkg].append(path)
+
+        for pkg, repos in sorted(pkg_repos.items()):
+            if len(repos) < 2:
+                continue
+            repos_sorted = sorted(repos)
+            for i, src in enumerate(repos_sorted):
+                for tgt in repos_sorted[i + 1 :]:
+                    self._edges.append(
+                        RepoEdge(
+                            source_repo=src,
+                            target_repo=tgt,
+                            edge_type="shared_package",
+                            details={"package": pkg},
+                        )
+                    )
+
+    def _find_env_var_flows(self) -> None:
+        """Find env vars defined in one repo and referenced in another."""
+        repo_paths = sorted(self._repos.keys())
+        for src_path in repo_paths:
+            src_node = self._repos[src_path]
+            for tgt_path in repo_paths:
+                if src_path == tgt_path:
+                    continue
+                tgt_node = self._repos[tgt_path]
+                shared = src_node.env_vars_defined & tgt_node.env_vars_referenced
+                for var in sorted(shared):
+                    self._edges.append(
+                        RepoEdge(
+                            source_repo=src_path,
+                            target_repo=tgt_path,
+                            edge_type="env_var_flow",
+                            details={"env_var": var},
+                        )
+                    )
+
+    def to_relationships(self) -> list[ComponentRelationship]:
+        """Convert graph edges to AIBOM ComponentRelationship objects."""
+        rels: list[ComponentRelationship] = []
+        for edge in self._edges:
+            src_name = Path(edge.source_repo).name
+            tgt_name = Path(edge.target_repo).name
+            rels.append(
+                ComponentRelationship(
+                    source_instance_id=f"repo:{src_name}",
+                    target_instance_id=f"repo:{tgt_name}",
+                    relationship_type=RelationshipType.CUSTOM,
+                    label=edge.edge_type,
+                    source_name=src_name,
+                    target_name=tgt_name,
+                )
+            )
+        return rels
+
+    def to_dict(self) -> dict[str, Any]:
+        """Export graph as serializable dict for JSON output."""
+        return {
+            "repos": [
+                {
+                    "path": n.path,
+                    "name": n.name,
+                    "component_count": len(n.components),
+                    "packages": sorted(n.packages),
+                    "env_vars_defined": sorted(n.env_vars_defined),
+                    "env_vars_referenced": sorted(n.env_vars_referenced),
+                }
+                for n in sorted(self._repos.values(), key=lambda x: x.path)
+            ],
+            "edges": [
+                {
+                    "source": Path(e.source_repo).name,
+                    "target": Path(e.target_repo).name,
+                    "type": e.edge_type,
+                    "details": e.details,
+                }
+                for e in self._edges
+            ],
+            "total_repos": len(self._repos),
+            "total_edges": len(self._edges),
+        }

--- a/aibom/src/aibom/models/scan.py
+++ b/aibom/src/aibom/models/scan.py
@@ -33,6 +33,8 @@ class AIComponent(BaseModel):
     framework: str = ""
     detection_source: DetectionSource = DetectionSource.CODE_ANALYSIS
     confidence: float = 1.0
+    needs_agentic: bool = False
+    agentic_hint: str = ""
 
     model_name: Optional[str] = None
     embedding_model: Optional[str] = None
@@ -153,14 +155,25 @@ class ScanResult(BaseModel):
         return [r for s in self.sources for r in s.relationships]
 
     @property
+    def confirmed_components(self) -> list[AIComponent]:
+        return [c for c in self.all_components if not c.needs_agentic]
+
+    @property
+    def agentic_candidates(self) -> list[AIComponent]:
+        return [c for c in self.all_components if c.needs_agentic]
+
+    @property
     def summary(self) -> dict[str, Any]:
         components = self.all_components
         by_type: dict[str, int] = {}
         for c in components:
-            by_type[c.component_type.value] = by_type.get(c.component_type.value, 0) + 1
+            if not c.needs_agentic:
+                by_type[c.component_type.value] = by_type.get(c.component_type.value, 0) + 1
+        agentic = [c for c in components if c.needs_agentic]
         return {
             "total_sources": len(self.sources),
-            "total_components": len(components),
+            "total_components": len(components) - len(agentic),
+            "agentic_candidates": len(agentic),
             "component_types": by_type,
             "total_relationships": len(self.all_relationships),
             "risk_score": self.risk.score,

--- a/aibom/src/aibom/multi_repo.py
+++ b/aibom/src/aibom/multi_repo.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Multi-repo discovery, remote cloning, and repos-file parsing.
+
+Supports:
+- Auto-detecting git repos under a parent directory
+- Reading repo paths/URLs from a text or JSON file
+- Shallow-cloning a remote git URL for ephemeral scanning
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+_LOGGER = logging.getLogger(__name__)
+
+_GIT_URL_RE = re.compile(
+    r"^(https?://|git@|ssh://|git://)"
+)
+
+
+def is_git_url(value: str) -> bool:
+    return bool(_GIT_URL_RE.match(value.strip()))
+
+
+def discover_repos(parent: Path, max_depth: int = 3) -> list[Path]:
+    """Find all git repositories under *parent* up to *max_depth* levels.
+
+    Returns sorted list of repo root paths (directories containing ``.git``).
+    """
+    found: list[Path] = []
+    if not parent.is_dir():
+        return found
+
+    def _walk(current: Path, depth: int) -> None:
+        if depth > max_depth:
+            return
+        git_dir = current / ".git"
+        if git_dir.exists():
+            found.append(current)
+            return
+        try:
+            children = sorted(current.iterdir())
+        except PermissionError:
+            return
+        for child in children:
+            if child.is_dir() and child.name not in (
+                ".git", "node_modules", ".venv", "venv", "__pycache__",
+            ):
+                _walk(child, depth + 1)
+
+    _walk(parent, 0)
+    return sorted(found)
+
+
+def read_repos_file(path: Path) -> list[str]:
+    """Parse a repos file (JSON array or newline-delimited text).
+
+    Blank lines and lines starting with ``#`` are ignored in text mode.
+    """
+    content = path.read_text(encoding="utf-8").strip()
+    if not content:
+        return []
+
+    if content.startswith("["):
+        try:
+            entries = json.loads(content)
+            if isinstance(entries, list):
+                return [str(e).strip() for e in entries if str(e).strip()]
+        except json.JSONDecodeError:
+            pass
+
+    return [
+        line.strip()
+        for line in content.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+class ClonedRepo:
+    """Context manager for a shallow-cloned remote repository."""
+
+    def __init__(self, url: str, *, branch: str | None = None):
+        self.url = url
+        self.branch = branch
+        self._tmpdir: str | None = None
+        self.path: Path | None = None
+
+    def __enter__(self) -> Path:
+        self._tmpdir = tempfile.mkdtemp(prefix="aibom_clone_")
+        cmd = [
+            "git", "clone", "--depth=1", "--single-branch",
+        ]
+        if self.branch:
+            cmd.extend(["--branch", self.branch])
+        cmd.extend([self.url, self._tmpdir])
+
+        _LOGGER.debug("Cloning %s → %s", self.url, self._tmpdir)
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+            raise RuntimeError(
+                f"git clone failed (rc={result.returncode}): {result.stderr.strip()}"
+            )
+        self.path = Path(self._tmpdir)
+        return self.path
+
+    def __exit__(self, *exc: object) -> None:
+        if self._tmpdir:
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+            _LOGGER.debug("Cleaned up clone: %s", self._tmpdir)
+            self._tmpdir = None
+            self.path = None

--- a/aibom/src/aibom/platform_adapters.py
+++ b/aibom/src/aibom/platform_adapters.py
@@ -1,0 +1,570 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path  # noqa: F401
+from typing import Any
+from urllib.parse import quote, urlparse
+
+import httpx
+
+__all__ = [
+    "BitbucketAdapter",
+    "GitHubAdapter",
+    "GitLabAdapter",
+    "RepoDiscovery",
+    "RepoInfo",
+    "get_adapter",
+]
+
+logger = logging.getLogger(__name__)
+
+_PAGE_SIZE = 100
+_MAX_PAGES = 10
+_MAX_REPOS = _PAGE_SIZE * _MAX_PAGES
+_CLIENT_TIMEOUT = 30.0
+
+
+@dataclass
+class RepoInfo:
+    """Metadata about a discovered repository."""
+
+    name: str
+    full_name: str
+    clone_url: str
+    default_branch: str = "main"
+    topics: list[str] = field(default_factory=list)
+    language: str = ""
+    description: str = ""
+    is_archived: bool = False
+
+
+class RepoDiscovery(ABC):
+    """Interface for discovering repositories from a source code platform."""
+
+    @abstractmethod
+    def list_repos(
+        self,
+        namespace: str,
+        *,
+        name_filter: str | None = None,
+        topic_filter: str | None = None,
+        include_archived: bool = False,
+    ) -> list[RepoInfo]:
+        """List repositories in a namespace (org/group/project)."""
+        ...
+
+
+def _passes_filters(
+    repo: RepoInfo,
+    *,
+    name_filter: str | None,
+    topic_filter: str | None,
+    include_archived: bool,
+) -> bool:
+    if not include_archived and repo.is_archived:
+        return False
+    if name_filter and name_filter.lower() not in repo.name.lower():
+        return False
+    if topic_filter:
+        tlow = topic_filter.lower()
+        if not any(t.lower() == tlow for t in repo.topics):
+            return False
+    return True
+
+
+def _github_parse_next_url(link_header: str | None) -> str | None:
+    if not link_header:
+        return None
+    for part in link_header.split(","):
+        chunk = part.strip()
+        if 'rel="next"' not in chunk and "rel='next'" not in chunk:
+            continue
+        lt = chunk.find("<")
+        gt = chunk.find(">", lt + 1)
+        if lt == -1 or gt == -1:
+            continue
+        return chunk[lt + 1:gt]
+    return None
+
+
+class GitHubAdapter(RepoDiscovery):
+    """Discover repos from GitHub organizations or users."""
+
+    BASE = "https://api.github.com"
+
+    def __init__(self, token: str | None = None, base_url: str | None = None):
+        self._token = token
+        self._base = (base_url or self.BASE).rstrip("/")
+        self._headers = {"Accept": "application/vnd.github+json"}
+        if token:
+            self._headers["Authorization"] = f"Bearer {token}"
+
+    def _repo_from_json(self, r: dict[str, Any]) -> RepoInfo:
+        topics = r.get("topics") or []
+        if not isinstance(topics, list):
+            topics = []
+        lang = r.get("language") or ""
+        if not isinstance(lang, str):
+            lang = str(lang)
+        desc = r.get("description") or ""
+        if not isinstance(desc, str):
+            desc = str(desc)
+        branch = r.get("default_branch") or "main"
+        if not isinstance(branch, str):
+            branch = str(branch)
+        return RepoInfo(
+            name=str(r.get("name") or ""),
+            full_name=str(r.get("full_name") or r.get("name") or ""),
+            clone_url=str(r.get("clone_url") or ""),
+            default_branch=branch,
+            topics=[str(t) for t in topics],
+            language=lang,
+            description=desc,
+            is_archived=bool(r.get("archived")),
+        )
+
+    def list_repos(
+        self,
+        namespace: str,
+        *,
+        name_filter: str | None = None,
+        topic_filter: str | None = None,
+        include_archived: bool = False,
+    ) -> list[RepoInfo]:
+        if not namespace.strip():
+            return []
+        ns = namespace.strip()
+        q = quote(ns, safe="")
+        org_ep = f"{self._base}/orgs/{q}/repos"
+        user_ep = f"{self._base}/users/{q}/repos"
+        out: list[RepoInfo] = []
+        try:
+            client_ctx = httpx.Client(
+                timeout=_CLIENT_TIMEOUT,
+                headers=self._headers,
+            )
+            with client_ctx as client:
+                link_hdr: str | None = None
+                for page in range(_MAX_PAGES):
+                    if len(out) >= _MAX_REPOS:
+                        break
+                    try:
+                        if page == 0:
+                            r = client.get(
+                                org_ep, params={"per_page": _PAGE_SIZE}
+                            )
+                            if r.status_code == 404:
+                                r = client.get(
+                                    user_ep, params={"per_page": _PAGE_SIZE}
+                                )
+                            elif r.status_code == 403:
+                                logger.warning(
+                                    "GitHub API returned %s for org %r: %s",
+                                    r.status_code,
+                                    ns,
+                                    r.text[:500],
+                                )
+                                return []
+                            if r.status_code in (404, 403):
+                                logger.warning(
+                                    "GitHub API returned %s for "
+                                    "namespace %r: %s",
+                                    r.status_code,
+                                    ns,
+                                    r.text[:500],
+                                )
+                                return []
+                        else:
+                            nxt = _github_parse_next_url(link_hdr)
+                            if not nxt:
+                                break
+                            r = client.get(nxt)
+                            if r.status_code in (404, 403):
+                                logger.warning(
+                                    "GitHub API returned %s while "
+                                    "listing %r: %s",
+                                    r.status_code,
+                                    ns,
+                                    r.text[:500],
+                                )
+                                break
+                        r.raise_for_status()
+                        batch = r.json()
+                        if not isinstance(batch, list):
+                            logger.warning(
+                                "GitHub API returned non-list "
+                                "payload for %r",
+                                ns,
+                            )
+                            break
+                        for item in batch:
+                            if len(out) >= _MAX_REPOS:
+                                break
+                            if not isinstance(item, dict):
+                                continue
+                            repo = self._repo_from_json(item)
+                            if _passes_filters(
+                                repo,
+                                name_filter=name_filter,
+                                topic_filter=topic_filter,
+                                include_archived=include_archived,
+                            ):
+                                out.append(repo)
+                        link_hdr = r.headers.get("link")
+                    except httpx.HTTPError as exc:
+                        logger.warning(
+                            "GitHub API request failed for %r: %s", ns, exc
+                        )
+                        break
+        except httpx.HTTPError as exc:
+            logger.warning("GitHub API client error for %r: %s", ns, exc)
+        except (ValueError, TypeError, KeyError) as exc:
+            logger.warning(
+                "GitHub API response parse error for %r: %s",
+                ns,
+                exc,
+            )
+        return out
+
+
+class GitLabAdapter(RepoDiscovery):
+    """Discover repos from GitLab groups."""
+
+    BASE = "https://gitlab.com"
+
+    def __init__(self, token: str | None = None, base_url: str | None = None):
+        self._token = token
+        root = (base_url or self.BASE).rstrip("/")
+        parsed = urlparse(root)
+        if parsed.path.rstrip("/") == "/api/v4":
+            self._api_base = root.rstrip("/")
+            self._origin = f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
+        else:
+            self._origin = root
+            self._api_base = f"{self._origin}/api/v4"
+        self._headers: dict[str, str] = {}
+        if token:
+            self._headers["PRIVATE-TOKEN"] = token
+
+    def _repo_from_json(self, p: dict[str, Any]) -> RepoInfo:
+        topics = p.get("topics") or []
+        if not isinstance(topics, list):
+            topics = []
+        lang = p.get("language") or ""
+        if not isinstance(lang, str):
+            lang = str(lang)
+        desc = p.get("description") or ""
+        if not isinstance(desc, str):
+            desc = str(desc)
+        branch = p.get("default_branch") or "main"
+        if not isinstance(branch, str):
+            branch = str(branch)
+        path_ns = str(p.get("path_with_namespace") or p.get("path") or "")
+        name = str(p.get("name") or "")
+        return RepoInfo(
+            name=name,
+            full_name=path_ns or name,
+            clone_url=str(p.get("http_url_to_repo") or ""),
+            default_branch=branch,
+            topics=[str(t) for t in topics],
+            language=lang,
+            description=desc,
+            is_archived=bool(p.get("archived")),
+        )
+
+    def list_repos(
+        self,
+        namespace: str,
+        *,
+        name_filter: str | None = None,
+        topic_filter: str | None = None,
+        include_archived: bool = False,
+    ) -> list[RepoInfo]:
+        if not namespace.strip():
+            return []
+        ns = namespace.strip()
+        enc = quote(ns, safe="")
+        out: list[RepoInfo] = []
+        try:
+            client_ctx = httpx.Client(
+                timeout=_CLIENT_TIMEOUT,
+                headers=self._headers,
+            )
+            with client_ctx as client:
+                group_url = (
+                    f"{self._api_base}/groups/{enc}/projects"
+                    f"?per_page={_PAGE_SIZE}&include_subgroups=true"
+                )
+                resp = client.get(group_url)
+                if resp.status_code == 404:
+                    is_group = False
+                    user_url = (
+                        f"{self._api_base}/users/{enc}/projects"
+                        f"?per_page={_PAGE_SIZE}"
+                    )
+                    resp = client.get(user_url)
+                    list_url = f"{self._api_base}/users/{enc}/projects"
+                else:
+                    is_group = True
+                    list_url = f"{self._api_base}/groups/{enc}/projects"
+
+                if resp.status_code in (404, 403):
+                    logger.warning(
+                        "GitLab API returned %s for namespace %r: %s",
+                        resp.status_code,
+                        ns,
+                        resp.text[:500],
+                    )
+                    return []
+
+                page = 1
+                for _ in range(_MAX_PAGES):
+                    if len(out) >= _MAX_REPOS:
+                        break
+                    try:
+                        if page == 1:
+                            r = resp
+                        else:
+                            params: dict[str, str | int] = {
+                                "page": page,
+                                "per_page": _PAGE_SIZE,
+                            }
+                            if is_group:
+                                params["include_subgroups"] = "true"
+                            r = client.get(list_url, params=params)
+                        if r.status_code in (404, 403):
+                            logger.warning(
+                                "GitLab API returned %s while listing %r: %s",
+                                r.status_code,
+                                ns,
+                                r.text[:500],
+                            )
+                            break
+                        r.raise_for_status()
+                        batch = r.json()
+                        if not isinstance(batch, list):
+                            logger.warning(
+                                "GitLab API returned non-list "
+                                "payload for %r",
+                                ns,
+                            )
+                            break
+                        for item in batch:
+                            if len(out) >= _MAX_REPOS:
+                                break
+                            if not isinstance(item, dict):
+                                continue
+                            repo = self._repo_from_json(item)
+                            if _passes_filters(
+                                repo,
+                                name_filter=name_filter,
+                                topic_filter=topic_filter,
+                                include_archived=include_archived,
+                            ):
+                                out.append(repo)
+                        next_page = r.headers.get("x-next-page", "").strip()
+                        if not next_page:
+                            break
+                        page = int(next_page)
+                    except httpx.HTTPError as exc:
+                        logger.warning(
+                            "GitLab API request failed for %r: %s", ns, exc
+                        )
+                        break
+                    except ValueError:
+                        logger.warning(
+                            "GitLab API invalid x-next-page for %r", ns
+                        )
+                        break
+        except httpx.HTTPError as exc:
+            logger.warning("GitLab API client error for %r: %s", ns, exc)
+        except (ValueError, TypeError, KeyError) as exc:
+            logger.warning(
+                "GitLab API response parse error for %r: %s",
+                ns,
+                exc,
+            )
+        return out
+
+
+def _bitbucket_https_clone(links: Any) -> str:
+    if not isinstance(links, dict):
+        return ""
+    clone = links.get("clone")
+    if not isinstance(clone, list):
+        return ""
+    https = ""
+    for entry in clone:
+        if not isinstance(entry, dict):
+            continue
+        href = entry.get("href")
+        name = entry.get("name")
+        if not isinstance(href, str):
+            continue
+        if name == "https":
+            return href
+        if href.startswith("https://"):
+            https = https or href
+    return https
+
+
+class BitbucketAdapter(RepoDiscovery):
+    """Discover repos from Bitbucket Cloud workspaces/projects."""
+
+    BASE = "https://api.bitbucket.org/2.0"
+
+    def __init__(self, token: str | None = None):
+        self._token = token
+        self._headers: dict[str, str] = {}
+        if token:
+            self._headers["Authorization"] = f"Bearer {token}"
+
+    def _repo_from_json(self, r: dict[str, Any]) -> RepoInfo:
+        links = r.get("links")
+        clone_url = _bitbucket_https_clone(links)
+        lang = r.get("language") or ""
+        if not isinstance(lang, str):
+            lang = str(lang)
+        desc = r.get("description") or ""
+        if not isinstance(desc, str):
+            desc = str(desc)
+        name = str(r.get("name") or "")
+        full_name = str(r.get("full_name") or name)
+        main = r.get("mainbranch")
+        branch = "main"
+        if isinstance(main, dict):
+            bn = main.get("name")
+            if isinstance(bn, str) and bn:
+                branch = bn
+        return RepoInfo(
+            name=name,
+            full_name=full_name,
+            clone_url=clone_url,
+            default_branch=branch,
+            topics=[],
+            language=lang,
+            description=desc,
+            is_archived=bool(r.get("archived")),
+        )
+
+    def list_repos(
+        self,
+        namespace: str,
+        *,
+        name_filter: str | None = None,
+        topic_filter: str | None = None,
+        include_archived: bool = False,
+    ) -> list[RepoInfo]:
+        if not namespace.strip():
+            return []
+        ws = namespace.strip()
+        enc = quote(ws, safe="")
+        out: list[RepoInfo] = []
+        try:
+            client_ctx = httpx.Client(
+                timeout=_CLIENT_TIMEOUT,
+                headers=self._headers,
+            )
+            with client_ctx as client:
+                url: str | None = (
+                    f"{self.BASE.rstrip('/')}/repositories/{enc}"
+                    f"?pagelen={_PAGE_SIZE}"
+                )
+                page_count = 0
+                while (
+                    url
+                    and page_count < _MAX_PAGES
+                    and len(out) < _MAX_REPOS
+                ):
+                    try:
+                        resp = client.get(url)
+                        if resp.status_code in (404, 403):
+                            logger.warning(
+                                "Bitbucket API returned %s for "
+                                "workspace %r: %s",
+                                resp.status_code,
+                                ws,
+                                resp.text[:500],
+                            )
+                            if page_count == 0:
+                                return out
+                            break
+                        resp.raise_for_status()
+                        data = resp.json()
+                        if not isinstance(data, dict):
+                            logger.warning(
+                                "Bitbucket API returned non-object "
+                                "payload for %r",
+                                ws,
+                            )
+                            break
+                        values = data.get("values")
+                        if not isinstance(values, list):
+                            logger.warning(
+                                "Bitbucket API missing values list "
+                                "for %r",
+                                ws,
+                            )
+                            break
+                        for item in values:
+                            if len(out) >= _MAX_REPOS:
+                                break
+                            if not isinstance(item, dict):
+                                continue
+                            repo = self._repo_from_json(item)
+                            if _passes_filters(
+                                repo,
+                                name_filter=name_filter,
+                                topic_filter=topic_filter,
+                                include_archived=include_archived,
+                            ):
+                                out.append(repo)
+                        page_count += 1
+                        nxt = data.get("next")
+                        url = nxt if isinstance(nxt, str) else None
+                    except httpx.HTTPError as exc:
+                        logger.warning(
+                            "Bitbucket API request failed for %r: %s", ws, exc
+                        )
+                        break
+        except httpx.HTTPError as exc:
+            logger.warning("Bitbucket API client error for %r: %s", ws, exc)
+        except (ValueError, TypeError, KeyError) as exc:
+            logger.warning(
+                "Bitbucket API response parse error for %r: %s", ws, exc
+            )
+        return out
+
+
+def get_adapter(
+    platform: str,
+    token: str | None = None,
+    base_url: str | None = None,
+) -> RepoDiscovery:
+    """Return an adapter for the given platform name."""
+    p = platform.lower()
+    if p in ("github", "gh"):
+        return GitHubAdapter(token=token, base_url=base_url)
+    if p in ("gitlab", "gl"):
+        return GitLabAdapter(token=token, base_url=base_url)
+    if p in ("bitbucket", "bb"):
+        return BitbucketAdapter(token=token)
+    raise ValueError(f"Unknown platform: {platform!r}")

--- a/aibom/src/aibom/scan_pipeline.py
+++ b/aibom/src/aibom/scan_pipeline.py
@@ -1,0 +1,218 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Orchestrates the four-stage v2 scan pipeline.
+
+Stages:
+  1. **Scan** — run all registered scanners (Tier 1 + Tier 2 EnvVarResolver).
+  2. **Cross-ref** — build env/package index, resolve env-var components.
+  3. **Agentic** — optionally enrich with LLM reasoning (if ``llm_config``).
+  4. **Assemble** — apply ``--strict`` filtering, collect counts.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from .cross_ref import (
+    CrossRefIndex,
+    ExternalRepoDep,
+    build_env_index,
+    build_package_index,
+    detect_external_repo_deps,
+    resolve_components,
+)
+from .models import ScanContext
+from .models.scan import AIComponent, ComponentRelationship
+from .scanners import run_scanners
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class PipelineResult:
+    """Outcome of a single-source pipeline run."""
+
+    components: list[AIComponent] = field(default_factory=list)
+    relationships: list[ComponentRelationship] = field(default_factory=list)
+    agentic_risk_flags: list[Any] = field(default_factory=list)
+    agentic_candidate_count: int = 0
+    env_index: CrossRefIndex | None = None
+    pkg_index: CrossRefIndex | None = None
+    external_deps: list[ExternalRepoDep] = field(default_factory=list)
+
+
+class ScanPipeline:
+    """Four-stage v2 scan pipeline wired into a single ``run()`` call."""
+
+    def __init__(
+        self,
+        scan_paths: list[str],
+        *,
+        output_format: str = "json",
+        output_file: str | None = None,
+        llm_config: dict[str, Any] | None = None,
+        kb_path: str | None = None,
+        fail_on: Any | None = None,
+        min_severity: Any | None = None,
+        strict: bool = False,
+        exclude_patterns: list[str] | None = None,
+    ) -> None:
+        self.scan_paths = scan_paths
+        self.output_format = output_format
+        self.output_file = output_file
+        self.llm_config = llm_config
+        self.kb_path = kb_path
+        self.fail_on = fail_on
+        self.min_severity = min_severity
+        self.strict = strict
+        self.exclude_patterns = exclude_patterns or []
+
+    def run(self) -> PipelineResult:
+        ctx_kwargs: dict[str, Any] = {
+            "paths": self.scan_paths,
+            "output_format": self.output_format,
+            "exclude_patterns": self.exclude_patterns,
+        }
+        if self.output_file is not None:
+            ctx_kwargs["output_file"] = self.output_file
+        if self.llm_config is not None:
+            ctx_kwargs["llm_config"] = self.llm_config
+        if self.kb_path is not None:
+            ctx_kwargs["kb_path"] = self.kb_path
+        if self.fail_on is not None:
+            ctx_kwargs["fail_on"] = self.fail_on
+        if self.min_severity is not None:
+            ctx_kwargs["min_severity"] = self.min_severity
+        ctx = ScanContext(**ctx_kwargs)
+
+        components, relationships = self._stage_scan(ctx)
+        components, env_idx, pkg_idx, ext_deps = self._stage_cross_ref(
+            components
+        )
+        components, relationships, agentic_flags = self._stage_agentic(
+            components, relationships
+        )
+        components, agentic_count = self._stage_assemble(components)
+
+        return PipelineResult(
+            components=components,
+            relationships=relationships,
+            agentic_risk_flags=agentic_flags,
+            agentic_candidate_count=agentic_count,
+            env_index=env_idx,
+            pkg_index=pkg_idx,
+            external_deps=ext_deps,
+        )
+
+    # ------------------------------------------------------------------
+    # Stage 1: Run all registered scanners
+    # ------------------------------------------------------------------
+
+    def _stage_scan(
+        self, ctx: ScanContext
+    ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+        _LOGGER.info("Stage 1/4 — scanning %d path(s)", len(self.scan_paths))
+        return run_scanners(ctx)
+
+    # ------------------------------------------------------------------
+    # Stage 2: Cross-reference resolution
+    # ------------------------------------------------------------------
+
+    def _stage_cross_ref(
+        self, components: list[AIComponent]
+    ) -> tuple[list[AIComponent], CrossRefIndex, CrossRefIndex, list[ExternalRepoDep]]:
+        _LOGGER.info("Stage 2/4 — cross-reference resolution")
+        env_idx = build_env_index(self.scan_paths)
+        pkg_idx = build_package_index(self.scan_paths)
+
+        _LOGGER.debug(
+            "Cross-ref index: %d env vars, %d packages",
+            sum(len(v) for v in env_idx.env.values()),
+            len(pkg_idx.packages),
+        )
+
+        resolved = resolve_components(components, env_idx)
+
+        ext_deps = detect_external_repo_deps(self.scan_paths)
+        if ext_deps:
+            _LOGGER.info(
+                "Detected %d external repo dependency(ies)", len(ext_deps)
+            )
+            escaping = [d for d in ext_deps if d.escapes_root]
+            if escaping:
+                _LOGGER.warning(
+                    "%d dependency(ies) reference paths outside scanned repos",
+                    len(escaping),
+                )
+
+        return resolved, env_idx, pkg_idx, ext_deps
+
+    # ------------------------------------------------------------------
+    # Stage 3: Agentic enrichment (optional)
+    # ------------------------------------------------------------------
+
+    def _stage_agentic(
+        self,
+        components: list[AIComponent],
+        relationships: list[ComponentRelationship],
+    ) -> tuple[list[AIComponent], list[ComponentRelationship], list[Any]]:
+        if not self.llm_config or not components:
+            return components, relationships, []
+
+        _LOGGER.info("Stage 3/4 — agentic enrichment")
+        try:
+            from .agentic.agent import run_agentic_enrichment
+
+            model_str = self.llm_config["model"]
+            components, agentic_rels, agentic_flags = run_agentic_enrichment(
+                model_string=model_str,
+                deterministic_components=components,
+                deterministic_relationships=relationships,
+                scan_paths=self.scan_paths,
+                llm_config=self.llm_config,
+            )
+            relationships = relationships + agentic_rels
+            return components, relationships, agentic_flags
+
+        except ImportError:
+            _LOGGER.warning(
+                "Agentic enrichment requires 'cisco-aibom[agentic]'. Skipping."
+            )
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.warning("Agentic enrichment failed: %s", exc)
+
+        return components, relationships, []
+
+    # ------------------------------------------------------------------
+    # Stage 4: Assemble — apply strict filtering, count agentic candidates
+    # ------------------------------------------------------------------
+
+    def _stage_assemble(
+        self, components: list[AIComponent]
+    ) -> tuple[list[AIComponent], int]:
+        _LOGGER.info("Stage 4/4 — assembling results")
+        agentic_count = sum(1 for c in components if c.needs_agentic)
+
+        if self.strict:
+            components = [c for c in components if not c.needs_agentic]
+            _LOGGER.info(
+                "Strict mode: filtered %d agentic candidates", agentic_count
+            )
+
+        return components, agentic_count

--- a/aibom/src/aibom/scanners/__init__.py
+++ b/aibom/src/aibom/scanners/__init__.py
@@ -16,7 +16,9 @@
 
 from .base import BaseScanner, scanner_registry, run_scanners
 from .config_scanner import ConfigScanner
+from .deployment_detector import DeploymentDetector
 from .dependency_scanner import DependencyScanner
+from .env_var_resolver import EnvVarResolver
 from .kb_enrichment_scanner import KBEnrichmentScanner
 from .mcp_detector import McpDetector
 from .ml_lifecycle_detector import MLLifecycleDetector
@@ -39,7 +41,9 @@ __all__ = [
     "BaseScanner",
     "BaseVulnProvider",
     "ConfigScanner",
+    "DeploymentDetector",
     "DependencyScanner",
+    "EnvVarResolver",
     "GrypeProvider",
     "KBEnrichmentScanner",
     "McpDetector",

--- a/aibom/src/aibom/scanners/config_scanner.py
+++ b/aibom/src/aibom/scanners/config_scanner.py
@@ -53,9 +53,34 @@ _ENV_LINE = re.compile(
 )
 
 _MODEL_NAME_RE = re.compile(
-    r"(?i)^(gpt-|claude-|o\d|gemini-|mistral|meta-llama|llama[-_]?[0-9]|text-embedding|"
-    r"command-|jamba-|cohere|azure/|models/|[a-z0-9][a-z0-9_.-]{0,40}/[a-z0-9_.-]+)"
+    r"(?i)^(gpt-|claude-|o[1-9]-|gemini-|mistral|meta-llama|llama[-_]?[0-9]|text-embedding|"
+    r"command-|jamba-|cohere|azure/|anthropic\.|amazon\.|models/|"
+    r"(?:(?:meta-llama|mistralai|google|openai|microsoft|nvidia|huggingface|"
+    r"sentence-transformers|bigscience|stabilityai|deepseek|qwen|tiiuae|"
+    r"databricks|together|cohere|anthropic)/[a-zA-Z0-9_.-]+))"
 )
+
+_NOT_MODEL_RE = re.compile(
+    r"(?i)"
+    r"(\.com/|\.io/|\.org/|\.dev/|dkr\.ecr|"
+    r"\.yaml$|\.yml$|\.json$|\.py$|\.tf$|\.crt$|\.key$|\.pem$|\.sh$|"
+    r"^arn:|^https?://|^ssh://|^git@|"
+    r"kubernetes\.io/|helm\.sh/|"
+    r"^actions/|@v\d+$|"
+    r"/secrets?/|/configmaps?/|/templates?/|"
+    r"^envoyproxy/|^nginx/|^redis/|^postgres/|^mysql/|^mongo)"
+)
+
+
+def _is_model_name(value: str) -> bool:
+    if not value or len(value) > 120:
+        return False
+    stripped = value.strip()
+    if not _MODEL_NAME_RE.match(stripped):
+        return False
+    if _NOT_MODEL_RE.search(stripped):
+        return False
+    return True
 
 _FROM_RE = re.compile(r"^\s*FROM\s+(--platform=\S+\s+)?(\S+)", re.IGNORECASE)
 _ENV_RE = re.compile(
@@ -168,11 +193,13 @@ def _looks_like_model_name(value: str) -> bool:
     v = value.strip().strip("\"'")
     if not v or len(v) > 256:
         return False
-    if v.startswith("http://") or v.startswith("https://"):
-        return False
-    if _MODEL_NAME_RE.match(v):
-        return True
-    if "/" in v and re.match(r"^[a-z0-9_.-]+/[a-zA-Z0-9_.-]+$", v):
+    try:
+        from .model_detector import _registry_lookup
+        if _registry_lookup(v) is not None:
+            return True
+    except ImportError:
+        pass
+    if _is_model_name(v):
         return True
     return False
 

--- a/aibom/src/aibom/scanners/deployment_detector.py
+++ b/aibom/src/aibom/scanners/deployment_detector.py
@@ -1,0 +1,1126 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml  # type: ignore[import-untyped]
+from pathspec import PathSpec
+
+from ..models import AIComponent, ComponentRelationship, ScanContext
+from ..models.enums import AIComponentType, DetectionSource
+from .base import BaseScanner
+
+_LOGGER = logging.getLogger(__name__)
+
+_SKIP_DIR_NAMES = frozenset(
+    {"node_modules", ".git", ".venv", "venv", "__pycache__", ".tox"}
+)
+
+_AWS_AI_RESOURCES: frozenset[str] = frozenset(
+    {
+        "AWS::SageMaker::Endpoint",
+        "AWS::SageMaker::Model",
+        "AWS::SageMaker::NotebookInstance",
+        "AWS::SageMaker::EndpointConfig",
+        "AWS::Bedrock::Agent",
+        "AWS::Bedrock::Guardrail",
+        "AWS::Bedrock::KnowledgeBase",
+        "AWS::Bedrock::DataSource",
+        "aws_sagemaker_endpoint",
+        "aws_sagemaker_model",
+        "aws_sagemaker_endpoint_configuration",
+        "aws_sagemaker_notebook_instance",
+        "aws_bedrock_agent_agent",
+        "aws_bedrock_guardrail",
+        "aws_bedrock_knowledge_base",
+        "aws_bedrockagent_data_source",
+    }
+)
+
+_AZURE_AI_RESOURCES: frozenset[str] = frozenset(
+    {
+        "Microsoft.CognitiveServices/accounts",
+        "Microsoft.MachineLearningServices/workspaces",
+        "Microsoft.MachineLearningServices/workspaces/onlineEndpoints",
+        "Microsoft.MachineLearningServices/workspaces/computes",
+        "azurerm_cognitive_account",
+        "azurerm_machine_learning_workspace",
+        "azurerm_machine_learning_online_endpoint",
+        "azurerm_machine_learning_compute_instance",
+    }
+)
+
+_GCP_AI_RESOURCES: frozenset[str] = frozenset(
+    {
+        "google_vertex_ai_endpoint",
+        "google_vertex_ai_featurestore",
+        "google_ml_engine_model",
+        "google_notebooks_instance",
+    }
+)
+
+_ALL_TF_AI_RESOURCES = _AWS_AI_RESOURCES | _AZURE_AI_RESOURCES | _GCP_AI_RESOURCES
+
+_GPU_INSTANCE_RE = re.compile(
+    r"(?i)(ml\.(p[345]d?|g[456]|trn1|inf[12])\.\w+|"
+    r"Standard_N[CDV]\w+|"
+    r"a2-(ultra|mega|high)gpu-\w+|n1-\w+-gpu\w*|"
+    r"g2-standard-\w+)"
+)
+
+_AI_CONTAINER_IMAGES: tuple[str, ...] = (
+    "ollama/ollama",
+    "vllm/vllm-openai",
+    "vllm/vllm",
+    "ghcr.io/huggingface/text-generation-inference",
+    "nvcr.io/nvidia/tritonserver",
+    "nvcr.io/nvidia/tensorrt",
+    "localai/localai",
+    "bentoml/",
+    "sagemaker-",
+    "huggingface-pytorch-",
+    "huggingface-tensorflow-",
+)
+
+_MODEL_NAME_RE = re.compile(
+    r"(?i)^(gpt-|claude-|o[1-9]-|gemini-|mistral|meta-llama|llama[-_]?[0-9]|"
+    r"text-embedding|command-|jamba-|cohere|anthropic\.|amazon\.|"
+    r"models/|"
+    r"(?:(?:meta-llama|mistralai|google|openai|microsoft|nvidia|huggingface|"
+    r"sentence-transformers|bigscience|stabilityai|deepseek|qwen|tiiuae|"
+    r"databricks|together|cohere|anthropic)/[a-zA-Z0-9_.-]+))"
+)
+
+_NOT_MODEL_RE = re.compile(
+    r"(?i)"
+    r"(\.com/|\.io/|\.org/|\.dev/|dkr\.ecr|"  # Docker registry domains
+    r"\.yaml$|\.yml$|\.json$|\.py$|\.tf$|\.crt$|\.key$|\.pem$|\.sh$|"  # file extensions
+    r"^arn:|^https?://|^ssh://|^git@|"  # URIs and ARNs
+    r"kubernetes\.io/|helm\.sh/|"  # K8s labels
+    r"^actions/|@v\d+$|"  # GitHub Actions
+    r"/secrets?/|/configmaps?/|/templates?/|"  # K8s resource paths
+    r"^envoyproxy/|^nginx/|^redis/|^postgres/|^mysql/|^mongo)"  # known non-AI images
+)
+
+
+def _is_known_model(value: str) -> bool:
+    """Check if a string is a known model ID using the model registry (LiteLLM + HF + builtin)."""
+    if not value or len(value) > 256:
+        return False
+    stripped = value.strip()
+    if _NOT_MODEL_RE.search(stripped):
+        return False
+    from .model_detector import _registry_lookup
+    return _registry_lookup(stripped) is not None
+
+_AI_ENV_NAMES: frozenset[str] = frozenset(
+    {
+        "MODEL_NAME",
+        "MODEL_ID",
+        "MODEL_PATH",
+        "MODEL_ENDPOINT",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "HUGGINGFACE_TOKEN",
+        "HF_TOKEN",
+        "COHERE_API_KEY",
+        "MISTRAL_API_KEY",
+        "AWS_SAGEMAKER_ENDPOINT",
+        "AZURE_OPENAI_ENDPOINT",
+        "AZURE_OPENAI_API_KEY",
+        "GOOGLE_AI_API_KEY",
+        "EMBEDDING_MODEL",
+        "LLM_MODEL",
+        "INFERENCE_ENDPOINT",
+    }
+)
+
+_SECRET_ENV_NAMES: frozenset[str] = frozenset(
+    {
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "HUGGINGFACE_TOKEN",
+        "HF_TOKEN",
+        "COHERE_API_KEY",
+        "MISTRAL_API_KEY",
+        "AZURE_OPENAI_API_KEY",
+        "GOOGLE_AI_API_KEY",
+    }
+)
+
+_TRAINING_IMAGE_HINTS: tuple[str, ...] = (
+    "huggingface",
+    "sagemaker",
+    "pytorch",
+    "tensorflow",
+    "training",
+)
+
+_K8S_WORKLOAD_KINDS = frozenset({"Deployment", "StatefulSet", "Job", "CronJob"})
+
+_TF_RESOURCE_RE = re.compile(r'resource\s+"([^"]+)"\s+"([^"]+)"', re.MULTILINE)
+_TF_VARIABLE_RE = re.compile(
+    r'variable\s+"([^"]+)"\s*\{[^}]*default\s*=\s*"([^"]*)"', re.DOTALL
+)
+_TF_STRING_ASSIGN_RE = re.compile(
+    r"(?m)^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*\"([^\"]*)\""
+)
+_TF_LOCALS_RE = re.compile(r"(?m)^\s*locals\s*\{")
+
+_BICEP_RESOURCE_RE = re.compile(r"resource\s+\w+\s+'([^']+)'", re.MULTILINE)
+_BICEP_PARAM_RE = re.compile(r"param\s+(\w+)\s+\w+\s*=\s*'([^']*)'", re.MULTILINE)
+
+
+_MODEL_KEY_HINTS = frozenset({
+    "model", "model_name", "model_id", "llm_model", "llm",
+    "deployment", "engine", "embedding", "embedding_model",
+    "default_model", "chat_model", "completion_model",
+})
+
+
+def _helm_key_suggests_model(key_path: str) -> bool:
+    parts = key_path.lower().replace("-", "_").split(".")
+    return any(p in _MODEL_KEY_HINTS for p in parts)
+
+
+_AZURE_DEPLOY_KEY_RE = re.compile(r"(?i)azure", re.IGNORECASE)
+_AZURE_ENGINE_TAIL_RE = re.compile(r"(?i)\.(engine|deployment|deployment_name)$")
+
+
+def _azure_deployment_hint(key_path: str, value: str) -> str:
+    """Return a richer agentic hint when the key path looks like an Azure deployment name."""
+    if _AZURE_DEPLOY_KEY_RE.search(key_path) and _AZURE_ENGINE_TAIL_RE.search(key_path):
+        return (
+            f"'{value}' is an Azure OpenAI deployment name (key '{key_path}'); "
+            f"the actual model behind this deployment cannot be determined "
+            f"without Azure API access or manual confirmation"
+        )
+    return f"Value '{value}' under key '{key_path}' may be model name"
+
+
+def _emit(
+    name: str,
+    comp_type: AIComponentType,
+    file_path: str,
+    line_number: int,
+    *,
+    framework: str = "",
+    model_name: str | None = None,
+    description: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    confidence: float = 1.0,
+    needs_agentic: bool = False,
+    agentic_hint: str = "",
+) -> AIComponent:
+    return AIComponent(
+        name=name,
+        component_type=comp_type,
+        file_path=file_path,
+        line_number=line_number,
+        framework=framework,
+        detection_source=DetectionSource.CONFIG_FILE,
+        model_name=model_name,
+        description=description,
+        metadata=metadata or {},
+        confidence=confidence,
+        needs_agentic=needs_agentic,
+        agentic_hint=agentic_hint,
+    )
+
+
+def _line_for_needle(content: str, needle: str) -> int:
+    idx = content.find(needle)
+    if idx < 0:
+        return 1
+    return content.count("\n", 0, idx) + 1
+
+
+def _line_at_offset(content: str, offset: int) -> int:
+    if offset < 0 or offset > len(content):
+        return 1
+    return content.count("\n", 0, offset) + 1
+
+
+def _build_pathspec(patterns: list[str]) -> Optional[PathSpec]:
+    if not patterns:
+        return None
+    return PathSpec.from_lines("gitwildmatch", patterns)
+
+
+def _is_excluded(abs_file: Path, root: Path, spec: Optional[PathSpec]) -> bool:
+    if not spec:
+        return False
+    try:
+        rel = abs_file.relative_to(root).as_posix()
+    except ValueError:
+        rel = abs_file.as_posix()
+    return spec.match_file(rel)
+
+
+def _path_has_skip_segment(path: Path, root: Path) -> bool:
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        return False
+    return any(p in _SKIP_DIR_NAMES for p in rel.parts[:-1])
+
+
+def _iter_target_files(context: ScanContext) -> Iterator[tuple[Path, Path]]:
+    spec = _build_pathspec(context.exclude_patterns)
+    for scan_root in context.paths:
+        root = Path(scan_root)
+        if not root.exists():
+            continue
+        base = root if root.is_dir() else root.parent
+        if root.is_file():
+            if not _is_excluded(root, base, spec):
+                yield root, base
+            continue
+        base = root.resolve()
+        for f in root.rglob("*"):
+            if not f.is_file():
+                continue
+            if _path_has_skip_segment(f, root):
+                continue
+            if _is_excluded(f, root, spec):
+                continue
+            yield f, root
+
+
+def _image_matches_ai(image: str) -> bool:
+    li = image.lower()
+    for m in _AI_CONTAINER_IMAGES:
+        ml = m.lower()
+        if ml.endswith("/"):
+            if ml in li:
+                return True
+        elif li.startswith(ml) or ml in li:
+            return True
+    return False
+
+
+def _is_training_image_hint(image: str) -> bool:
+    li = image.lower()
+    return any(h in li for h in _TRAINING_IMAGE_HINTS)
+
+
+def _dedup(components: list[AIComponent]) -> list[AIComponent]:
+    seen: set[tuple[str, int, str]] = set()
+    out: list[AIComponent] = []
+    for c in components:
+        key = (c.file_path, c.line_number, c.name)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(c)
+    return out
+
+
+def _balance_braces(text: str, open_idx: int) -> tuple[str, int]:
+    depth = 0
+    j = open_idx
+    while j < len(text):
+        c = text[j]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_idx : j + 1], j + 1
+        j += 1
+    return text[open_idx:], len(text)
+
+
+def _bicep_resource_type(raw: str) -> str:
+    if "@" in raw:
+        return raw.split("@", 1)[0].strip()
+    return raw.strip()
+
+
+def _is_cloudformation(data: dict[str, Any]) -> bool:
+    if "AWSTemplateFormatVersion" in data:
+        return True
+    res = data.get("Resources")
+    if isinstance(res, dict):
+        for v in res.values():
+            if not isinstance(v, dict):
+                continue
+            t = v.get("Type", "")
+            if isinstance(t, str) and t.startswith("AWS::"):
+                return True
+    return False
+
+
+def _is_arm_template(data: dict[str, Any]) -> bool:
+    schema = data.get("$schema", "")
+    return isinstance(schema, str) and "deploymenttemplate" in schema.lower()
+
+
+def _is_helm_values_filename(name: str) -> bool:
+    n = name.lower()
+    if n == "values.yaml" or n == "values.yml":
+        return True
+    return (n.startswith("values-") and n.endswith((".yaml", ".yml")))
+
+
+def _is_kubernetes_yaml(content: str, data: Any) -> bool:
+    if not isinstance(data, dict):
+        return False
+    if "apiVersion" in data and "kind" in data:
+        return True
+    if "apiVersion" in content and "kind:" in content:
+        return True
+    return False
+
+
+def _classify_yaml_json(
+    path: Path, content: str, data: dict[str, Any]
+) -> Optional[str]:
+    name = path.name.lower()
+    if _is_helm_values_filename(name):
+        return "helm"
+    if _is_cloudformation(data):
+        return "cloudformation"
+    if _is_arm_template(data):
+        return "arm"
+    if _is_kubernetes_yaml(content, data):
+        return "k8s"
+    if name in ("kustomization.yaml", "kustomization.yml"):
+        return "k8s"
+    return None
+
+
+def _neutralize_cfn_yaml_intrinsics(yaml_text: str) -> str:
+    t = re.sub(r"!Ref\s+\w+", '"__Ref__"', yaml_text)
+    t = re.sub(r"!GetAtt\s+[\w.]+\s+\w+", '"__GetAtt__"', t)
+    return t
+
+
+def _safe_yaml_documents(content: str) -> list[Any]:
+    def _load_all(raw: str) -> list[Any]:
+        return [d for d in yaml.safe_load_all(raw) if d is not None]
+
+    cfnish = "AWSTemplateFormatVersion" in content or (
+        "Resources:" in content and "AWS::" in content
+    )
+    if cfnish:
+        try:
+            return _load_all(_neutralize_cfn_yaml_intrinsics(content))
+        except yaml.YAMLError as e:
+            _LOGGER.debug("YAML parse error (cfn neutralized): %s", e)
+    try:
+        return _load_all(content)
+    except yaml.YAMLError as e:
+        _LOGGER.debug("YAML parse error: %s", e)
+        return []
+
+
+def _parse_k8s_yaml(
+    file_path: Path, data: dict[str, Any], raw: str = ""
+) -> list[AIComponent]:
+    fp = str(file_path)
+    out: list[AIComponent] = []
+    kind = data.get("kind")
+    if not isinstance(kind, str):
+        return out
+
+    if kind == "Service":
+        meta = data.get("metadata") or {}
+        ann = meta.get("annotations") or {}
+        if isinstance(ann, dict):
+            for ak, av in ann.items():
+                if isinstance(av, str) and _is_known_model(av):
+                    ln = _line_for_needle(raw, av) if raw else 1
+                    out.append(
+                        _emit(
+                            av.strip()[:120],
+                            AIComponentType.MODEL,
+                            fp,
+                            ln,
+                            model_name=av.strip(),
+                            metadata={"annotation": str(ak)},
+                            confidence=0.95,
+                        )
+                    )
+        return out
+
+    if kind in ("ConfigMap", "Secret"):
+        blobs: list[dict[str, Any]] = []
+        for key in ("data", "stringData"):
+            b = data.get(key)
+            if isinstance(b, dict):
+                blobs.append(b)
+        for blob in blobs:
+            for ek, ev in blob.items():
+                if not isinstance(ek, str):
+                    continue
+                if ek in _AI_ENV_NAMES and isinstance(ev, str) and ev.strip():
+                    ln = _line_for_needle(raw, ev) if raw else 1
+                    comp_type = (
+                        AIComponentType.SECRET
+                        if ek in _SECRET_ENV_NAMES
+                        else AIComponentType.MODEL
+                    )
+                    out.append(
+                        _emit(
+                            f"env:{ek}",
+                            comp_type,
+                            fp,
+                            ln,
+                            model_name=ev.strip() if comp_type == AIComponentType.MODEL else None,
+                            metadata={"config_key": ek},
+                        )
+                    )
+                if isinstance(ev, str):
+                    stripped = ev.strip()
+                    if _is_known_model(stripped):
+                        ln = _line_for_needle(raw, ev) if raw else 1
+                        out.append(
+                            _emit(
+                                stripped[:120],
+                                AIComponentType.MODEL,
+                                fp,
+                                ln,
+                                model_name=stripped,
+                                metadata={"config_key": ek},
+                                confidence=0.95,
+                            )
+                        )
+        return out
+
+    if kind in _K8S_WORKLOAD_KINDS:
+        spec = data.get("spec") or {}
+        template = spec.get("template") or spec
+        pod_spec = template.get("spec") or {}
+        containers: list[dict[str, Any]] = []
+        for c in pod_spec.get("containers") or []:
+            if isinstance(c, dict):
+                containers.append(c)
+        for c in pod_spec.get("initContainers") or []:
+            if isinstance(c, dict):
+                containers.append(c)
+
+        for container in containers:
+            image = container.get("image", "")
+            res = container.get("resources") or {}
+            limits = res.get("limits") or {}
+            gpu_meta: dict[str, Any] = {}
+            if isinstance(limits, dict):
+                for gk, gv in limits.items():
+                    if isinstance(gk, str) and gk in ("nvidia.com/gpu", "amd.com/gpu"):
+                        gpu_meta["gpu"] = str(gv)
+                        gpu_meta["accelerator"] = (
+                            "nvidia" if "nvidia" in gk.lower() else "amd"
+                        )
+            if isinstance(image, str) and _image_matches_ai(image):
+                ln = _line_for_needle(raw, image) if raw else 1
+                meta = {"container": container.get("name", ""), "image": image}
+                meta.update(gpu_meta)
+                out.append(
+                    _emit(
+                        image[:200],
+                        AIComponentType.DEPENDENCY,
+                        fp,
+                        ln,
+                        metadata=meta,
+                    )
+                )
+            for ent in container.get("env") or []:
+                if not isinstance(ent, dict):
+                    continue
+                ename = ent.get("name", "")
+                if not isinstance(ename, str) or ename not in _AI_ENV_NAMES:
+                    continue
+                val = ent.get("value", "")
+                if not isinstance(val, str):
+                    val = ""
+                comp_type = (
+                    AIComponentType.SECRET
+                    if ename in _SECRET_ENV_NAMES
+                    else AIComponentType.MODEL
+                )
+                ln = _line_for_needle(raw, ename) if raw else 1
+                out.append(
+                    _emit(
+                        f"env:{ename}",
+                        comp_type,
+                        fp,
+                        ln,
+                        model_name=val.strip() or None if comp_type == AIComponentType.MODEL else None,
+                        metadata={"env": ename},
+                    )
+                )
+            limits_check = res.get("limits") or {}
+            gpu = False
+            for gk in limits_check:
+                if isinstance(gk, str) and gk in ("nvidia.com/gpu", "amd.com/gpu"):
+                    gpu = True
+                    break
+            if isinstance(image, str) and gpu and _is_training_image_hint(image):
+                if kind in ("Job", "CronJob"):
+                    ln = _line_for_needle(raw, image) if raw else 1
+                    out.append(
+                        _emit(
+                            f"training:{container.get('name', 'job')}",
+                            AIComponentType.TRAINING_RUN,
+                            fp,
+                            ln,
+                            metadata={"image": image, "kind": kind},
+                        )
+                    )
+
+    return out
+
+
+def _walk_helm_values(
+    obj: Any,
+    file_path: str,
+    out: list[AIComponent],
+    key_path: str = "",
+) -> None:
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if not isinstance(k, str):
+                continue
+            lk = k.lower()
+            sub = f"{key_path}.{k}" if key_path else k
+            if isinstance(v, str):
+                stripped = v.strip()
+                if _image_matches_ai(v):
+                    out.append(
+                        _emit(
+                            v[:200],
+                            AIComponentType.DEPENDENCY,
+                            file_path,
+                            1,
+                            metadata={"helm_key": sub, "image": v},
+                        )
+                    )
+                elif _is_known_model(stripped):
+                    out.append(
+                        _emit(
+                            stripped[:120],
+                            AIComponentType.MODEL,
+                            file_path,
+                            1,
+                            model_name=stripped,
+                            metadata={"helm_key": sub},
+                            confidence=0.95,
+                        )
+                    )
+                elif _helm_key_suggests_model(sub) and stripped and len(stripped) < 120:
+                    hint = _azure_deployment_hint(sub, stripped)
+                    out.append(
+                        _emit(
+                            stripped[:120],
+                            AIComponentType.MODEL,
+                            file_path,
+                            1,
+                            model_name=stripped,
+                            metadata={"helm_key": sub},
+                            confidence=0.5,
+                            needs_agentic=True,
+                            agentic_hint=hint,
+                        )
+                    )
+            elif lk == "gpu" and isinstance(v, int) and v > 0:
+                out.append(
+                    _emit(
+                        f"gpu:{sub}",
+                        AIComponentType.TRAINING_RUN,
+                        file_path,
+                        1,
+                        metadata={"gpu_count": v, "helm_key": sub},
+                    )
+                )
+            elif isinstance(v, (dict, list)):
+                _walk_helm_values(v, file_path, out, sub)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            _walk_helm_values(item, file_path, out, f"{key_path}[{i}]")
+
+
+def _parse_helm_values(file_path: Path, data: dict[str, Any]) -> list[AIComponent]:
+    out: list[AIComponent] = []
+    _walk_helm_values(data, str(file_path), out)
+    return out
+
+
+def _parse_terraform_resource_block(
+    rtype: str,
+    rname: str,
+    block: str,
+    file_path: str,
+    full_content: str,
+    block_start: int,
+    header_line: int,
+) -> list[AIComponent]:
+    out: list[AIComponent] = []
+    if rtype not in _ALL_TF_AI_RESOURCES:
+        return out
+    meta = {"terraform_resource_type": rtype, "terraform_resource_name": rname}
+    out.append(
+        _emit(
+            f"{rtype}.{rname}",
+            AIComponentType.OTHER,
+            file_path,
+            header_line,
+            description=f"Terraform resource {rtype}",
+            metadata=meta,
+        )
+    )
+    for m in _TF_STRING_ASSIGN_RE.finditer(block):
+        key, val = m.group(1), m.group(2)
+        lk = key.lower()
+        abs_off = block_start + m.start()
+        ln = _line_at_offset(full_content, abs_off)
+        if lk in ("model_id", "model_name", "model_data_url") and val.strip():
+            out.append(
+                _emit(
+                    val[:120],
+                    AIComponentType.MODEL,
+                    file_path,
+                    ln,
+                    model_name=val,
+                    metadata={**meta, "field": key},
+                )
+            )
+        if lk in ("image", "container_image") and val.strip() and _image_matches_ai(val):
+            out.append(
+                _emit(
+                    val[:200],
+                    AIComponentType.DEPENDENCY,
+                    file_path,
+                    ln,
+                    metadata={**meta, "field": key, "image": val},
+                )
+            )
+        if lk == "instance_type" and _GPU_INSTANCE_RE.search(val):
+            out.append(
+                _emit(
+                    f"gpu_instance:{val}",
+                    AIComponentType.TRAINING_RUN,
+                    file_path,
+                    ln,
+                    metadata={**meta, "instance_type": val},
+                )
+            )
+    return out
+
+
+def _parse_terraform_locals(content: str, file_path: str) -> list[AIComponent]:
+    out: list[AIComponent] = []
+    for lm in _TF_LOCALS_RE.finditer(content):
+        brace_idx = content.find("{", lm.start())
+        if brace_idx < 0:
+            continue
+        block, _ = _balance_braces(content, brace_idx)
+        for m in _TF_STRING_ASSIGN_RE.finditer(block):
+            key = m.group(1)
+            val = m.group(2)
+            lk = key.lower()
+            if not any(
+                x in lk for x in ("model", "image", "endpoint", "llm", "embedding", "gpu")
+            ):
+                continue
+            abs_off = brace_idx + m.start()
+            ln = _line_at_offset(content, abs_off)
+            known = _is_known_model(val)
+            if known:
+                out.append(
+                    _emit(
+                        val.strip()[:120],
+                        AIComponentType.MODEL,
+                        file_path,
+                        ln,
+                        model_name=val.strip(),
+                        metadata={"terraform_local": key},
+                        confidence=0.95,
+                    )
+                )
+            if _image_matches_ai(val):
+                out.append(
+                    _emit(
+                        val[:200],
+                        AIComponentType.DEPENDENCY,
+                        file_path,
+                        ln,
+                        metadata={"terraform_local": key, "image": val},
+                    )
+                )
+    return out
+
+
+def _parse_terraform(file_path: Path, content: str) -> list[AIComponent]:
+    fp = str(file_path)
+    out: list[AIComponent] = []
+    for m in _TF_RESOURCE_RE.finditer(content):
+        rtype, rname = m.group(1), m.group(2)
+        header_line = _line_at_offset(content, m.start())
+        brace_idx = content.find("{", m.end())
+        if brace_idx < 0:
+            continue
+        block, _ = _balance_braces(content, brace_idx)
+        out.extend(
+            _parse_terraform_resource_block(
+                rtype, rname, block, fp, content, brace_idx, header_line
+            )
+        )
+    for vm in _TF_VARIABLE_RE.finditer(content):
+        var_name, default_val = vm.group(1), vm.group(2)
+        known = _is_known_model(default_val)
+        if known:
+            ln = _line_for_needle(content, vm.group(0))
+            out.append(
+                _emit(
+                    default_val.strip()[:120],
+                    AIComponentType.MODEL,
+                    fp,
+                    ln,
+                    model_name=default_val.strip(),
+                    metadata={"terraform_variable": var_name},
+                    confidence=0.95,
+                )
+            )
+        if _image_matches_ai(default_val):
+            ln = _line_for_needle(content, vm.group(0))
+            out.append(
+                _emit(
+                    default_val[:200],
+                    AIComponentType.DEPENDENCY,
+                    fp,
+                    ln,
+                    metadata={"terraform_variable": var_name, "image": default_val},
+                )
+            )
+    out.extend(_parse_terraform_locals(content, fp))
+    return out
+
+
+def _walk_cfn_properties(
+    props: Any,
+    fp: str,
+    prefix: str,
+    out: list[AIComponent],
+) -> None:
+    if isinstance(props, dict):
+        for pk, pv in props.items():
+            if isinstance(pk, str) and pk.lower() in (
+                "modelid",
+                "model_id",
+                "modelname",
+                "model_name",
+            ):
+                if isinstance(pv, str) and pv.strip():
+                    out.append(
+                        _emit(
+                            pv.strip()[:120],
+                            AIComponentType.MODEL,
+                            fp,
+                            1,
+                            model_name=pv.strip(),
+                            metadata={"cfn_property": f"{prefix}.{pk}"},
+                        )
+                    )
+            if isinstance(pk, str) and pk.lower() in ("instancetype", "instance_type"):
+                if isinstance(pv, str) and _GPU_INSTANCE_RE.search(pv):
+                    out.append(
+                        _emit(
+                            f"gpu_instance:{pv}",
+                            AIComponentType.TRAINING_RUN,
+                            fp,
+                            1,
+                            metadata={"cfn_property": f"{prefix}.{pk}", "instance_type": pv},
+                        )
+                    )
+            if isinstance(pk, str) and "s3" in pk.lower() and isinstance(pv, str):
+                if pv.startswith("s3://") and "model" in pk.lower():
+                    out.append(
+                        _emit(
+                            pv[:200],
+                            AIComponentType.MODEL_ARTIFACT,
+                            fp,
+                            1,
+                            storage_uri=pv,
+                            metadata={"cfn_property": f"{prefix}.{pk}"},
+                        )
+                    )
+            _walk_cfn_properties(pv, fp, f"{prefix}.{pk}" if prefix else pk, out)
+    elif isinstance(props, list):
+        for i, item in enumerate(props):
+            _walk_cfn_properties(item, fp, f"{prefix}[{i}]", out)
+
+
+def _parse_cloudformation(file_path: Path, data: dict[str, Any]) -> list[AIComponent]:
+    fp = str(file_path)
+    out: list[AIComponent] = []
+    resources = data.get("Resources")
+    if isinstance(resources, dict):
+        for rid, rdef in resources.items():
+            if not isinstance(rdef, dict):
+                continue
+            rtype = rdef.get("Type", "")
+            if not isinstance(rtype, str) or rtype not in _AWS_AI_RESOURCES:
+                continue
+            out.append(
+                _emit(
+                    str(rid),
+                    AIComponentType.OTHER,
+                    fp,
+                    1,
+                    description=f"CloudFormation {rtype}",
+                    metadata={"cfn_type": rtype, "logical_id": rid},
+                )
+            )
+            props = rdef.get("Properties")
+            _walk_cfn_properties(props, fp, str(rid), out)
+
+    params = data.get("Parameters")
+    if isinstance(params, dict):
+        for pname, pdef in params.items():
+            if not isinstance(pdef, dict):
+                continue
+            default = pdef.get("Default")
+            if isinstance(default, str):
+                if _is_known_model(default):
+                    out.append(
+                        _emit(
+                            default.strip()[:120],
+                            AIComponentType.MODEL,
+                            fp,
+                            1,
+                            model_name=default.strip(),
+                            metadata={"cfn_parameter": str(pname)},
+                            confidence=0.95,
+                        )
+                    )
+    return out
+
+
+def _parse_arm_template(file_path: Path, data: dict[str, Any]) -> list[AIComponent]:
+    fp = str(file_path)
+    out: list[AIComponent] = []
+    resources = data.get("resources")
+    if isinstance(resources, list):
+        for res in resources:
+            if not isinstance(res, dict):
+                continue
+            rtype = res.get("type", "")
+            if not isinstance(rtype, str):
+                continue
+            base_type = rtype.split("@", 1)[0].strip()
+            if base_type not in _AZURE_AI_RESOURCES:
+                continue
+            name = res.get("name", "resource")
+            if not isinstance(name, str):
+                name = "resource"
+            out.append(
+                _emit(
+                    name,
+                    AIComponentType.OTHER,
+                    fp,
+                    1,
+                    description=f"ARM {base_type}",
+                    metadata={"arm_type": base_type},
+                )
+            )
+            props = res.get("properties") or {}
+            if base_type == "Microsoft.CognitiveServices/accounts" and isinstance(
+                props, dict
+            ):
+                deployments = props.get("deployments")
+                if isinstance(deployments, list):
+                    for dep in deployments:
+                        if not isinstance(dep, dict):
+                            continue
+                        model = dep.get("model")
+                        if isinstance(model, dict):
+                            mname = model.get("name") or model.get("format")
+                            if isinstance(mname, str) and _is_known_model(mname):
+                                out.append(
+                                    _emit(
+                                        mname.strip()[:120],
+                                        AIComponentType.MODEL,
+                                        fp,
+                                        1,
+                                        model_name=mname.strip(),
+                                        metadata={"arm_deployment": dep.get("name", "")},
+                                        confidence=0.95,
+                                    )
+                                )
+            if isinstance(props, dict):
+                sku = props.get("sku")
+                if isinstance(sku, dict):
+                    sname = sku.get("name", "")
+                    if isinstance(sname, str) and _GPU_INSTANCE_RE.search(sname):
+                        out.append(
+                            _emit(
+                                f"sku:{sname}",
+                                AIComponentType.TRAINING_RUN,
+                                fp,
+                                1,
+                                metadata={"arm_sku": sname},
+                            )
+                        )
+
+    parameters = data.get("parameters")
+    if isinstance(parameters, dict):
+        for pname, pdef in parameters.items():
+            if not isinstance(pdef, dict):
+                continue
+            default = pdef.get("defaultValue") or pdef.get("default")
+            if isinstance(default, str) and _is_known_model(default):
+                out.append(
+                    _emit(
+                        default.strip()[:120],
+                        AIComponentType.MODEL,
+                        fp,
+                        1,
+                        model_name=default.strip(),
+                        metadata={"arm_parameter": str(pname)},
+                        confidence=0.95,
+                    )
+                )
+    return out
+
+
+def _parse_bicep(file_path: Path, content: str) -> list[AIComponent]:
+    fp = str(file_path)
+    out: list[AIComponent] = []
+    for m in _BICEP_RESOURCE_RE.finditer(content):
+        raw_type = m.group(1)
+        rtype = _bicep_resource_type(raw_type)
+        if rtype in _AZURE_AI_RESOURCES:
+            ln = _line_for_needle(content, m.group(0))
+            out.append(
+                _emit(
+                    rtype,
+                    AIComponentType.OTHER,
+                    fp,
+                    ln,
+                    description="Bicep AI resource",
+                    metadata={"bicep_type": rtype},
+                )
+            )
+    for pm in _BICEP_PARAM_RE.finditer(content):
+        pname, pval = pm.group(1), pm.group(2)
+        if _is_known_model(pval):
+            ln = _line_for_needle(content, pm.group(0))
+            out.append(
+                _emit(
+                    pval.strip()[:120],
+                    AIComponentType.MODEL,
+                    fp,
+                    ln,
+                    model_name=pval.strip(),
+                    metadata={"bicep_param": pname},
+                    confidence=0.95,
+                )
+            )
+    return out
+
+
+def _process_file(path: Path) -> list[AIComponent]:
+    fp = str(path)
+    suffix = path.suffix.lower()
+    name_lower = path.name.lower()
+
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        _LOGGER.debug("skip unreadable %s: %s", path, e)
+        return []
+
+    if suffix == ".tf":
+        try:
+            return _parse_terraform(path, content)
+        except Exception as e:
+            _LOGGER.debug("terraform parse %s: %s", path, e)
+            return []
+
+    if suffix == ".bicep":
+        try:
+            return _parse_bicep(path, content)
+        except Exception as e:
+            _LOGGER.debug("bicep parse %s: %s", path, e)
+            return []
+
+    if suffix == ".json":
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as e:
+            _LOGGER.debug("json parse %s: %s", path, e)
+            return []
+        if not isinstance(data, dict):
+            return []
+        try:
+            if _is_cloudformation(data):
+                return _parse_cloudformation(path, data)
+            if _is_arm_template(data):
+                return _parse_arm_template(path, data)
+        except Exception as e:
+            _LOGGER.debug("json IaC parse %s: %s", path, e)
+        return []
+
+    if suffix in (".yaml", ".yml") or name_lower.endswith((".yaml", ".yml")):
+        docs = _safe_yaml_documents(content)
+        all_out: list[AIComponent] = []
+        for doc in docs:
+            if not isinstance(doc, dict):
+                continue
+            try:
+                fmt = _classify_yaml_json(path, content, doc)
+                if fmt == "helm":
+                    all_out.extend(_parse_helm_values(path, doc))
+                elif fmt == "k8s":
+                    all_out.extend(_parse_k8s_yaml(path, doc, content))
+                elif fmt == "cloudformation":
+                    all_out.extend(_parse_cloudformation(path, doc))
+                elif fmt == "arm":
+                    all_out.extend(_parse_arm_template(path, doc))
+            except Exception as e:
+                _LOGGER.debug("yaml IaC parse %s: %s", path, e)
+        return all_out
+
+    return []
+
+
+class DeploymentDetector(BaseScanner):
+    name = "deployment_detector"
+
+    def supports(self, context: ScanContext) -> bool:
+        return True
+
+    def scan(
+        self, context: ScanContext
+    ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+        components: list[AIComponent] = []
+        for fpath, _root in _iter_target_files(context):
+            try:
+                found = _process_file(fpath)
+                components.extend(found)
+            except Exception as e:
+                _LOGGER.debug("deployment scan %s: %s", fpath, e)
+        components = _dedup(components)
+        _LOGGER.debug("deployment_detector: %d components", len(components))
+        return components, []

--- a/aibom/src/aibom/scanners/env_var_resolver.py
+++ b/aibom/src/aibom/scanners/env_var_resolver.py
@@ -1,0 +1,304 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Scanner that detects env var references in AI-related keyword arguments.
+
+Tier 2 of the three-tier detection architecture.  This scanner finds patterns
+like ``model=os.getenv("LLM_MODEL")`` and emits components with
+``metadata.env`` set so that the cross-ref resolution pass can fill in the
+actual value from config files (.env, docker-compose, Helm values, etc.).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Iterator
+
+from pathspec import PathSpec
+
+from ..models import AIComponent, ComponentRelationship, ScanContext
+from ..models.enums import AIComponentType, DetectionSource
+from .base import BaseScanner
+
+_LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Env-var access patterns per language
+# ---------------------------------------------------------------------------
+
+_PY_GETENV = re.compile(
+    r"""os\.getenv\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']"""
+)
+_PY_ENVIRON_BRACKET = re.compile(
+    r"""os\.environ\[\s*["']([A-Za-z_][A-Za-z0-9_]*)["']\s*\]"""
+)
+_PY_ENVIRON_GET = re.compile(
+    r"""os\.environ\.get\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']"""
+)
+_PY_ENV_PATTERNS = [_PY_GETENV, _PY_ENVIRON_BRACKET, _PY_ENVIRON_GET]
+
+_JS_PROCESS_ENV_DOT = re.compile(
+    r"""process\.env\.([A-Za-z_][A-Za-z0-9_]*)"""
+)
+_JS_PROCESS_ENV_BRACKET = re.compile(
+    r"""process\.env\[\s*["']([A-Za-z_][A-Za-z0-9_]*)["']\s*\]"""
+)
+_JS_ENV_PATTERNS = [_JS_PROCESS_ENV_DOT, _JS_PROCESS_ENV_BRACKET]
+
+_GO_GETENV = re.compile(
+    r"""os\.Getenv\(\s*"([A-Za-z_][A-Za-z0-9_]*)"\s*\)"""
+)
+
+_JAVA_GETENV = re.compile(
+    r"""System\.getenv\(\s*"([A-Za-z_][A-Za-z0-9_]*)"\s*\)"""
+)
+
+_RUBY_ENV_BRACKET = re.compile(
+    r"""ENV\[\s*["']([A-Za-z_][A-Za-z0-9_]*)["']\s*\]"""
+)
+_RUBY_ENV_FETCH = re.compile(
+    r"""ENV\.fetch\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']"""
+)
+_RUBY_ENV_PATTERNS = [_RUBY_ENV_BRACKET, _RUBY_ENV_FETCH]
+
+_LANG_PATTERNS: dict[str, list[re.Pattern[str]]] = {
+    ".py": _PY_ENV_PATTERNS,
+    ".js": _JS_ENV_PATTERNS,
+    ".ts": _JS_ENV_PATTERNS,
+    ".jsx": _JS_ENV_PATTERNS,
+    ".tsx": _JS_ENV_PATTERNS,
+    ".mjs": _JS_ENV_PATTERNS,
+    ".go": [_GO_GETENV],
+    ".java": [_JAVA_GETENV],
+    ".rb": _RUBY_ENV_PATTERNS,
+}
+
+# ---------------------------------------------------------------------------
+# AI-related kwarg contexts
+# ---------------------------------------------------------------------------
+
+_MODEL_KWARGS = frozenset({
+    "model", "model_name", "model_id", "deployment_name",
+})
+_API_KEY_KWARGS = frozenset({
+    "api_key", "openai_api_key",
+})
+_ENDPOINT_KWARGS = frozenset({
+    "base_url", "endpoint", "azure_endpoint", "api_base",
+})
+
+_ALL_AI_KWARGS = _MODEL_KWARGS | _API_KEY_KWARGS | _ENDPOINT_KWARGS
+
+_KWARG_RE = re.compile(
+    r"\b(" + "|".join(re.escape(k) for k in sorted(_ALL_AI_KWARGS)) + r")"
+    r"""\s*[:=]\s*""",
+)
+
+_MODEL_VAR_NAMES = frozenset({
+    "model", "model_name", "model_id", "llm_model",
+    "deployment_name", "engine",
+})
+
+_ASSIGN_LHS_RE = re.compile(
+    r"""(?:^|\n)\s*(?:(?:const|let|var|final)\s+)?"""
+    r"""([A-Za-z_][A-Za-z0-9_]*)\s*[:=]\s*""",
+)
+
+# ---------------------------------------------------------------------------
+# File iteration (shared pattern with other scanners)
+# ---------------------------------------------------------------------------
+
+
+def _build_pathspec(patterns: list[str] | tuple[str, ...]) -> PathSpec | None:
+    if not patterns:
+        return None
+    return PathSpec.from_lines("gitwildmatch", patterns)
+
+
+def _iter_files(context: ScanContext) -> Iterator[tuple[Path, str]]:
+    spec = _build_pathspec(context.exclude_patterns)
+    for scan_root in context.paths:
+        root = Path(scan_root)
+        if not root.exists():
+            continue
+        if root.is_file():
+            rel = root.name
+            if spec and spec.match_file(rel):
+                continue
+            yield root, rel
+            continue
+        base = root.resolve()
+        for f in root.rglob("*"):
+            if not f.is_file():
+                continue
+            try:
+                rel = f.resolve().relative_to(base).as_posix()
+            except ValueError:
+                rel = f.as_posix()
+            if spec and spec.match_file(rel):
+                continue
+            yield f, rel
+
+
+def _line_number(text: str, pos: int) -> int:
+    return text[:pos].count("\n") + 1
+
+
+_COMMENT_PREFIXES = {
+    ".py": "#",
+    ".rb": "#",
+    ".js": "//",
+    ".ts": "//",
+    ".jsx": "//",
+    ".tsx": "//",
+    ".mjs": "//",
+    ".go": "//",
+    ".java": "//",
+}
+
+
+def _is_commented(text: str, pos: int, suffix: str) -> bool:
+    """Return True if *pos* falls on a line that is a comment."""
+    prefix = _COMMENT_PREFIXES.get(suffix)
+    if not prefix:
+        return False
+    line_start = text.rfind("\n", 0, pos) + 1
+    line_text = text[line_start:pos + 80].split("\n", 1)[0]
+    return line_text.lstrip().startswith(prefix)
+
+
+# ---------------------------------------------------------------------------
+# Context classification
+# ---------------------------------------------------------------------------
+
+
+def _classify_kwarg(text: str, env_match_start: int) -> str | None:
+    """Look backward from an env-var match to find the nearest AI kwarg assignment."""
+    window_start = max(0, env_match_start - 120)
+    window = text[window_start:env_match_start]
+
+    best_pos = -1
+    best_ctx = None
+    for m in _KWARG_RE.finditer(window):
+        kwarg_name = m.group(1)
+        if m.end() > best_pos:
+            best_pos = m.end()
+            if kwarg_name in _MODEL_KWARGS:
+                best_ctx = "model_kwarg"
+            elif kwarg_name in _API_KEY_KWARGS:
+                best_ctx = "api_key_kwarg"
+            elif kwarg_name in _ENDPOINT_KWARGS:
+                best_ctx = "endpoint_kwarg"
+    return best_ctx
+
+
+def _classify_assignment(text: str, env_match_start: int) -> str | None:
+    """Check if the env var is assigned to a model-like variable name."""
+    window_start = max(0, env_match_start - 80)
+    window = text[window_start:env_match_start]
+
+    for m in _ASSIGN_LHS_RE.finditer(window):
+        var_name = m.group(1).lower()
+        if var_name in _MODEL_VAR_NAMES:
+            return "model_assignment"
+    return None
+
+
+def _env_context_to_component_type(ctx: str) -> AIComponentType:
+    if ctx in ("model_kwarg", "model_assignment"):
+        return AIComponentType.MODEL
+    if ctx == "api_key_kwarg":
+        return AIComponentType.SECRET
+    if ctx == "endpoint_kwarg":
+        return AIComponentType.DEPENDENCY
+    return AIComponentType.MODEL
+
+
+# ---------------------------------------------------------------------------
+# Scanner
+# ---------------------------------------------------------------------------
+
+
+class EnvVarResolver(BaseScanner):
+    name = "env_var_resolver"
+
+    def supports(self, context: ScanContext) -> bool:
+        return any(Path(p).exists() for p in context.paths)
+
+    def scan(
+        self, context: ScanContext
+    ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+        components: list[AIComponent] = []
+        seen: set[tuple[str, str, str]] = set()
+
+        for fpath, _rel in _iter_files(context):
+            suffix = fpath.suffix.lower()
+            patterns = _LANG_PATTERNS.get(suffix)
+            if not patterns:
+                continue
+
+            try:
+                text = fpath.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+
+            fp_str = str(fpath)
+
+            for rx in patterns:
+                for m in rx.finditer(text):
+                    env_name = m.group(1)
+                    match_start = m.start()
+
+                    if _is_commented(text, match_start, suffix):
+                        continue
+
+                    ctx = _classify_kwarg(text, match_start)
+                    if ctx is None:
+                        ctx = _classify_assignment(text, match_start)
+                    if ctx is None:
+                        continue
+
+                    dedup_key = (fp_str, env_name, ctx)
+                    if dedup_key in seen:
+                        continue
+                    seen.add(dedup_key)
+
+                    comp_type = _env_context_to_component_type(ctx)
+                    line_no = _line_number(text, match_start)
+
+                    components.append(AIComponent(
+                        name=f"env:{env_name}",
+                        component_type=comp_type,
+                        file_path=fp_str,
+                        line_number=line_no,
+                        framework="",
+                        detection_source=DetectionSource.CODE_ANALYSIS,
+                        model_name=None,
+                        confidence=0.3,
+                        needs_agentic=True,
+                        agentic_hint=(
+                            f"env var {env_name} used as {ctx}; "
+                            f"value unknown until cross-ref resolution"
+                        ),
+                        metadata={
+                            "env": env_name,
+                            "env_context": ctx,
+                        },
+                    ))
+
+        return components, []

--- a/aibom/src/aibom/scanners/import_context.py
+++ b/aibom/src/aibom/scanners/import_context.py
@@ -1,0 +1,116 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared import-context checker for determining whether a file has AI/ML framework imports.
+
+Scanners use this to gate ambiguous pattern matches: if the file has no AI
+framework imports, a `.fit()` call is far more likely to be sklearn preprocessing
+or a pandas operation than an ML training run.
+"""
+
+from __future__ import annotations
+
+import re
+
+_ML_IMPORT_RE = re.compile(
+    r"(?:^|\n)\s*(?:from|import)\s+"
+    r"(?:torch|tensorflow|tf|keras|transformers|accelerate|"
+    r"huggingface_hub|datasets|tokenizers|peft|trl|"
+    r"lightning|pytorch_lightning|"
+    r"jax|flax|optax|"
+    r"sklearn|scikit.learn|xgboost|lightgbm|catboost)\b",
+    re.MULTILINE,
+)
+
+_LLM_IMPORT_RE = re.compile(
+    r"(?:^|\n)\s*(?:from|import)\s+"
+    r"(?:openai|anthropic|cohere|google\.generativeai|"
+    r"langchain|langchain_core|langchain_openai|langchain_anthropic|langchain_community|"
+    r"llama_index|llamaindex|"
+    r"litellm|"
+    r"crewai|autogen|dspy|"
+    r"vertexai|google\.cloud\.aiplatform)\b",
+    re.MULTILINE,
+)
+
+_AGENT_IMPORT_RE = re.compile(
+    r"(?:^|\n)\s*(?:from|import)\s+"
+    r"(?:langchain|langchain_core|langchain_openai|"
+    r"crewai|autogen|smolagents|"
+    r"llama_index|llamaindex|"
+    r"langgraph|deepagents|"
+    r"swarm|agency_swarm|"
+    r"agno|phidata|pydantic_ai)\b",
+    re.MULTILINE,
+)
+
+_DATA_IMPORT_RE = re.compile(
+    r"(?:^|\n)\s*(?:from|import)\s+"
+    r"(?:datasets|tensorflow_datasets|torchvision|torchtext|"
+    r"dvc|great_expectations|"
+    r"apache_beam|pyspark\.ml)\b",
+    re.MULTILINE,
+)
+
+_EXPERIMENT_IMPORT_RE = re.compile(
+    r"(?:^|\n)\s*(?:from|import)\s+"
+    r"(?:wandb|mlflow|neptune|comet_ml|clearml|"
+    r"tensorboard|torch\.utils\.tensorboard|"
+    r"trackio|swanlab|aim)\b",
+    re.MULTILINE,
+)
+
+_MCP_IMPORT_RE = re.compile(
+    r"(?:^|\n)\s*(?:from|import)\s+"
+    r"(?:mcp|mcp\.server|mcp\.client|"
+    r"langchain_mcp_adapters|fastmcp)\b",
+    re.MULTILINE,
+)
+
+
+def has_ml_imports(text: str) -> bool:
+    return bool(_ML_IMPORT_RE.search(text))
+
+
+def has_llm_imports(text: str) -> bool:
+    return bool(_LLM_IMPORT_RE.search(text))
+
+
+def has_agent_imports(text: str) -> bool:
+    return bool(_AGENT_IMPORT_RE.search(text))
+
+
+def has_data_imports(text: str) -> bool:
+    return bool(_DATA_IMPORT_RE.search(text))
+
+
+def has_experiment_imports(text: str) -> bool:
+    return bool(_EXPERIMENT_IMPORT_RE.search(text))
+
+
+def has_mcp_imports(text: str) -> bool:
+    return bool(_MCP_IMPORT_RE.search(text))
+
+
+def has_any_ai_imports(text: str) -> bool:
+    return (
+        has_ml_imports(text)
+        or has_llm_imports(text)
+        or has_agent_imports(text)
+        or has_data_imports(text)
+        or has_experiment_imports(text)
+        or has_mcp_imports(text)
+    )

--- a/aibom/src/aibom/scanners/mcp_detector.py
+++ b/aibom/src/aibom/scanners/mcp_detector.py
@@ -225,18 +225,35 @@ def _components_from_python(path: Path) -> list[AIComponent]:
         )
 
     mdec = _RE_MCP_TOOL_DECORATOR.search(text)
+    has_mcp = bool(m_imp or m_srv_imp or _RE_FASTMCP.search(text))
     if mdec:
-        out.append(
-            AIComponent(
-                name=f"{path.stem}_mcp_tooling",
-                component_type=AIComponentType.TOOL,
-                file_path=fp,
-                line_number=_line_for_match(text, mdec.start()),
-                framework="mcp",
-                detection_source=DetectionSource.CODE_ANALYSIS,
-                metadata={"mcp_decorators": True},
+        if has_mcp:
+            out.append(
+                AIComponent(
+                    name=f"{path.stem}_mcp_tooling",
+                    component_type=AIComponentType.TOOL,
+                    file_path=fp,
+                    line_number=_line_for_match(text, mdec.start()),
+                    framework="mcp",
+                    detection_source=DetectionSource.CODE_ANALYSIS,
+                    metadata={"mcp_decorators": True},
+                )
             )
-        )
+        else:
+            out.append(
+                AIComponent(
+                    name=f"{path.stem}_mcp_tooling",
+                    component_type=AIComponentType.TOOL,
+                    file_path=fp,
+                    line_number=_line_for_match(text, mdec.start()),
+                    framework="mcp",
+                    detection_source=DetectionSource.CODE_ANALYSIS,
+                    confidence=0.3,
+                    needs_agentic=True,
+                    agentic_hint="@tool decorator without MCP imports in file",
+                    metadata={"mcp_decorators": True},
+                )
+            )
 
     client_hits: list[tuple[str, int]] = []
     for label, pat in (

--- a/aibom/src/aibom/scanners/ml_lifecycle_detector.py
+++ b/aibom/src/aibom/scanners/ml_lifecycle_detector.py
@@ -27,6 +27,7 @@ from pathspec import PathSpec
 from ..models import AIComponent, ComponentRelationship, ScanContext
 from ..models.enums import AIComponentType, DetectionSource
 from .base import BaseScanner
+from .import_context import has_any_ai_imports, has_data_imports, has_ml_imports
 
 
 @dataclass(frozen=True)
@@ -303,6 +304,13 @@ _CONCEPT_PATTERNS: list[ConceptPattern] = [
 
 _YAML_DATA_SECTION_RE = re.compile(r"^\s*data:\s*(?:#.*)?$")
 
+_K8S_DATA_SECTION_RE = re.compile(
+    r"^\s*kind:\s*(ConfigMap|Secret|Deployment|StatefulSet|DaemonSet|Service|"
+    r"Ingress|Job|CronJob|ServiceAccount|Role|RoleBinding|ClusterRole|"
+    r"ClusterRoleBinding|PersistentVolumeClaim|HorizontalPodAutoscaler)\s*$",
+    re.MULTILINE,
+)
+
 
 def _emit(
     concept: AIComponentType,
@@ -315,6 +323,9 @@ def _emit(
     hyperparameters: Optional[dict[str, Any]] = None,
     storage_uri: Optional[str] = None,
     text: Optional[str] = None,
+    confidence: float = 0.85,
+    needs_agentic: bool = False,
+    agentic_hint: str = "",
 ) -> AIComponent:
     hp = hyperparameters or {}
     name = concept.value
@@ -327,12 +338,66 @@ def _emit(
         line_number=line_number,
         framework=framework,
         detection_source=detection_source,
-        confidence=0.85,
+        confidence=confidence,
+        needs_agentic=needs_agentic,
+        agentic_hint=agentic_hint,
         description=description,
         text=text,
         storage_uri=storage_uri,
         hyperparameters=hp,
     )
+
+
+_AMBIGUOUS_TRAINING_FW = frozenset({
+    "keras/pytorch", "pytorch/tensorflow", "pytorch",
+})
+
+_AMBIGUOUS_DATASET_FW = frozenset({
+    "pandas", "cloud-storage", "azure-blob",
+})
+
+
+def _concept_confidence(
+    concept: AIComponentType,
+    suffix: str,
+    file_has_ml: bool,
+    file_has_ai: bool,
+    file_has_data: bool,
+    framework: str,
+) -> tuple[float, bool, str]:
+    """Return (confidence, needs_agentic, hint) based on import context."""
+    if suffix != ".py":
+        return (0.75, False, "")
+
+    if concept == AIComponentType.TRAINING_RUN:
+        if file_has_ml:
+            return (0.9, False, "")
+        return (0.3, True, f".fit()/{framework} without ML imports in file")
+
+    if concept == AIComponentType.DATASET:
+        if file_has_ml or file_has_data:
+            return (0.85, False, "")
+        if framework in _AMBIGUOUS_DATASET_FW:
+            return (0.3, True, f"pd.read_csv/{framework} without ML/data imports")
+        return (0.7, False, "")
+
+    if concept == AIComponentType.HYPERPARAMETER:
+        if file_has_ml:
+            return (0.85, False, "")
+        return (0.35, True, "hyperparameter kwarg without ML imports")
+
+    if concept in (AIComponentType.MODEL_ARTIFACT, AIComponentType.DATA_VERSIONING):
+        return (0.9, False, "")
+
+    if concept in (AIComponentType.EXPERIMENT_TRACKER, AIComponentType.MODEL_REGISTRY):
+        return (0.85, False, "")
+
+    if concept == AIComponentType.ML_PIPELINE:
+        if file_has_ai or file_has_ml:
+            return (0.85, False, "")
+        return (0.5, True, "pipeline pattern without AI/ML imports")
+
+    return (0.85, False, "")
 
 
 class MLLifecycleDetector(BaseScanner):
@@ -369,6 +434,10 @@ class MLLifecycleDetector(BaseScanner):
                 text = fpath.read_text(encoding="utf-8", errors="replace")
             except OSError:
                 continue
+
+            file_has_ml = has_ml_imports(text) if suffix == ".py" else False
+            file_has_ai = has_any_ai_imports(text) if suffix == ".py" else False
+            file_has_data = has_data_imports(text) if suffix == ".py" else False
 
             is_ci = (
                 rel.startswith(".github/workflows/")
@@ -426,21 +495,25 @@ class MLLifecycleDetector(BaseScanner):
                 stripped = line.strip()
 
                 if is_yaml and _YAML_DATA_SECTION_RE.match(line):
-                    uri = _extract_uri_from_line(line)
-                    add(
-                        _emit(
-                            AIComponentType.DATASET,
-                            "yaml-config",
-                            "YAML data section",
-                            fp_str,
-                            line_no,
-                            detection_source=DetectionSource.CONFIG_FILE,
-                            storage_uri=uri,
-                            text=stripped[:200],
+                    is_k8s_manifest = _K8S_DATA_SECTION_RE.search(text) is not None
+                    if not is_k8s_manifest:
+                        uri = _extract_uri_from_line(line)
+                        add(
+                            _emit(
+                                AIComponentType.DATASET,
+                                "yaml-config",
+                                "YAML data section",
+                                fp_str,
+                                line_no,
+                                detection_source=DetectionSource.CONFIG_FILE,
+                                storage_uri=uri,
+                                text=stripped[:200],
+                            )
                         )
-                    )
 
                 if suffix == ".py":
+                    hp_conf = 0.85 if file_has_ml else 0.35
+                    hp_agentic = not file_has_ml
                     for hp_rx, hp_key in _HP_RULES:
                         for m in hp_rx.finditer(line):
                             raw = m.group(1).strip()
@@ -453,6 +526,9 @@ class MLLifecycleDetector(BaseScanner):
                                 line_no,
                                 hyperparameters={hp_key: val},
                                 text=stripped[:200],
+                                confidence=hp_conf,
+                                needs_agentic=hp_agentic,
+                                agentic_hint=f"'{hp_key}' kwarg without ML imports in file" if hp_agentic else "",
                             )
                             key = (
                                 fp_str,
@@ -490,6 +566,10 @@ class MLLifecycleDetector(BaseScanner):
                                 AIComponentType.MODEL_ARTIFACT,
                             ):
                                 uri = _extract_uri_from_line(line)
+
+                            ctx_conf, ctx_agentic, ctx_hint = _concept_confidence(
+                                cp.concept, suffix, file_has_ml, file_has_ai, file_has_data, fw
+                            )
                             add(
                                 _emit(
                                     cp.concept,
@@ -499,6 +579,9 @@ class MLLifecycleDetector(BaseScanner):
                                     line_no,
                                     storage_uri=uri,
                                     text=stripped[:200],
+                                    confidence=ctx_conf,
+                                    needs_agentic=ctx_agentic,
+                                    agentic_hint=ctx_hint,
                                 )
                             )
 

--- a/aibom/src/aibom/scanners/model_detector.py
+++ b/aibom/src/aibom/scanners/model_detector.py
@@ -289,6 +289,11 @@ BUILTIN_MODEL_REGISTRY: dict[str, dict[str, Any]] = {
     r"^gpt-4o$": {"provider": "openai", "family": "gpt-4o", "deprecated": False},
     r"^gpt-4-turbo$": {"provider": "openai", "family": "gpt-4", "deprecated": False},
     r"^gpt-4$": {"provider": "openai", "family": "gpt-4", "deprecated": False},
+    r"^gpt-4-32k": {"provider": "openai", "family": "gpt-4", "deprecated": True},
+    r"^gpt-4\.1$": {"provider": "openai", "family": "gpt-4.1", "deprecated": False},
+    r"^gpt-4\.1-mini$": {"provider": "openai", "family": "gpt-4.1", "deprecated": False},
+    r"^gpt-4\.1-nano$": {"provider": "openai", "family": "gpt-4.1", "deprecated": False},
+    r"^gpt-4\.5": {"provider": "openai", "family": "gpt-4.5", "deprecated": False},
     r"^gpt-3\.5-turbo$": {
         "provider": "openai",
         "family": "gpt-3.5",
@@ -300,6 +305,8 @@ BUILTIN_MODEL_REGISTRY: dict[str, dict[str, Any]] = {
     r"^o3-mini$": {"provider": "openai", "family": "o3", "deprecated": False},
     r"^o3$": {"provider": "openai", "family": "o3", "deprecated": False},
     r"^o4-mini$": {"provider": "openai", "family": "o4", "deprecated": False},
+    r"^text-embedding-ada-002$": {"provider": "openai", "family": "embedding", "deprecated": True},
+    r"^text-embedding-3-(small|large)$": {"provider": "openai", "family": "embedding", "deprecated": False},
     r"^claude-3-5-sonnet-\d{8}$": {
         "provider": "anthropic",
         "family": "claude-3-5-sonnet",
@@ -711,7 +718,7 @@ def _make_component(
                     md[hf_key] = meta[hf_key]
     else:
         provider = "unknown"
-        confidence = 0.7
+        confidence = 0.4
         url = _model_card_url(model_name, provider)
         md = {
             "model_card_url": url,
@@ -726,6 +733,7 @@ def _make_component(
         if method in ("config_file", "env_var")
         else DetectionSource.CODE_ANALYSIS
     )
+    needs_agentic = meta is None
     return AIComponent(
         name=model_name,
         component_type=AIComponentType.MODEL,
@@ -734,6 +742,8 @@ def _make_component(
         framework=provider,
         detection_source=src,
         confidence=confidence,
+        needs_agentic=needs_agentic,
+        agentic_hint=f"'{model_name}' not found in model registry; may be private or misidentified" if needs_agentic else "",
         model_name=model_name,
         metadata=md,
     )

--- a/aibom/src/aibom/scanners/multi_language_scanner.py
+++ b/aibom/src/aibom/scanners/multi_language_scanner.py
@@ -756,20 +756,83 @@ def _regex_scan_file(
                 if _is_plausible_model_id(val):
                     add_model(_line_at(text, m.start()), val)
 
+    has_ai_dep = len(components) > 0
+
     for pat in _MODEL_GENERIC_RES:
         for m in pat.finditer(text):
             gd = m.groupdict()
             if gd.get("val"):
                 val = _normalize_model_literal(gd["val"])
                 if _is_plausible_model_id(val):
-                    add_model(_line_at(text, m.start()), val)
+                    if has_ai_dep:
+                        add_model(_line_at(text, m.start()), val)
+                    else:
+                        ln = _line_at(text, m.start())
+                        key = (ln, "model", val)
+                        if key not in seen:
+                            seen.add(key)
+                            components.append(
+                                AIComponent(
+                                    name=val,
+                                    component_type=AIComponentType.MODEL,
+                                    file_path=rel,
+                                    line_number=ln,
+                                    framework=ecosystem,
+                                    detection_source=DetectionSource.CODE_ANALYSIS,
+                                    confidence=0.3,
+                                    model_name=val,
+                                    needs_agentic=True,
+                                    agentic_hint=f"'model: {val}' without AI SDK imports in file",
+                                    metadata={"scanner": "multi_language_scanner"},
+                                )
+                            )
 
     for m in _AGENT_RE.finditer(text):
-        add_agent(_line_at(text, m.start()))
+        ln = _line_at(text, m.start())
+        if has_ai_dep:
+            add_agent(ln)
+        else:
+            key = (ln, "agent", "Agent")
+            if key not in seen:
+                seen.add(key)
+                components.append(
+                    AIComponent(
+                        name="Agent",
+                        component_type=AIComponentType.AGENT,
+                        file_path=rel,
+                        line_number=ln,
+                        framework=ecosystem,
+                        detection_source=DetectionSource.CODE_ANALYSIS,
+                        confidence=0.25,
+                        needs_agentic=True,
+                        agentic_hint="'new Agent()' without AI SDK imports in file",
+                        metadata={"scanner": "multi_language_scanner"},
+                    )
+                )
 
     for i, tr in enumerate(_TOOL_RES):
         for m in tr.finditer(text):
-            add_tool(_line_at(text, m.start()), f"tool_pattern_{i}")
+            ln = _line_at(text, m.start())
+            if has_ai_dep:
+                add_tool(ln, f"tool_pattern_{i}")
+            else:
+                key = (ln, "tool", f"tool_pattern_{i}")
+                if key not in seen:
+                    seen.add(key)
+                    components.append(
+                        AIComponent(
+                            name=f"tool_pattern_{i}",
+                            component_type=AIComponentType.TOOL,
+                            file_path=rel,
+                            line_number=ln,
+                            framework=ecosystem,
+                            detection_source=DetectionSource.CODE_ANALYSIS,
+                            confidence=0.25,
+                            needs_agentic=True,
+                            agentic_hint="Tool pattern without AI SDK imports in file",
+                            metadata={"scanner": "multi_language_scanner"},
+                        )
+                    )
 
     for line, pkg in _tree_sitter_imports(lang, path.suffix, text, packages):
         add_dep(line, pkg)

--- a/aibom/src/aibom/scanners/secret_detector.py
+++ b/aibom/src/aibom/scanners/secret_detector.py
@@ -233,6 +233,7 @@ def _regex_scan_line(
             continue
         if not pat.regex.search(line):
             continue
+        is_low_confidence = pat.confidence < 0.6
         comp = AIComponent(
             name=pat.name,
             component_type=AIComponentType.SECRET,
@@ -240,6 +241,8 @@ def _regex_scan_line(
             line_number=line_number,
             detection_source=DetectionSource.CODE_ANALYSIS,
             confidence=pat.confidence,
+            needs_agentic=is_low_confidence,
+            agentic_hint=f"Generic hex pattern for {pat.name}; needs context verification" if is_low_confidence else "",
             description=f"Potential {pat.name} detected",
             text=None,
             metadata={

--- a/aibom/tests/test_cross_ref.py
+++ b/aibom/tests/test_cross_ref.py
@@ -1,0 +1,298 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aibom.cross_ref import (
+    CrossRefIndex,
+    EnvVarEntry,
+    build_env_index,
+    build_package_index,
+    resolve_components,
+)
+from aibom.models.enums import AIComponentType, DetectionSource
+from aibom.models.scan import AIComponent
+
+
+class TestEnvVarIndexing:
+    def test_dotenv_parsing(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text(
+            """MODEL_NAME=gpt-4o
+OPENAI_API_KEY="sk-abc123"
+# comment
+EMPTY_VAR=
+EMBEDDING_MODEL='text-embedding-3-small'
+""",
+            encoding="utf-8",
+        )
+        idx = build_env_index([str(tmp_path)])
+        assert idx.env["MODEL_NAME"][0].value == "gpt-4o"
+        assert idx.env["OPENAI_API_KEY"][0].value == "sk-abc123"
+        assert idx.env["EMBEDDING_MODEL"][0].value == "text-embedding-3-small"
+        assert idx.env["EMPTY_VAR"][0].value == ""
+
+    def test_docker_compose_env_dict(self, tmp_path: Path) -> None:
+        (tmp_path / "docker-compose.yml").write_text(
+            """services:
+  api:
+    image: app:latest
+    environment:
+      MODEL_NAME: gpt-4o
+      OPENAI_API_KEY: sk-xyz
+""",
+            encoding="utf-8",
+        )
+        idx = build_env_index([str(tmp_path)])
+        assert idx.env["MODEL_NAME"][0].value == "gpt-4o"
+        assert idx.env["OPENAI_API_KEY"][0].value == "sk-xyz"
+        assert idx.env["MODEL_NAME"][0].source_type == "docker-compose"
+        assert idx.env["OPENAI_API_KEY"][0].source_type == "docker-compose"
+
+    def test_docker_compose_env_list(self, tmp_path: Path) -> None:
+        (tmp_path / "docker-compose.yml").write_text(
+            """services:
+  api:
+    environment:
+      - MODEL_NAME=claude-3-sonnet
+      - DEBUG=true
+""",
+            encoding="utf-8",
+        )
+        idx = build_env_index([str(tmp_path)])
+        assert idx.env["MODEL_NAME"][0].value == "claude-3-sonnet"
+        assert idx.env["DEBUG"][0].value == "true"
+
+    def test_tfvars_parsing(self, tmp_path: Path) -> None:
+        (tmp_path / "terraform.tfvars").write_text(
+            """model_name = "anthropic.claude-3-sonnet"
+region     = "us-east-1"
+gpu_count  = 2
+""",
+            encoding="utf-8",
+        )
+        idx = build_env_index([str(tmp_path)])
+        assert idx.env["model_name"][0].value == "anthropic.claude-3-sonnet"
+        assert idx.env["region"][0].value == "us-east-1"
+
+    def test_helm_values(self, tmp_path: Path) -> None:
+        (tmp_path / "values.yaml").write_text(
+            """inference:
+  modelName: gpt-4o-mini
+  endpoint: https://api.openai.com
+  replicas: 3
+""",
+            encoding="utf-8",
+        )
+        idx = build_env_index([str(tmp_path)])
+        assert idx.env["modelName"][0].value == "gpt-4o-mini"
+
+    def test_k8s_configmap(self, tmp_path: Path) -> None:
+        (tmp_path / "configmap.yaml").write_text(
+            """apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ai-config
+data:
+  MODEL_NAME: gpt-4o
+  LOG_LEVEL: debug
+""",
+            encoding="utf-8",
+        )
+        idx = build_env_index([str(tmp_path)])
+        assert idx.env["MODEL_NAME"][0].value == "gpt-4o"
+        assert idx.env["MODEL_NAME"][0].source_type == "k8s-configmap"
+
+    def test_multiple_sources_same_var(self, tmp_path: Path) -> None:
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        (a / ".env").write_text("MODEL_NAME=first\n", encoding="utf-8")
+        (b / ".env").write_text("MODEL_NAME=second\n", encoding="utf-8")
+        idx = build_env_index([str(tmp_path)])
+        values = {e.value for e in idx.env["MODEL_NAME"]}
+        assert values == {"first", "second"}
+
+    def test_empty_dir(self, tmp_path: Path) -> None:
+        idx = build_env_index([str(tmp_path)])
+        assert idx.env == {}
+
+
+class TestPackageIndexing:
+    def test_requirements_txt(self, tmp_path: Path) -> None:
+        (tmp_path / "requirements.txt").write_text(
+            """langchain>=0.2.0
+openai==1.30.0
+requests>=2.31.0
+transformers
+""",
+            encoding="utf-8",
+        )
+        idx = build_package_index([str(tmp_path)])
+        assert "langchain" in idx.packages
+        assert "openai" in idx.packages
+        assert "transformers" in idx.packages
+        assert "requests" not in idx.packages
+
+    def test_package_json(self, tmp_path: Path) -> None:
+        payload = {
+            "dependencies": {
+                "@langchain/core": "^0.2.0",
+                "express": "^4.18.0",
+                "@anthropic-ai/sdk": "^0.20.0",
+            }
+        }
+        (tmp_path / "package.json").write_text(
+            json.dumps(payload, indent=2),
+            encoding="utf-8",
+        )
+        idx = build_package_index([str(tmp_path)])
+        assert "@langchain/core" in idx.packages
+        assert "@anthropic-ai/sdk" in idx.packages
+        assert "express" not in idx.packages
+
+    def test_pyproject_toml(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            """[project]
+dependencies = ["torch>=2.0", "pydantic>=2.0"]
+[project.optional-dependencies]
+ml = ["transformers>=4.40"]
+""",
+            encoding="utf-8",
+        )
+        idx = build_package_index([str(tmp_path)])
+        assert "torch" in idx.packages
+        assert "transformers" in idx.packages
+        assert "pydantic" not in idx.packages
+
+    def test_go_mod(self, tmp_path: Path) -> None:
+        (tmp_path / "go.mod").write_text(
+            """module github.com/org/service
+require (
+    github.com/openai/openai-go v0.1.0
+    github.com/gin-gonic/gin v1.9.0
+)
+""",
+            encoding="utf-8",
+        )
+        idx = build_package_index([str(tmp_path)])
+        assert "github.com/openai/openai-go" in idx.packages
+        assert "github.com/gin-gonic/gin" not in idx.packages
+
+
+class TestResolveComponents:
+    def test_resolves_env_var_model_name(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text("MODEL_NAME=gpt-4o\n", encoding="utf-8")
+        idx = build_env_index([str(tmp_path)])
+        comp = AIComponent(
+            name="m",
+            component_type=AIComponentType.MODEL,
+            detection_source=DetectionSource.CONFIG_FILE,
+            model_name=None,
+            metadata={"env": "MODEL_NAME"},
+        )
+        out = resolve_components([comp], idx)
+        assert out[0].model_name == "gpt-4o"
+
+    def test_resolves_dollar_var_in_model_name(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text("MODEL_NAME=claude-3-sonnet\n", encoding="utf-8")
+        idx = build_env_index([str(tmp_path)])
+        comp = AIComponent(
+            name="m",
+            component_type=AIComponentType.MODEL,
+            detection_source=DetectionSource.CONFIG_FILE,
+            model_name="${MODEL_NAME}",
+            metadata={},
+        )
+        out = resolve_components([comp], idx)
+        assert out[0].model_name == "claude-3-sonnet"
+
+    def test_no_resolution_when_already_set(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text("MODEL_NAME=other\n", encoding="utf-8")
+        idx = build_env_index([str(tmp_path)])
+        comp = AIComponent(
+            name="m",
+            component_type=AIComponentType.MODEL,
+            detection_source=DetectionSource.CONFIG_FILE,
+            model_name="gpt-4o",
+            metadata={"env": "MODEL_NAME"},
+        )
+        out = resolve_components([comp], idx)
+        assert out[0].model_name == "gpt-4o"
+
+    def test_no_resolution_when_var_missing(self, tmp_path: Path) -> None:
+        idx = build_env_index([str(tmp_path)])
+        comp = AIComponent(
+            name="m",
+            component_type=AIComponentType.MODEL,
+            detection_source=DetectionSource.CONFIG_FILE,
+            model_name=None,
+            metadata={"env": "UNKNOWN_VAR"},
+        )
+        out = resolve_components([comp], idx)
+        assert out[0].model_name is None
+
+    def test_resolves_config_key(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text("MODEL_NAME=gpt-4o\n", encoding="utf-8")
+        idx = build_env_index([str(tmp_path)])
+        comp = AIComponent(
+            name="m",
+            component_type=AIComponentType.MODEL,
+            detection_source=DetectionSource.CONFIG_FILE,
+            model_name=None,
+            metadata={"config_key": "MODEL_NAME"},
+        )
+        out = resolve_components([comp], idx)
+        assert out[0].model_name == "gpt-4o"
+
+    def test_provenance_metadata_on_resolution(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text("LLM_MODEL=gpt-4o\n", encoding="utf-8")
+        idx = build_env_index([str(tmp_path)])
+        comp = AIComponent(
+            name="env:LLM_MODEL",
+            component_type=AIComponentType.MODEL,
+            detection_source=DetectionSource.CODE_ANALYSIS,
+            model_name=None,
+            needs_agentic=True,
+            metadata={"env": "LLM_MODEL", "env_context": "model_kwarg"},
+        )
+        out = resolve_components([comp], idx)
+        assert out[0].model_name == "gpt-4o"
+        assert out[0].metadata.get("resolved_from") == "dotenv"
+        assert "resolved_source_file" in out[0].metadata
+        assert out[0].metadata.get("resolved_env_var") == "LLM_MODEL"
+
+    def test_unresolved_env_gets_agentic_hint(self) -> None:
+        idx = CrossRefIndex()
+        comp = AIComponent(
+            name="env:MISSING_VAR",
+            component_type=AIComponentType.MODEL,
+            detection_source=DetectionSource.CODE_ANALYSIS,
+            model_name=None,
+            needs_agentic=True,
+            metadata={"env": "MISSING_VAR", "env_context": "model_kwarg"},
+        )
+        out = resolve_components([comp], idx)
+        assert out[0].needs_agentic is True
+        assert "MISSING_VAR" in out[0].agentic_hint
+        assert "not found in any config source" in out[0].agentic_hint
+        assert out[0].metadata.get("unresolved_env_var") == "MISSING_VAR"
+
+    def test_resolution_upgrades_confidence_on_registry_hit(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text("LLM_MODEL=gpt-4o\n", encoding="utf-8")
+        idx = build_env_index([str(tmp_path)])
+        comp = AIComponent(
+            name="env:LLM_MODEL",
+            component_type=AIComponentType.MODEL,
+            detection_source=DetectionSource.CODE_ANALYSIS,
+            confidence=0.3,
+            needs_agentic=True,
+            model_name=None,
+            metadata={"env": "LLM_MODEL", "env_context": "model_kwarg"},
+        )
+        out = resolve_components([comp], idx)
+        assert out[0].confidence >= 0.5

--- a/aibom/tests/test_cross_repo_detection.py
+++ b/aibom/tests/test_cross_repo_detection.py
@@ -1,0 +1,259 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aibom.cross_ref import detect_external_repo_deps
+
+
+class TestPoetryGitDeps:
+    def test_poetry_git_dependency(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            """[tool.poetry.dependencies]
+python = "^3.11"
+ai-common-py = {git = "https://github.com/org/ai-common-py.git", branch = "main", subdirectory = "models"}
+""",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].name == "ai-common-py"
+        assert deps[0].dep_type == "git"
+        assert "ai-common-py" in deps[0].url_or_path
+        assert deps[0].subdirectory == "models"
+        assert deps[0].branch == "main"
+
+    def test_poetry_path_dependency(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            """[tool.poetry.dependencies]
+shared-lib = {path = "../../shared-lib"}
+""",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].dep_type == "path"
+        assert deps[0].escapes_root is True
+
+    def test_poetry_dev_deps(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            """[tool.poetry.dev-dependencies]
+test-utils = {git = "https://github.com/org/test-utils.git"}
+""",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].name == "test-utils"
+
+    def test_poetry_group_deps(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            """[tool.poetry.group.dev.dependencies]
+lint-rules = {git = "https://github.com/org/lint-rules.git", tag = "v1.0"}
+""",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].tag == "v1.0"
+
+
+class TestUvSources:
+    def test_uv_git_source(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            """[project]
+dependencies = ["ai-common"]
+
+[tool.uv.sources]
+ai-common = {git = "https://github.com/org/ai-common.git", branch = "main"}
+""",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].name == "ai-common"
+        assert deps[0].dep_type == "git"
+        assert deps[0].branch == "main"
+
+    def test_uv_path_source(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            """[project]
+dependencies = ["local-pkg"]
+
+[tool.uv.sources]
+local-pkg = {path = "../local-pkg"}
+""",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].dep_type == "path"
+        assert deps[0].escapes_root is True
+
+    def test_uv_with_subdirectory(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            """[tool.uv.sources]
+ml-lib = {git = "https://github.com/org/mono.git", subdirectory = "packages/ml"}
+""",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].subdirectory == "packages/ml"
+
+
+class TestRequirementsTxtGit:
+    def test_git_plus_https(self, tmp_path: Path) -> None:
+        (tmp_path / "requirements.txt").write_text(
+            "git+https://github.com/org/ai-common-py.git@main#egg=ai-common-py\n",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].dep_type == "git"
+        assert deps[0].name == "ai-common-py"
+        assert deps[0].branch == "main"
+
+    def test_editable_git(self, tmp_path: Path) -> None:
+        (tmp_path / "requirements.txt").write_text(
+            "-e git+https://github.com/org/sdk.git@v2.0#egg=sdk\n",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].dep_type == "git"
+        assert deps[0].name == "sdk"
+
+    def test_editable_local_path(self, tmp_path: Path) -> None:
+        (tmp_path / "requirements.txt").write_text(
+            "-e ../shared-lib\n",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].dep_type == "editable"
+        assert deps[0].escapes_root is True
+
+    def test_normal_deps_ignored(self, tmp_path: Path) -> None:
+        (tmp_path / "requirements.txt").write_text(
+            "langchain>=0.2.0\nopenai==1.30.0\n",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 0
+
+
+class TestPackageJsonGit:
+    def test_git_dep(self, tmp_path: Path) -> None:
+        payload = {
+            "dependencies": {
+                "ai-utils": "git+https://github.com/org/ai-utils.git#main",
+                "express": "^4.18.0",
+            }
+        }
+        (tmp_path / "package.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].name == "ai-utils"
+        assert deps[0].dep_type == "git"
+
+    def test_github_shorthand(self, tmp_path: Path) -> None:
+        payload = {"dependencies": {"tool": "github:org/tool#v2"}}
+        (tmp_path / "package.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+
+    def test_file_dep(self, tmp_path: Path) -> None:
+        payload = {"dependencies": {"local": "file:../local-pkg"}}
+        (tmp_path / "package.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].dep_type == "path"
+        assert deps[0].escapes_root is True
+
+
+class TestGoModReplace:
+    def test_local_replace(self, tmp_path: Path) -> None:
+        (tmp_path / "go.mod").write_text(
+            """module github.com/org/svc
+go 1.22
+require github.com/org/common v0.0.0
+replace github.com/org/common => ../common
+""",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].dep_type == "path"
+        assert deps[0].url_or_path == "../common"
+        assert deps[0].escapes_root is True
+
+    def test_remote_replace(self, tmp_path: Path) -> None:
+        (tmp_path / "go.mod").write_text(
+            """module github.com/org/svc
+replace github.com/old/pkg => github.com/new/pkg v1.0.0
+""",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].dep_type == "git"
+        assert deps[0].url_or_path == "github.com/new/pkg"
+
+    def test_no_replace(self, tmp_path: Path) -> None:
+        (tmp_path / "go.mod").write_text(
+            """module github.com/org/svc
+go 1.22
+require github.com/gin-gonic/gin v1.9.0
+""",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 0
+
+
+class TestPathEscaping:
+    def test_path_inside_repo_not_flagged(self, tmp_path: Path) -> None:
+        sub = tmp_path / "packages" / "lib"
+        sub.mkdir(parents=True)
+        (tmp_path / "pyproject.toml").write_text(
+            """[tool.poetry.dependencies]
+lib = {path = "packages/lib"}
+""",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].escapes_root is False
+
+    def test_absolute_path_flagged(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            """[tool.poetry.dependencies]
+lib = {path = "/opt/shared/lib"}
+""",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].escapes_root is True
+
+    def test_git_deps_not_flagged(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            """[tool.poetry.dependencies]
+lib = {git = "https://github.com/org/lib.git"}
+""",
+            encoding="utf-8",
+        )
+        deps = detect_external_repo_deps([str(tmp_path)])
+        assert len(deps) == 1
+        assert deps[0].escapes_root is False

--- a/aibom/tests/test_dep_graph.py
+++ b/aibom/tests/test_dep_graph.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aibom.cross_ref import CrossRefIndex, EnvVarEntry
+from aibom.dep_graph import DependencyGraph, RepoEdge
+from aibom.models import AIComponent, ComponentRelationship
+from aibom.models.enums import AIComponentType, RelationshipType
+
+
+def _dep(name: str) -> AIComponent:
+    return AIComponent(name=name, component_type=AIComponentType.DEPENDENCY)
+
+
+class TestDependencyGraph:
+    def test_shared_packages(self, tmp_path: Path) -> None:
+        repo_a = tmp_path / "repo_a"
+        repo_b = tmp_path / "repo_b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+        g = DependencyGraph()
+        g.add_repo(str(repo_a), [_dep("numpy"), _dep("pandas")])
+        g.add_repo(str(repo_b), [_dep("numpy"), _dep("scipy")])
+        edges = g.build()
+        shared = [e for e in edges if e.edge_type == "shared_package"]
+        assert len(shared) == 1
+        assert shared[0].details["package"] == "numpy"
+        assert {shared[0].source_repo, shared[0].target_repo} == {str(repo_a), str(repo_b)}
+
+    def test_env_var_flows(self, tmp_path: Path) -> None:
+        repo_a = tmp_path / "repo_a"
+        repo_b = tmp_path / "repo_b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+        env_file = repo_a / ".env"
+        env_file.write_text("MODEL_NAME=gpt-4\n", encoding="utf-8")
+        xref = CrossRefIndex()
+        xref.env["MODEL_NAME"] = [
+            EnvVarEntry(
+                name="MODEL_NAME",
+                value="gpt-4",
+                source_type="dotenv",
+                source_path=str(env_file),
+            )
+        ]
+        g = DependencyGraph()
+        g.add_repo(str(repo_a), [], cross_ref=xref)
+        g.add_repo(
+            str(repo_b),
+            [
+                AIComponent(
+                    name="cfg",
+                    component_type=AIComponentType.OTHER,
+                    metadata={"env": "MODEL_NAME"},
+                )
+            ],
+        )
+        edges = g.build()
+        flows = [e for e in edges if e.edge_type == "env_var_flow"]
+        assert len(flows) == 1
+        assert flows[0].details["env_var"] == "MODEL_NAME"
+        assert flows[0].source_repo == str(repo_a)
+        assert flows[0].target_repo == str(repo_b)
+
+    def test_no_edges_single_repo(self, tmp_path: Path) -> None:
+        repo = tmp_path / "solo"
+        repo.mkdir()
+        g = DependencyGraph()
+        g.add_repo(str(repo), [_dep("numpy")])
+        assert g.build() == []
+
+    def test_to_relationships(self, tmp_path: Path) -> None:
+        repo_a = tmp_path / "repo_a"
+        repo_b = tmp_path / "repo_b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+        g = DependencyGraph()
+        g.add_repo(str(repo_a), [_dep("x")])
+        g.add_repo(str(repo_b), [_dep("x")])
+        g.build()
+        rels = g.to_relationships()
+        assert len(rels) == 1
+        r = rels[0]
+        assert isinstance(r, ComponentRelationship)
+        assert r.relationship_type == RelationshipType.CUSTOM
+        assert r.label == "shared_package"
+        assert r.source_instance_id == "repo:repo_a"
+        assert r.target_instance_id == "repo:repo_b"
+        assert r.source_name == "repo_a"
+        assert r.target_name == "repo_b"
+
+    def test_to_dict(self, tmp_path: Path) -> None:
+        repo_a = tmp_path / "repo_a"
+        repo_b = tmp_path / "repo_b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+        g = DependencyGraph()
+        g.add_repo(str(repo_a), [_dep("numpy")])
+        g.add_repo(str(repo_b), [_dep("numpy")])
+        g.build()
+        d = g.to_dict()
+        json.dumps(d)
+        assert d["total_repos"] == 2
+        assert d["total_edges"] == 1
+        assert len(d["repos"]) == 2
+        assert d["edges"][0]["type"] == "shared_package"
+        assert d["edges"][0]["details"] == {"package": "numpy"}
+
+    def test_empty_graph(self) -> None:
+        g = DependencyGraph()
+        assert g.build() == []
+        assert g.to_relationships() == []
+        d = g.to_dict()
+        assert d["repos"] == []
+        assert d["edges"] == []
+        assert d["total_repos"] == 0
+        assert d["total_edges"] == 0
+
+    def test_multiple_shared_packages(self, tmp_path: Path) -> None:
+        repo_a = tmp_path / "repo_a"
+        repo_b = tmp_path / "repo_b"
+        repo_c = tmp_path / "repo_c"
+        for p in (repo_a, repo_b, repo_c):
+            p.mkdir()
+        g = DependencyGraph()
+        g.add_repo(str(repo_a), [_dep("p1"), _dep("p2")])
+        g.add_repo(str(repo_b), [_dep("p1"), _dep("p2")])
+        g.add_repo(str(repo_c), [_dep("p1"), _dep("p2")])
+        edges = g.build()
+        shared = [e for e in edges if e.edge_type == "shared_package"]
+        assert len(shared) == 6
+        by_pkg: dict[str, list[RepoEdge]] = {}
+        for e in shared:
+            by_pkg.setdefault(e.details["package"], []).append(e)
+        assert set(by_pkg.keys()) == {"p1", "p2"}
+        assert len(by_pkg["p1"]) == 3
+        assert len(by_pkg["p2"]) == 3

--- a/aibom/tests/test_deployment_detector.py
+++ b/aibom/tests/test_deployment_detector.py
@@ -1,0 +1,364 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aibom.models import AIComponentType, DetectionSource, ScanContext
+from aibom.scanners.base import scanner_registry
+from aibom.scanners.deployment_detector import DeploymentDetector
+
+from .conftest import run_scanner
+
+
+class TestHelmK8sDetection:
+    def test_detects_ai_container_image_in_deployment(self, tmp_path: Path) -> None:
+        yml = """apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm
+spec:
+  template:
+    spec:
+      containers:
+        - name: inference
+          image: vllm/vllm-openai:latest
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"deploy.yaml": yml})
+        deps = [c for c in comps if c.component_type == AIComponentType.DEPENDENCY]
+        assert deps
+        assert any("vllm" in (c.metadata.get("image") or "").lower() for c in deps)
+        assert any(c.metadata.get("gpu") == "1" for c in deps)
+
+    def test_detects_model_name_in_configmap(self, tmp_path: Path) -> None:
+        yml = """apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cfg
+data:
+  MODEL_NAME: "gpt-4o"
+  OPENAI_API_KEY: "sk-xxx"
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"cm.yaml": yml})
+        models = [c for c in comps if c.component_type == AIComponentType.MODEL]
+        assert any(c.model_name == "gpt-4o" for c in models)
+
+    def test_detects_model_in_helm_values(self, tmp_path: Path) -> None:
+        yml = """inference:
+  model: gpt-4o-mini
+  image: vllm/vllm-openai:v0.4.0
+  resources:
+    gpu: 1
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"values.yaml": yml})
+        models = [c for c in comps if c.component_type == AIComponentType.MODEL]
+        deps = [c for c in comps if c.component_type == AIComponentType.DEPENDENCY]
+        assert any(c.model_name == "gpt-4o-mini" for c in models)
+        assert any("vllm" in (c.metadata.get("image") or "").lower() for c in deps)
+
+    def test_detects_training_job(self, tmp_path: Path) -> None:
+        yml = """apiVersion: batch/v1
+kind: Job
+metadata:
+  name: train
+spec:
+  template:
+    spec:
+      containers:
+        - name: trainer
+          image: pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"job.yaml": yml})
+        runs = [c for c in comps if c.component_type == AIComponentType.TRAINING_RUN]
+        assert runs
+        assert any("pytorch" in (c.metadata.get("image") or "").lower() for c in runs)
+
+    def test_ignores_non_ai_deployment(self, tmp_path: Path) -> None:
+        yml = """apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"deploy.yaml": yml})
+        assert comps == []
+
+
+class TestTerraformDetection:
+    def test_detects_sagemaker_endpoint(self, tmp_path: Path) -> None:
+        hcl = '''resource "aws_sagemaker_endpoint" "inference" {
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.my_config.name
+}
+resource "aws_sagemaker_model" "my_model" {
+  name = "my-model"
+  primary_container {
+    image = "123456789.dkr.ecr.us-east-1.amazonaws.com/sagemaker-huggingface:latest"
+    model_data_url = "s3://my-bucket/models/model.tar.gz"
+  }
+}
+'''
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"main.tf": hcl})
+        assert len(comps) >= 2
+        assert any(
+            "sagemaker" in (c.metadata.get("terraform_resource_type") or "").lower()
+            for c in comps
+        )
+
+    def test_detects_bedrock_agent(self, tmp_path: Path) -> None:
+        hcl = '''resource "aws_bedrock_agent_agent" "assistant" {
+  model_id = "anthropic.claude-3-sonnet"
+}
+'''
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"bedrock.tf": hcl})
+        models = [c for c in comps if c.component_type == AIComponentType.MODEL]
+        assert any(c.model_name == "anthropic.claude-3-sonnet" for c in models)
+
+    def test_detects_azure_openai_terraform(self, tmp_path: Path) -> None:
+        hcl = '''resource "azurerm_cognitive_account" "openai" {
+  kind = "OpenAI"
+}
+'''
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"azure.tf": hcl})
+        assert comps
+        assert any(
+            c.metadata.get("terraform_resource_type") == "azurerm_cognitive_account"
+            for c in comps
+        )
+
+    def test_detects_gcp_vertex(self, tmp_path: Path) -> None:
+        hcl = '''resource "google_vertex_ai_endpoint" "endpoint" {
+  display_name = "inference"
+}
+'''
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"gcp.tf": hcl})
+        assert comps
+        assert any(
+            c.metadata.get("terraform_resource_type") == "google_vertex_ai_endpoint"
+            for c in comps
+        )
+
+    def test_detects_gpu_instance_type(self, tmp_path: Path) -> None:
+        hcl = '''resource "aws_sagemaker_notebook_instance" "nb" {
+  name          = "nb"
+  instance_type = "ml.p4d.24xlarge"
+}
+'''
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"gpu.tf": hcl})
+        gpuish = [
+            c
+            for c in comps
+            if c.metadata.get("instance_type")
+            and "ml.p4d" in str(c.metadata.get("instance_type"))
+        ]
+        assert gpuish
+
+    def test_detects_variable_defaults(self, tmp_path: Path) -> None:
+        hcl = '''variable "model_name" { default = "claude-3-sonnet" }
+'''
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"vars.tf": hcl})
+        models = [c for c in comps if c.component_type == AIComponentType.MODEL]
+        assert any(c.model_name == "claude-3-sonnet" for c in models)
+
+
+class TestCloudFormationDetection:
+    def test_detects_cfn_sagemaker(self, tmp_path: Path) -> None:
+        yml = """AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MyEndpoint:
+    Type: AWS::SageMaker::Endpoint
+    Properties:
+      EndpointConfigName: !Ref MyConfig
+  MyModel:
+    Type: AWS::SageMaker::Model
+    Properties:
+      ModelName: my-inference-model
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"cfn.yaml": yml})
+        assert any(c.metadata.get("cfn_type") == "AWS::SageMaker::Endpoint" for c in comps)
+        assert any(c.metadata.get("cfn_type") == "AWS::SageMaker::Model" for c in comps)
+
+    def test_detects_cfn_bedrock(self, tmp_path: Path) -> None:
+        yml = """AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  Agent:
+    Type: AWS::Bedrock::Agent
+    Properties: {}
+  Guard:
+    Type: AWS::Bedrock::Guardrail
+    Properties: {}
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"bedrock.yaml": yml})
+        types = {c.metadata.get("cfn_type") for c in comps}
+        assert "AWS::Bedrock::Agent" in types
+        assert "AWS::Bedrock::Guardrail" in types
+
+    def test_detects_cfn_parameters(self, tmp_path: Path) -> None:
+        yml = """AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  ModelName:
+    Type: String
+    Default: gpt-4o
+Resources: {}
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"params.yaml": yml})
+        models = [c for c in comps if c.component_type == AIComponentType.MODEL]
+        assert any(c.model_name == "gpt-4o" for c in models)
+
+    def test_detects_cfn_json(self, tmp_path: Path) -> None:
+        doc = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Resources": {
+                "MyEndpoint": {
+                    "Type": "AWS::SageMaker::Endpoint",
+                    "Properties": {"EndpointConfigName": {"Ref": "MyConfig"}},
+                },
+                "MyModel": {
+                    "Type": "AWS::SageMaker::Model",
+                    "Properties": {"ModelName": "my-inference-model"},
+                },
+            },
+        }
+        comps, _ = run_scanner(
+            DeploymentDetector, tmp_path, {"cfn.json": json.dumps(doc, indent=2)}
+        )
+        assert any(c.metadata.get("cfn_type") == "AWS::SageMaker::Endpoint" for c in comps)
+        assert any(c.metadata.get("cfn_type") == "AWS::SageMaker::Model" for c in comps)
+
+
+class TestAzureARMDetection:
+    def test_detects_arm_cognitive_services(self, tmp_path: Path) -> None:
+        doc = {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "resources": [
+                {
+                    "type": "Microsoft.CognitiveServices/accounts",
+                    "name": "my-openai",
+                    "properties": {
+                        "kind": "OpenAI",
+                        "deployments": [
+                            {
+                                "model": {
+                                    "name": "gpt-4o",
+                                    "version": "2024-05-13",
+                                }
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+        comps, _ = run_scanner(
+            DeploymentDetector, tmp_path, {"arm.json": json.dumps(doc)}
+        )
+        models = [c for c in comps if c.component_type == AIComponentType.MODEL]
+        assert any(c.model_name == "gpt-4o" for c in models)
+
+    def test_detects_arm_ml_workspace(self, tmp_path: Path) -> None:
+        doc = {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "resources": [
+                {
+                    "type": "Microsoft.MachineLearningServices/workspaces",
+                    "name": "ws1",
+                    "properties": {},
+                }
+            ],
+        }
+        comps, _ = run_scanner(
+            DeploymentDetector, tmp_path, {"ml.json": json.dumps(doc)}
+        )
+        assert any(
+            c.metadata.get("arm_type") == "Microsoft.MachineLearningServices/workspaces"
+            for c in comps
+        )
+
+
+class TestBicepDetection:
+    def test_detects_bicep_cognitive_services(self, tmp_path: Path) -> None:
+        src = """resource openai 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
+  name: 'my-openai'
+  kind: 'OpenAI'
+}
+param modelName string = 'gpt-4o'
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"main.bicep": src})
+        assert any(
+            c.metadata.get("bicep_type") == "Microsoft.CognitiveServices/accounts"
+            for c in comps
+        )
+        models = [c for c in comps if c.component_type == AIComponentType.MODEL]
+        assert any(c.model_name == "gpt-4o" for c in models)
+
+
+class TestScannerIntegration:
+    def test_scanner_registered(self) -> None:
+        assert DeploymentDetector in scanner_registry
+
+    def test_supports_always_true(self, tmp_path: Path) -> None:
+        ctx = ScanContext(paths=[str(tmp_path)])
+        assert DeploymentDetector().supports(ctx) is True
+
+    def test_mixed_iac_directory(self, tmp_path: Path) -> None:
+        files = {
+            "infra/main.tf": '''resource "google_vertex_ai_endpoint" "e" {
+  display_name = "x"
+}
+''',
+            "k8s/cm.yaml": """apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: m
+data:
+  MODEL_NAME: "gpt-4o"
+""",
+            "helm/values.yaml": """inference:
+  model: gpt-4o-mini
+  image: vllm/vllm-openai:v0.4.0
+""",
+        }
+        comps, rels = run_scanner(DeploymentDetector, tmp_path, files)
+        assert rels == []
+        assert any(
+            c.metadata.get("terraform_resource_type") == "google_vertex_ai_endpoint"
+            for c in comps
+        )
+        assert any(c.model_name == "gpt-4o" for c in comps)
+        assert any(c.model_name == "gpt-4o-mini" for c in comps)
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, rels = DeploymentDetector().scan(ctx)
+        assert comps == [] and rels == []
+
+    def test_malformed_yaml_handled(self, tmp_path: Path) -> None:
+        comps, rels = run_scanner(
+            DeploymentDetector, tmp_path, {"broken.yaml": "foo: [\n  x"}
+        )
+        assert rels == []
+        assert isinstance(comps, list)
+
+    def test_detection_source_is_config_file(self, tmp_path: Path) -> None:
+        yml = """apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c
+data:
+  MODEL_NAME: "gpt-4o"
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"x.yaml": yml})
+        assert comps
+        assert all(c.detection_source == DetectionSource.CONFIG_FILE for c in comps)

--- a/aibom/tests/test_env_var_resolver.py
+++ b/aibom/tests/test_env_var_resolver.py
@@ -1,0 +1,206 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aibom.models import ScanContext
+from aibom.models.enums import AIComponentType
+from aibom.scanners.env_var_resolver import EnvVarResolver
+
+
+def _make_ctx(tmp_path: Path) -> ScanContext:
+    return ScanContext(paths=[str(tmp_path)])
+
+
+class TestPythonEnvVarExtraction:
+    def test_os_getenv_in_model_kwarg(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text(
+            'from openai import OpenAI\nclient = OpenAI()\n'
+            'resp = client.chat.completions.create(\n'
+            '    model=os.getenv("LLM_MODEL"),\n'
+            '    messages=[]\n'
+            ')\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].name == "env:LLM_MODEL"
+        assert comps[0].metadata["env"] == "LLM_MODEL"
+        assert comps[0].metadata["env_context"] == "model_kwarg"
+        assert comps[0].needs_agentic is True
+
+    def test_os_environ_bracket_in_api_key(self, tmp_path: Path) -> None:
+        (tmp_path / "config.py").write_text(
+            'client = Client(api_key=os.environ["OPENAI_KEY"])\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].metadata["env"] == "OPENAI_KEY"
+        assert comps[0].metadata["env_context"] == "api_key_kwarg"
+        assert comps[0].component_type == AIComponentType.SECRET
+
+    def test_os_environ_get_in_endpoint(self, tmp_path: Path) -> None:
+        (tmp_path / "svc.py").write_text(
+            'client = AzureOpenAI(azure_endpoint=os.environ.get("AZURE_ENDPOINT"))\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].metadata["env"] == "AZURE_ENDPOINT"
+        assert comps[0].metadata["env_context"] == "endpoint_kwarg"
+
+    def test_model_name_assignment(self, tmp_path: Path) -> None:
+        (tmp_path / "run.py").write_text(
+            'model_name = os.getenv("MODEL_ID")\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].metadata["env_context"] == "model_kwarg"
+
+    def test_generic_var_model_matches_kwarg(self, tmp_path: Path) -> None:
+        """'model' is in both kwarg set and assignment set; kwarg wins."""
+        (tmp_path / "run.py").write_text(
+            'model = os.getenv("CHOSEN_MODEL")\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].metadata["env_context"] == "model_kwarg"
+
+    def test_llm_model_assignment(self, tmp_path: Path) -> None:
+        """Variable 'llm_model' not in kwarg set => falls through to assignment."""
+        (tmp_path / "run.py").write_text(
+            'llm_model = os.getenv("MY_LLM")\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].metadata["env_context"] == "model_assignment"
+
+    def test_ignores_unrelated_getenv(self, tmp_path: Path) -> None:
+        (tmp_path / "unrelated.py").write_text(
+            'log_level = os.getenv("LOG_LEVEL")\n'
+            'home = os.environ["HOME"]\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 0
+
+    def test_dedup_same_env_same_context(self, tmp_path: Path) -> None:
+        (tmp_path / "dup.py").write_text(
+            'a = client.create(model=os.getenv("LLM_MODEL"))\n'
+            'b = client.create(model=os.getenv("LLM_MODEL"))\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+
+
+class TestJavaScriptEnvVarExtraction:
+    def test_process_env_dot(self, tmp_path: Path) -> None:
+        (tmp_path / "app.ts").write_text(
+            'const client = new OpenAI({ model: process.env.OPENAI_MODEL });\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].metadata["env"] == "OPENAI_MODEL"
+
+    def test_process_env_bracket(self, tmp_path: Path) -> None:
+        (tmp_path / "svc.js").write_text(
+            'const key = process.env["API_KEY"];\n'
+            'client.init({ api_key: key });\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 0  # not directly in kwarg context
+
+
+class TestGoEnvVarExtraction:
+    def test_os_getenv_in_model_context(self, tmp_path: Path) -> None:
+        (tmp_path / "main.go").write_text(
+            'func run() {\n'
+            '    model = os.Getenv("LLM_MODEL")\n'
+            '}\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].metadata["env"] == "LLM_MODEL"
+
+
+class TestJavaEnvVarExtraction:
+    def test_system_getenv(self, tmp_path: Path) -> None:
+        (tmp_path / "App.java").write_text(
+            'String model = System.getenv("AI_MODEL");\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].metadata["env"] == "AI_MODEL"
+
+
+class TestRubyEnvVarExtraction:
+    def test_env_bracket(self, tmp_path: Path) -> None:
+        (tmp_path / "app.rb").write_text(
+            'model_name = ENV["RUBY_MODEL"]\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].metadata["env"] == "RUBY_MODEL"
+
+    def test_env_fetch(self, tmp_path: Path) -> None:
+        (tmp_path / "config.rb").write_text(
+            'model = ENV.fetch("LLM_MODEL")\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+
+
+class TestCommentSkipping:
+    def test_python_comment_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text(
+            '# model=os.getenv("COMMENTED_MODEL")\n'
+            'real = client.create(model=os.getenv("REAL_MODEL"))\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].metadata["env"] == "REAL_MODEL"
+
+    def test_js_comment_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "app.ts").write_text(
+            '// const m = { model: process.env.COMMENTED };\n'
+            'const real = { model: process.env.ACTUAL_MODEL };\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].metadata["env"] == "ACTUAL_MODEL"
+
+    def test_indented_comment_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "svc.py").write_text(
+            '    # api_key=os.getenv("OLD_KEY")\n'
+            '    api_key=os.getenv("NEW_KEY")\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].metadata["env"] == "NEW_KEY"
+
+
+class TestUnsupportedLanguage:
+    def test_txt_file_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "notes.txt").write_text(
+            'model=os.getenv("SECRET_MODEL")\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 0

--- a/aibom/tests/test_model_detector.py
+++ b/aibom/tests/test_model_detector.py
@@ -113,7 +113,8 @@ class TestModelDetector:
         )
         assert len(comps) == 1
         assert comps[0].model_name == "totally-unknown-custom-llm-id"
-        assert comps[0].confidence == 0.7
+        assert comps[0].confidence == 0.4
+        assert comps[0].needs_agentic is True
         assert comps[0].metadata.get("provider") == "unknown"
 
     def test_model_card_url_open_vs_closed(self, tmp_path: Path) -> None:
@@ -217,7 +218,8 @@ class TestModelDetector:
                 {"app.py": 'model="someorg/nonexistent-model"\n'},
             )
         assert len(comps) == 1
-        assert comps[0].confidence == 0.7
+        assert comps[0].confidence == 0.4
+        assert comps[0].needs_agentic is True
         assert comps[0].metadata["registry_source"] == "none"
 
     def test_bedrock_arn_resolves_via_alias(self, tmp_path: Path) -> None:

--- a/aibom/tests/test_multi_repo.py
+++ b/aibom/tests/test_multi_repo.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from aibom.multi_repo import (
+    ClonedRepo,
+    discover_repos,
+    is_git_url,
+    read_repos_file,
+)
+
+
+class TestIsGitUrl:
+    def test_https(self) -> None:
+        assert is_git_url("https://github.com/org/repo.git")
+
+    def test_ssh(self) -> None:
+        assert is_git_url("git@github.com:org/repo.git")
+
+    def test_git_protocol(self) -> None:
+        assert is_git_url("git://example.com/repo.git")
+
+    def test_ssh_protocol(self) -> None:
+        assert is_git_url("ssh://git@example.com/repo.git")
+
+    def test_local_path(self) -> None:
+        assert not is_git_url("/home/user/repo")
+
+    def test_relative_path(self) -> None:
+        assert not is_git_url("./repo")
+
+    def test_empty(self) -> None:
+        assert not is_git_url("")
+
+
+class TestDiscoverRepos:
+    def test_finds_git_repos(self, tmp_path: Path) -> None:
+        (tmp_path / "repo-a" / ".git").mkdir(parents=True)
+        (tmp_path / "repo-b" / ".git").mkdir(parents=True)
+        (tmp_path / "not-a-repo").mkdir()
+
+        repos = discover_repos(tmp_path)
+        names = [r.name for r in repos]
+        assert "repo-a" in names
+        assert "repo-b" in names
+        assert "not-a-repo" not in names
+
+    def test_nested_repos(self, tmp_path: Path) -> None:
+        (tmp_path / "org" / "project" / ".git").mkdir(parents=True)
+        repos = discover_repos(tmp_path)
+        assert len(repos) == 1
+        assert repos[0].name == "project"
+
+    def test_respects_max_depth(self, tmp_path: Path) -> None:
+        deep = tmp_path / "a" / "b" / "c" / "d" / ".git"
+        deep.mkdir(parents=True)
+        assert discover_repos(tmp_path, max_depth=2) == []
+        assert len(discover_repos(tmp_path, max_depth=4)) == 1
+
+    def test_stops_at_git_root(self, tmp_path: Path) -> None:
+        (tmp_path / "parent" / ".git").mkdir(parents=True)
+        (tmp_path / "parent" / "nested" / ".git").mkdir(parents=True)
+        repos = discover_repos(tmp_path)
+        assert len(repos) == 1
+        assert repos[0].name == "parent"
+
+    def test_nonexistent_dir(self, tmp_path: Path) -> None:
+        assert discover_repos(tmp_path / "no-such") == []
+
+    def test_empty_dir(self, tmp_path: Path) -> None:
+        assert discover_repos(tmp_path) == []
+
+
+class TestReadReposFile:
+    def test_json_array(self, tmp_path: Path) -> None:
+        f = tmp_path / "repos.json"
+        f.write_text(json.dumps(["/repo/a", "/repo/b"]))
+        assert read_repos_file(f) == ["/repo/a", "/repo/b"]
+
+    def test_newline_delimited(self, tmp_path: Path) -> None:
+        f = tmp_path / "repos.txt"
+        f.write_text("/repo/a\n/repo/b\n\n# comment\n/repo/c\n")
+        result = read_repos_file(f)
+        assert result == ["/repo/a", "/repo/b", "/repo/c"]
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "empty.txt"
+        f.write_text("")
+        assert read_repos_file(f) == []
+
+    def test_json_with_git_urls(self, tmp_path: Path) -> None:
+        urls = ["https://github.com/org/a.git", "git@github.com:org/b.git"]
+        f = tmp_path / "urls.json"
+        f.write_text(json.dumps(urls))
+        assert read_repos_file(f) == urls
+
+    def test_mixed_text(self, tmp_path: Path) -> None:
+        f = tmp_path / "mixed.txt"
+        f.write_text("# local repos\n/local/repo\nhttps://github.com/org/repo\n")
+        result = read_repos_file(f)
+        assert len(result) == 2
+
+
+class TestClonedRepo:
+    @patch("aibom.multi_repo.subprocess.run")
+    def test_clone_success(self, mock_run: object, tmp_path: Path) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(  # type: ignore[attr-defined]
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        with patch("aibom.multi_repo.tempfile.mkdtemp", return_value=str(tmp_path)):
+            with ClonedRepo("https://github.com/org/repo.git") as path:
+                assert path == tmp_path
+
+    @patch("aibom.multi_repo.subprocess.run")
+    def test_clone_failure_raises(self, mock_run: object) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(  # type: ignore[attr-defined]
+            args=[], returncode=128, stdout="", stderr="fatal: not found"
+        )
+        with pytest.raises(RuntimeError, match="git clone failed"):
+            with ClonedRepo("https://github.com/org/bad.git") as _:
+                pass
+
+    @patch("aibom.multi_repo.subprocess.run")
+    def test_branch_option(self, mock_run: object, tmp_path: Path) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(  # type: ignore[attr-defined]
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        with patch("aibom.multi_repo.tempfile.mkdtemp", return_value=str(tmp_path)):
+            with ClonedRepo("https://github.com/org/repo.git", branch="dev") as _:
+                call_args = mock_run.call_args[0][0]  # type: ignore[attr-defined]
+                assert "--branch" in call_args
+                assert "dev" in call_args

--- a/aibom/tests/test_platform_adapters.py
+++ b/aibom/tests/test_platform_adapters.py
@@ -1,0 +1,339 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import httpx
+import respx
+import pytest
+
+from aibom.platform_adapters import (
+    BitbucketAdapter,
+    GitHubAdapter,
+    GitLabAdapter,
+    RepoInfo,
+    get_adapter,
+)
+
+
+def _gh_repo(
+    name: str,
+    *,
+    archived: bool = False,
+    topics: list[str] | None = None,
+) -> dict:
+    return {
+        "name": name,
+        "full_name": f"org/{name}",
+        "clone_url": f"https://github.com/org/{name}.git",
+        "default_branch": "main",
+        "topics": topics or [],
+        "language": "Python",
+        "description": f"{name} repo",
+        "archived": archived,
+    }
+
+
+def _gl_repo(name: str, group: str = "my-group") -> dict:
+    return {
+        "name": name,
+        "path_with_namespace": f"{group}/{name}",
+        "http_url_to_repo": f"https://gitlab.com/{group}/{name}.git",
+        "default_branch": "main",
+        "topics": [],
+        "description": f"{name} project",
+    }
+
+
+_GH_ORG_REPOS = "https://api.github.com/orgs/{ns}/repos?per_page=100"
+_GH_USER_REPOS = "https://api.github.com/users/{ns}/repos?per_page=100"
+_GL_GROUP_PROJECTS = (
+    "https://gitlab.com/api/v4/groups/{ns}/projects"
+    "?per_page=100&include_subgroups=true"
+)
+_GL_GROUP_PROJECTS_INTERNAL = (
+    "https://gitlab.internal.com/api/v4/groups/{ns}/projects"
+    "?per_page=100&include_subgroups=true"
+)
+_BB_WS = "https://api.bitbucket.org/2.0/repositories/{ws}?pagelen=100"
+
+
+class TestGetAdapter:
+    def test_github_aliases(self) -> None:
+        assert isinstance(get_adapter("github"), GitHubAdapter)
+        assert isinstance(get_adapter("gh"), GitHubAdapter)
+
+    def test_gitlab_aliases(self) -> None:
+        assert isinstance(get_adapter("gitlab"), GitLabAdapter)
+        assert isinstance(get_adapter("gl"), GitLabAdapter)
+
+    def test_bitbucket_aliases(self) -> None:
+        assert isinstance(get_adapter("bitbucket"), BitbucketAdapter)
+        assert isinstance(get_adapter("bb"), BitbucketAdapter)
+
+    def test_unknown_raises(self) -> None:
+        with pytest.raises(ValueError):
+            get_adapter("unknown")
+
+
+class TestGitHubAdapter:
+    @respx.mock(assert_all_called=False)
+    def test_list_org_repos(self, respx_mock: respx.MockRouter) -> None:
+        payload = json.loads(json.dumps([_gh_repo("r1"), _gh_repo("r2")]))
+        respx_mock.get(_GH_ORG_REPOS.format(ns="my-org")).mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        repos = GitHubAdapter().list_repos("my-org")
+        assert len(repos) == 2
+        assert repos[0] == RepoInfo(
+            name="r1",
+            full_name="org/r1",
+            clone_url="https://github.com/org/r1.git",
+            default_branch="main",
+            topics=[],
+            language="Python",
+            description="r1 repo",
+            is_archived=False,
+        )
+        assert repos[1].name == "r2"
+
+    @respx.mock(assert_all_called=False)
+    def test_falls_back_to_user(self, respx_mock: respx.MockRouter) -> None:
+        respx_mock.get(_GH_ORG_REPOS.format(ns="my-user")).mock(
+            return_value=httpx.Response(404)
+        )
+        respx_mock.get(_GH_USER_REPOS.format(ns="my-user")).mock(
+            return_value=httpx.Response(200, json=[_gh_repo("solo")])
+        )
+        repos = GitHubAdapter().list_repos("my-user")
+        assert len(repos) == 1
+        assert repos[0].name == "solo"
+
+    @respx.mock(assert_all_called=False)
+    def test_name_filter(self, respx_mock: respx.MockRouter) -> None:
+        payload = [
+            _gh_repo("frontend"),
+            _gh_repo("api-gateway"),
+            _gh_repo("billing-api"),
+        ]
+        respx_mock.get(_GH_ORG_REPOS.format(ns="o")).mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        repos = GitHubAdapter().list_repos("o", name_filter="api")
+        assert [r.name for r in repos] == ["api-gateway", "billing-api"]
+
+    @respx.mock(assert_all_called=False)
+    def test_topic_filter(self, respx_mock: respx.MockRouter) -> None:
+        payload = [
+            _gh_repo("a", topics=["ai", "ml"]),
+            _gh_repo("b", topics=[]),
+            _gh_repo("c", topics=["other"]),
+        ]
+        respx_mock.get(_GH_ORG_REPOS.format(ns="o")).mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        repos = GitHubAdapter().list_repos("o", topic_filter="ai")
+        assert len(repos) == 1
+        assert repos[0].name == "a"
+
+    @respx.mock(assert_all_called=False)
+    def test_excludes_archived(self, respx_mock: respx.MockRouter) -> None:
+        payload = [_gh_repo("live"), _gh_repo("old", archived=True)]
+        respx_mock.get(_GH_ORG_REPOS.format(ns="o")).mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        repos = GitHubAdapter().list_repos("o")
+        assert [r.name for r in repos] == ["live"]
+
+    @respx.mock(assert_all_called=False)
+    def test_includes_archived(self, respx_mock: respx.MockRouter) -> None:
+        payload = [_gh_repo("live"), _gh_repo("old", archived=True)]
+        respx_mock.get(_GH_ORG_REPOS.format(ns="o")).mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        repos = GitHubAdapter().list_repos("o", include_archived=True)
+        assert [r.name for r in repos] == ["live", "old"]
+
+    @respx.mock(assert_all_called=False)
+    def test_auth_header(self, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.get(_GH_ORG_REPOS.format(ns="my-org")).mock(
+            return_value=httpx.Response(200, json=json.loads("[]"))
+        )
+        GitHubAdapter(token="ghp_xxx").list_repos("my-org")
+        assert route.called
+        hdrs = route.calls.last.request.headers
+        assert hdrs["Authorization"] == "Bearer ghp_xxx"
+
+    @respx.mock(assert_all_called=False)
+    def test_api_error_returns_empty(
+        self, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.get(_GH_ORG_REPOS.format(ns="my-org")).mock(
+            return_value=httpx.Response(500)
+        )
+        assert GitHubAdapter().list_repos("my-org") == []
+
+
+class TestGitLabAdapter:
+    @respx.mock(assert_all_called=False)
+    def test_list_group_repos(self, respx_mock: respx.MockRouter) -> None:
+        payload = [_gl_repo("p1")]
+        respx_mock.get(_GL_GROUP_PROJECTS.format(ns="my-group")).mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        repos = GitLabAdapter().list_repos("my-group")
+        assert len(repos) == 1
+        assert repos[0] == RepoInfo(
+            name="p1",
+            full_name="my-group/p1",
+            clone_url="https://gitlab.com/my-group/p1.git",
+            default_branch="main",
+            topics=[],
+            language="",
+            description="p1 project",
+            is_archived=False,
+        )
+
+    @respx.mock(assert_all_called=False)
+    def test_name_filter(self, respx_mock: respx.MockRouter) -> None:
+        payload = [
+            _gl_repo("frontend", group="g"),
+            _gl_repo("api-gateway", group="g"),
+            _gl_repo("billing-api", group="g"),
+        ]
+        respx_mock.get(_GL_GROUP_PROJECTS.format(ns="g")).mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        repos = GitLabAdapter().list_repos("g", name_filter="api")
+        assert [r.name for r in repos] == ["api-gateway", "billing-api"]
+
+    @respx.mock(assert_all_called=False)
+    def test_auth_header(self, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.get(_GL_GROUP_PROJECTS.format(ns="g")).mock(
+            return_value=httpx.Response(200, json=json.loads("[]"))
+        )
+        GitLabAdapter(token="gl_xxx").list_repos("g")
+        assert route.called
+        assert route.calls.last.request.headers["PRIVATE-TOKEN"] == "gl_xxx"
+
+    @respx.mock(assert_all_called=False)
+    def test_custom_base_url(self, respx_mock: respx.MockRouter) -> None:
+        respx_mock.get(_GL_GROUP_PROJECTS_INTERNAL.format(ns="my-group")).mock(
+            return_value=httpx.Response(200, json=json.loads("[]"))
+        )
+        GitLabAdapter(base_url="https://gitlab.internal.com").list_repos(
+            "my-group"
+        )
+
+
+class TestBitbucketAdapter:
+    @respx.mock(assert_all_called=False)
+    def test_list_workspace_repos(self, respx_mock: respx.MockRouter) -> None:
+        body = {
+            "values": [
+                {
+                    "name": "repo1",
+                    "full_name": "my-workspace/repo1",
+                    "links": {
+                        "clone": [
+                            {
+                                "name": "https",
+                                "href": (
+                                    "https://bitbucket.org/"
+                                    "my-workspace/repo1.git"
+                                ),
+                            }
+                        ]
+                    },
+                    "mainbranch": {"name": "main"},
+                    "language": "python",
+                    "description": "desc",
+                }
+            ],
+            "next": None,
+        }
+        respx_mock.get(_BB_WS.format(ws="my-workspace")).mock(
+            return_value=httpx.Response(200, json=body)
+        )
+        repos = BitbucketAdapter().list_repos("my-workspace")
+        assert len(repos) == 1
+        assert repos[0] == RepoInfo(
+            name="repo1",
+            full_name="my-workspace/repo1",
+            clone_url="https://bitbucket.org/my-workspace/repo1.git",
+            default_branch="main",
+            topics=[],
+            language="python",
+            description="desc",
+            is_archived=False,
+        )
+
+    @respx.mock(assert_all_called=False)
+    def test_pagination(self, respx_mock: respx.MockRouter) -> None:
+        page2_url = (
+            "https://api.bitbucket.org/2.0/repositories/w?page=2"
+        )
+        page1 = {
+            "values": [
+                {
+                    "name": "r1",
+                    "full_name": "w/r1",
+                    "links": {
+                        "clone": [
+                            {
+                                "name": "https",
+                                "href": "https://bitbucket.org/w/r1.git",
+                            }
+                        ]
+                    },
+                    "mainbranch": {"name": "main"},
+                    "language": None,
+                    "description": None,
+                }
+            ],
+            "next": page2_url,
+        }
+        page2 = {
+            "values": [
+                {
+                    "name": "r2",
+                    "full_name": "w/r2",
+                    "links": {
+                        "clone": [
+                            {
+                                "name": "https",
+                                "href": "https://bitbucket.org/w/r2.git",
+                            }
+                        ]
+                    },
+                    "mainbranch": {"name": "develop"},
+                    "language": None,
+                    "description": None,
+                }
+            ],
+            "next": None,
+        }
+        respx_mock.get(_BB_WS.format(ws="w")).mock(
+            return_value=httpx.Response(200, json=page1)
+        )
+        respx_mock.get(page2_url).mock(
+            return_value=httpx.Response(200, json=page2)
+        )
+        repos = BitbucketAdapter().list_repos("w")
+        assert [r.name for r in repos] == ["r1", "r2"]
+
+
+class TestRepoInfo:
+    def test_defaults(self) -> None:
+        r = RepoInfo(
+            name="n",
+            full_name="o/n",
+            clone_url="https://example.com/o/n.git",
+        )
+        assert r.default_branch == "main"
+        assert r.topics == []
+        assert r.language == ""
+        assert r.description == ""
+        assert r.is_archived is False

--- a/aibom/tests/test_scan_pipeline.py
+++ b/aibom/tests/test_scan_pipeline.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aibom.models.enums import AIComponentType
+from aibom.scan_pipeline import ScanPipeline
+
+
+class TestScanPipeline:
+    def test_basic_run(self, tmp_path: Path) -> None:
+        """A scan path with a simple Python file should complete all 4 stages."""
+        (tmp_path / "app.py").write_text(
+            'from openai import OpenAI\nclient = OpenAI(model="gpt-4o")\n'
+        )
+        pipeline = ScanPipeline(scan_paths=[str(tmp_path)])
+        result = pipeline.run()
+        assert result.components is not None
+        assert result.env_index is not None
+        assert result.pkg_index is not None
+
+    def test_strict_filters_agentic(self, tmp_path: Path) -> None:
+        """Strict mode should remove agentic candidates from results."""
+        (tmp_path / "values.yaml").write_text(
+            "inference:\n  model: some-custom-thing\n"
+        )
+        pipeline_relaxed = ScanPipeline(
+            scan_paths=[str(tmp_path)], strict=False
+        )
+        result_relaxed = pipeline_relaxed.run()
+
+        pipeline_strict = ScanPipeline(
+            scan_paths=[str(tmp_path)], strict=True
+        )
+        result_strict = pipeline_strict.run()
+
+        agentic_relaxed = [c for c in result_relaxed.components if c.needs_agentic]
+        agentic_strict = [c for c in result_strict.components if c.needs_agentic]
+        assert len(agentic_strict) == 0
+        if agentic_relaxed:
+            assert result_strict.agentic_candidate_count > 0
+
+    def test_cross_ref_resolution(self, tmp_path: Path) -> None:
+        """EnvVarResolver + cross-ref should wire env vars to config values."""
+        (tmp_path / ".env").write_text("LLM_MODEL=gpt-4o\n")
+        (tmp_path / "app.py").write_text(
+            'import os\nfrom openai import OpenAI\n'
+            'client = OpenAI()\n'
+            'resp = client.chat.completions.create(\n'
+            '    model=os.getenv("LLM_MODEL"),\n'
+            '    messages=[]\n'
+            ')\n'
+        )
+        pipeline = ScanPipeline(scan_paths=[str(tmp_path)])
+        result = pipeline.run()
+
+        env_comps = [
+            c for c in result.components if c.name.startswith("env:")
+        ]
+        resolved = [
+            c for c in env_comps
+            if c.model_name and c.model_name == "gpt-4o"
+        ]
+        if env_comps:
+            assert any(
+                c.metadata.get("resolved_value") == "gpt-4o" or c.model_name == "gpt-4o"
+                for c in env_comps
+            )
+
+    def test_external_deps_detected(self, tmp_path: Path) -> None:
+        """Pipeline should detect cross-repo git dependencies."""
+        (tmp_path / "pyproject.toml").write_text(
+            """[tool.poetry.dependencies]
+python = "^3.11"
+ai-common = {git = "https://github.com/org/ai-common.git", branch = "main"}
+""",
+            encoding="utf-8",
+        )
+        (tmp_path / "app.py").write_text("print('hello')\n")
+        pipeline = ScanPipeline(scan_paths=[str(tmp_path)])
+        result = pipeline.run()
+        assert len(result.external_deps) >= 1
+        assert result.external_deps[0].name == "ai-common"
+
+    def test_empty_path(self, tmp_path: Path) -> None:
+        """Empty scan path should return empty results gracefully."""
+        pipeline = ScanPipeline(scan_paths=[str(tmp_path)])
+        result = pipeline.run()
+        assert result.components == [] or isinstance(result.components, list)
+        assert result.agentic_candidate_count >= 0
+
+
+class TestResolveComponentsProvenance:
+    def test_provenance_metadata_added(self, tmp_path: Path) -> None:
+        """Resolved env vars should carry provenance in metadata."""
+        (tmp_path / ".env").write_text("MODEL_VAR=gpt-4o\n")
+        (tmp_path / "main.py").write_text(
+            'import os\n'
+            'model=os.getenv("MODEL_VAR")\n'
+        )
+        pipeline = ScanPipeline(scan_paths=[str(tmp_path)])
+        result = pipeline.run()
+
+        env_comps = [
+            c for c in result.components
+            if c.metadata.get("env") == "MODEL_VAR"
+        ]
+        for c in env_comps:
+            if c.metadata.get("resolved_from"):
+                assert c.metadata["resolved_from"] == "dotenv"
+                assert "resolved_source_file" in c.metadata


### PR DESCRIPTION
## Summary

Implements cross-reference resolution, scan pipeline restructuring, and cross-repository dependency detection to significantly improve detection precision and reduce false positives.

### Cross-Reference Resolution

- **EnvVarResolver scanner** — extracts environment variable references (`os.getenv`, `process.env`, `os.Getenv`, `System.getenv`, `ENV[]`) from Python, JavaScript/TypeScript, Go, Java, and Ruby source code when used in AI-related keyword arguments (`model=`, `api_key=`, `endpoint=`, etc.); correctly skips commented-out lines
- **Enhanced `resolve_components()`** — traces env var references to their definitions in `.env`, `docker-compose.yaml`, Helm `values.yaml`, Terraform `.tfvars`; adds provenance metadata on resolution; validates resolved model names against LiteLLM and HuggingFace registries; flags unresolved references as agentic candidates with actionable hints

### Scan Pipeline

- **`ScanPipeline` class** — extracts scan orchestration from `cli.py` into a clean four-stage pipeline: scan → cross-ref → agentic → assemble. `cli.py` is now focused on argument parsing and output formatting.

### Cross-Repository Dependency Detection

- **`detect_external_repo_deps()`** — parses dependency manifests for external repository references:
  - Poetry (`pyproject.toml` git + path dependencies)
  - uv (`[tool.uv.sources]` git + path references)
  - pip (`requirements.txt` git URLs, editable `-e` paths)
  - npm (`package.json` git and `file:` dependencies)
  - Go (`go.mod` `replace` directives for local paths and remote modules)
- Flags path dependencies that escape the repository root and prompts users to include missing repositories in the scan

### IaC and Deployment Detection

- **Deployment detector** — identifies AI assets in Infrastructure-as-Code files across Helm/K8s, Terraform, CloudFormation, Azure ARM, and Bicep; distinguishes known model names (via registry validation) from ambiguous deployment references
- **`import_context.py`** — shared utility for checking ML/LLM/Agent/MCP framework import presence, used by multiple scanners to gate ambiguous pattern matches

### Three-Tier Detection Confidence

- **`AIComponent` model** — adds `confidence`, `needs_agentic`, and `agentic_hint` fields
- **Scanner refactoring** — `config_scanner`, `mcp_detector`, `ml_lifecycle_detector`, `model_detector`, `multi_language_scanner`, and `secret_detector` now emit tiered confidence levels: high-confidence for structurally certain detections, low-confidence agentic candidates for ambiguous matches
- **`--strict` CLI flag** — emits only high-confidence confirmed components
- **Agentic recommendation** — when ambiguous candidates exist and `--llm-model` is not provided, the CLI recommends re-running with agentic enrichment

### Model Registry Improvements

- Adds `gpt-4-32k` (deprecated), `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.5`, `text-embedding-ada-002` (deprecated), `text-embedding-3-small`, `text-embedding-3-large` to the builtin registry

### Agentic Provider Support

- Fixes provider inference for `ollama/` and `bedrock_converse/` model strings by explicitly parsing the provider prefix
- Removes hard requirement for `--llm-api-base` (not needed for Bedrock or Ollama)
- Adds clear error messaging when a `langchain-<provider>` package is missing

### Multi-Repository Scaffolding

- `multi_repo.py` — repo discovery and Git clone utilities
- `dep_graph.py` — inter-repository dependency graph construction
- `platform_adapters.py` — GitHub, GitLab, Bitbucket API adapters
- `agentic/cross_repo.py` — agentic cross-repo reasoning tools

## Test plan

- [x] `test_env_var_resolver.py` — env var extraction across 5 languages, kwarg context classification, comment skipping
- [x] `test_cross_ref.py` — provenance metadata on resolution, registry validation upgrade, unresolved agentic flagging
- [x] `test_cross_repo_detection.py` — Poetry/uv/pip/npm/Go dependency detection, escaping path flags
- [x] `test_scan_pipeline.py` — pipeline execution, strict mode filtering, cross-ref wiring
- [x] `test_deployment_detector.py` — IaC scanning across Helm, K8s, Terraform, CloudFormation, ARM, Bicep
- [x] `test_model_detector.py` — unknown model confidence downgrade, registry hit validation
- [x] `test_dep_graph.py`, `test_multi_repo.py`, `test_platform_adapters.py` — scaffolding unit tests
- [x] E2E validation against real multi-repo codebases in both deterministic and agentic modes