### PR TITLE
pin litellm==1.80.16 and bump version to 0.5.2

### DIFF
--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-aibom"
-version = "0.5.1"
+version = "0.5.2"
 description = "A tool to generate an AI BOM from source code."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -20,7 +20,7 @@ dependencies = [
     "libcst>=1.0.0",
     "duckdb>=1.0.0",
     "typer>=0.9.0",
-    "litellm>=1.77.0",
+    "litellm==1.80.16",
     "pandas>=2.0.0",
     "fastapi>=0.104.0",
     "uvicorn>=0.24.0",

--- a/aibom/src/aibom/manifest.json
+++ b/aibom/src/aibom/manifest.json
@@ -1,8 +1,8 @@
 {
-  "analyzer_version": "0.5.1",
-  "schema_version": "0.5.1",
+  "analyzer_version": "0.5.2",
+  "schema_version": "0.5.2",
   "duckdb_sha256": "b1165384a646094aa6a4762d676f285c1c68b6d7f9367c90a129b529904a3268",
-  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-0.5.1.duckdb",
+  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-0.5.2.duckdb",
   "upload_mode": "direct",
   "max_direct_upload_mb": 25,
   "log_level": "INFO"

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "cisco-aibom"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -280,7 +280,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "libcst", specifier = ">=1.0.0" },
-    { name = "litellm", specifier = ">=1.77.0" },
+    { name = "litellm", specifier = "==1.80.16" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "pydantic", specifier = ">=2.6.0" },


### PR DESCRIPTION
Pin litellm to the 1.80.16 to prevent https://futuresearch.ai/blog/litellm-pypi-supply-chain-attack/ and update release version.