### PR TITLE
feat(perf): Phase 5 — performance, agentic reliability, and precision

### DIFF
--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pathspec>=0.12.0",
     "cyclonedx-python-lib>=9.0.0",
     "jinja2>=3.1.0",
+    "aiofiles>=24.1.0",
 ]
 
 [project.scripts]

--- a/aibom/scripts/build_catalog.py
+++ b/aibom/scripts/build_catalog.py
@@ -114,6 +114,16 @@ def build_catalog(
 
     count = con.execute("SELECT COUNT(*) FROM component_catalog").fetchone()[0]
     print(f"Catalog built with {count} entries.")
+
+    con.execute(
+        """
+        CREATE TABLE component_catalog_last_seg AS
+        SELECT id, split_part(id, '.', -1) AS last_seg
+        FROM component_catalog;
+        """
+    )
+    print("Built component_catalog_last_seg token table.")
+
     con.close()
 
     digest = _sha256(output_path)

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -23,14 +23,18 @@ when the user passes ``--agent-model`` to the CLI.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import time
+from pathlib import Path
 from typing import Any, Optional
 
 from ..models import (
     AIComponent,
     ComponentRelationship,
     DetectionSource,
+    RelationshipType,
     RiskFlag,
     ScanResult,
     SourceResult,
@@ -43,6 +47,25 @@ _LOGGER = logging.getLogger(__name__)
 
 class AgenticEnrichmentError(Exception):
     """Raised when the agentic enrichment pipeline fails."""
+
+
+def _configure_rate_limiter(init_kwargs: dict[str, Any]) -> None:
+    """Attach a client-side rate limiter to the LLM unless one is already set.
+
+    ``rate_limiter`` is a first-class field on LangChain's ``BaseChatModel``,
+    so it works for *every* provider (Bedrock, OpenAI, Anthropic, Azure,
+    Ollama, etc.) without provider-specific branching.  It proactively
+    throttles outgoing requests so the provider never sees a burst — preventing
+    rate-limit errors rather than recovering from them after the fact.
+    """
+    if "rate_limiter" not in init_kwargs:
+        from langchain_core.rate_limiters import InMemoryRateLimiter
+
+        init_kwargs["rate_limiter"] = InMemoryRateLimiter(
+            requests_per_second=1.0,
+            check_every_n_seconds=0.1,
+            max_bucket_size=10,
+        )
 
 
 def create_aibom_agent(
@@ -93,17 +116,20 @@ def create_aibom_agent(
         if llm_config.get("api_version") and provider_prefix == "azure_openai":
             init_kwargs["api_version"] = llm_config["api_version"]
 
+    _configure_rate_limiter(init_kwargs)
+
     try:
         model = init_chat_model(model_id, **init_kwargs)
     except ImportError as exc:
-        provider = init_kwargs.get("model_provider", "unknown")
-        raise ImportError(
-            f"Provider '{provider}' requires its LangChain integration package. "
-            f"Install it with: pip install langchain-{provider}\n"
-            f"Original error: {exc}"
-        ) from exc
+        raise ImportError(str(exc)) from exc
     tools = build_tools()
 
+    # NOTE: LangGraph's recommended proactive approach (RemainingSteps in
+    # the graph state) cannot be used here because Deep Agents merges all
+    # middleware state schemas into Input/Output schemas where managed
+    # channels are forbidden.  We rely on the reactive approach instead:
+    # _RECURSION_LIMIT=1000 (safety net) + GraphRecursionError catch in
+    # _run_batch / _run_batch_async.
     agent = create_deep_agent(
         model=model,
         tools=tools,
@@ -113,94 +139,421 @@ def create_aibom_agent(
     return agent
 
 
+_DEFAULT_BATCH_SIZE = 5
+
+# LangGraph default since v1.0.6 and also the Deep Agents default.
+# Set explicitly so the intent is clear: this is a safety net against
+# infinite loops, NOT a workload budget.
+_RECURSION_LIMIT = 1000
+
+_MAX_CONCURRENT_BATCHES = 1
+
+_SIMPLE_CANDIDATE_TYPES = frozenset({"model", "dependency", "embedding"})
+
+
+def _classify_candidates(
+    components: list[AIComponent],
+) -> tuple[list[AIComponent], list[AIComponent]]:
+    """Split candidates into simple (registry-confirmable) vs complex.
+
+    Simple candidates: known model/dependency/embedding with a model_name
+    that just needs registry lookup confirmation.
+    Complex candidates: everything else — ambiguous types, missing model
+    names, multi-file reasoning required.
+    """
+    simple: list[AIComponent] = []
+    complex_: list[AIComponent] = []
+    for c in components:
+        is_simple = (
+            c.component_type.value in _SIMPLE_CANDIDATE_TYPES
+            and c.model_name
+            and not c.metadata.get("env_var_ref")
+            and not c.metadata.get("env")
+            and not c.metadata.get("partial_kb_id")
+            and not c.metadata.get("suggestive_signal")
+        )
+        if is_simple:
+            simple.append(c)
+        else:
+            complex_.append(c)
+    return simple, complex_
+
+
+def _run_batch(
+    agent: Any,
+    middleware: AIBOMScannerMiddleware,
+    batch: list[AIComponent],
+    relationships: list[ComponentRelationship],
+    scan_paths: list[str],
+    batch_num: int,
+    total_batches: int,
+    all_components: list[AIComponent] | None = None,
+) -> tuple[list[AIComponent], list[AIComponent], list[ComponentRelationship], list[RiskFlag]]:
+    """Invoke the agent on a single batch and return parsed results."""
+    from .tools import _reset_tool_stats, get_tool_stats
+
+    _reset_tool_stats()
+    _LOGGER.info(
+        "Agentic batch %d/%d — %d components [%s]",
+        batch_num, total_batches, len(batch),
+        ", ".join(c.name for c in batch),
+    )
+    summary = _build_context_message(
+        batch, relationships, scan_paths, all_components=all_components,
+    )
+    t0 = time.monotonic()
+
+    try:
+        result = agent.invoke(
+            {"messages": [{"role": "user", "content": summary}]},
+            config={"recursion_limit": _RECURSION_LIMIT},
+        )
+    except Exception as exc:
+        elapsed = time.monotonic() - t0
+        stats = get_tool_stats()
+        _LOGGER.warning(
+            "Batch %d failed after %.1fs: %s | tool_stats=%s",
+            batch_num, elapsed, exc, json.dumps(stats),
+        )
+        return batch, [], [], []
+
+    elapsed = time.monotonic() - t0
+    stats = get_tool_stats()
+    total_tool_calls = sum(s["calls"] for s in stats.values())
+    total_tool_time = sum(s["total_s"] for s in stats.values())
+
+    _LOGGER.info(
+        "Batch %d completed in %.1fs — %d tool calls (%.1fs tool time) | breakdown=%s",
+        batch_num, elapsed, total_tool_calls, total_tool_time,
+        json.dumps(stats),
+    )
+
+    final_message = _extract_final_message(result)
+    if not final_message:
+        _LOGGER.warning("Batch %d returned no usable output", batch_num)
+        return batch, [], [], []
+
+    new_components, new_rels, risk_flags = middleware.extract_findings(final_message)
+    enriched = middleware.apply_enrichments(batch, final_message)
+    return enriched, new_components, new_rels, risk_flags
+
+
+async def _run_batch_async(
+    agent: Any,
+    middleware: AIBOMScannerMiddleware,
+    batch: list[AIComponent],
+    relationships: list[ComponentRelationship],
+    scan_paths: list[str],
+    batch_num: int,
+    total_batches: int,
+    all_components: list[AIComponent] | None = None,
+) -> tuple[list[AIComponent], list[AIComponent], list[ComponentRelationship], list[RiskFlag]]:
+    """Async version of _run_batch using agent.ainvoke()."""
+    from .tools import _reset_tool_stats, get_tool_stats
+
+    _reset_tool_stats()
+    _LOGGER.info(
+        "Agentic batch %d/%d — %d components [%s]",
+        batch_num, total_batches, len(batch),
+        ", ".join(c.name for c in batch),
+    )
+    summary = _build_context_message(
+        batch, relationships, scan_paths, all_components=all_components,
+    )
+    t0 = time.monotonic()
+
+    try:
+        result = await agent.ainvoke(
+            {"messages": [{"role": "user", "content": summary}]},
+            config={"recursion_limit": _RECURSION_LIMIT},
+        )
+    except Exception as exc:
+        elapsed = time.monotonic() - t0
+        stats = get_tool_stats()
+        _LOGGER.warning(
+            "Batch %d failed after %.1fs: %s | tool_stats=%s",
+            batch_num, elapsed, exc, json.dumps(stats),
+        )
+        return batch, [], [], []
+
+    elapsed = time.monotonic() - t0
+    stats = get_tool_stats()
+    total_tool_calls = sum(s["calls"] for s in stats.values())
+    total_tool_time = sum(s["total_s"] for s in stats.values())
+
+    _LOGGER.info(
+        "Batch %d completed in %.1fs — %d tool calls (%.1fs tool time) | breakdown=%s",
+        batch_num, elapsed, total_tool_calls, total_tool_time,
+        json.dumps(stats),
+    )
+
+    final_message = _extract_final_message(result)
+    if not final_message:
+        _LOGGER.warning("Batch %d returned no usable output", batch_num)
+        return batch, [], [], []
+
+    new_components, new_rels, risk_flags = middleware.extract_findings(final_message)
+    enriched = middleware.apply_enrichments(batch, final_message)
+    return enriched, new_components, new_rels, risk_flags
+
+
+async def _run_batches_parallel(
+    agent: Any,
+    middleware: AIBOMScannerMiddleware,
+    batches: list[list[AIComponent]],
+    relationships: list[ComponentRelationship],
+    scan_paths: list[str],
+    all_components: list[AIComponent] | None = None,
+    max_concurrent: int = _MAX_CONCURRENT_BATCHES,
+) -> tuple[list[AIComponent], list[AIComponent], list[ComponentRelationship], list[RiskFlag]]:
+    """Run batches concurrently, capped at *max_concurrent* simultaneous LLM conversations."""
+    sem = asyncio.Semaphore(max_concurrent)
+
+    async def _guarded(batch: list[AIComponent], idx: int) -> tuple[list[AIComponent], list[AIComponent], list[ComponentRelationship], list[RiskFlag]]:
+        async with sem:
+            return await _run_batch_async(
+                agent, middleware, batch,
+                relationships, scan_paths,
+                idx, len(batches),
+                all_components=all_components,
+            )
+
+    tasks = [_guarded(batch, idx) for idx, batch in enumerate(batches, 1)]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    all_enriched: list[AIComponent] = []
+    all_new: list[AIComponent] = []
+    all_rels: list[ComponentRelationship] = []
+    all_flags: list[RiskFlag] = []
+
+    for i, r in enumerate(results):
+        if isinstance(r, Exception):
+            _LOGGER.warning("Parallel batch %d raised: %s", i + 1, r)
+            all_enriched.extend(batches[i])
+            continue
+        enriched, new, rels, flags = r
+        all_enriched.extend(enriched)
+        all_new.extend(new)
+        all_rels.extend(rels)
+        all_flags.extend(flags)
+
+    return all_enriched, all_new, all_rels, all_flags
+
+
 def run_agentic_enrichment(
     model_string: str,
     deterministic_components: list[AIComponent],
     deterministic_relationships: list[ComponentRelationship],
     scan_paths: list[str],
     llm_config: dict[str, Any] | None = None,
+    batch_size: int = _DEFAULT_BATCH_SIZE,
+    fast_model: str | None = None,
 ) -> tuple[list[AIComponent], list[ComponentRelationship], list[RiskFlag]]:
-    """Run the full agentic enrichment pipeline.
+    """Run the full agentic enrichment pipeline with batching and tiered models.
 
-    1. Creates the AIBOM agent with the specified model.
-    2. Feeds the deterministic scan results as context.
-    3. Invokes the agent to enrich, resolve, and discover.
-    4. Parses the agent's output and merges into AIBOM model objects.
+    Parameters
+    ----------
+    model_string:
+        Primary LLM model (used for complex candidates).
+    deterministic_components:
+        Components from the deterministic pipeline.
+    deterministic_relationships:
+        Relationships from the deterministic pipeline.
+    scan_paths:
+        Paths being scanned.
+    llm_config:
+        LLM connection config (api_key, api_base, etc.).
+    batch_size:
+        Max components per agent invocation (default 5).
+    fast_model:
+        Optional cheaper/faster model for simple confirmations.
+        Falls back to ``model_string`` if not provided.
 
     Returns
     -------
     Tuple of (enriched_components, new_relationships, risk_flags).
-    The enriched_components list includes both the original components
-    (with any updates applied) and any new components the agent discovered.
     """
-    agent = create_aibom_agent(model_string, llm_config=llm_config)
-    middleware = AIBOMScannerMiddleware()
+    from .tools import set_allowed_search_roots
 
-    summary = _build_context_message(
-        deterministic_components, deterministic_relationships, scan_paths
-    )
+    set_allowed_search_roots([str(Path(p).resolve()) for p in scan_paths])
+
+    simple, complex_ = _classify_candidates(deterministic_components)
 
     _LOGGER.info(
-        "Running agentic enrichment with %s (%d components, %d relationships)",
+        "Running agentic enrichment with %s (%d simple, %d complex, %d relationships)",
         model_string,
-        len(deterministic_components),
+        len(simple),
+        len(complex_),
         len(deterministic_relationships),
     )
 
-    try:
-        result = agent.invoke(
-            {"messages": [{"role": "user", "content": summary}]}
+    all_enriched: list[AIComponent] = []
+    all_new: list[AIComponent] = []
+    all_rels: list[ComponentRelationship] = []
+    all_flags: list[RiskFlag] = []
+    middleware = AIBOMScannerMiddleware()
+
+    tier_model = fast_model or model_string
+    if simple:
+        _LOGGER.info(
+            "Tier 1 (simple confirmations): %d candidates via %s",
+            len(simple), tier_model,
         )
-    except Exception as exc:
-        raise AgenticEnrichmentError(
-            f"Agent invocation failed: {exc}"
-        ) from exc
+        agent = create_aibom_agent(tier_model, llm_config=llm_config)
+        batches = [
+            simple[i : i + batch_size] for i in range(0, len(simple), batch_size)
+        ]
+        if len(batches) > 1:
+            _LOGGER.info("Running %d simple batches in parallel", len(batches))
+            enriched, new, rels, flags = asyncio.run(
+                _run_batches_parallel(
+                    agent, middleware, batches,
+                    deterministic_relationships, scan_paths,
+                    all_components=deterministic_components,
+                )
+            )
+            all_enriched.extend(enriched)
+            all_new.extend(new)
+            all_rels.extend(rels)
+            all_flags.extend(flags)
+        else:
+            for idx, batch in enumerate(batches, 1):
+                enriched, new, rels, flags = _run_batch(
+                    agent, middleware, batch,
+                    deterministic_relationships, scan_paths,
+                    idx, len(batches),
+                    all_components=deterministic_components,
+                )
+                all_enriched.extend(enriched)
+                all_new.extend(new)
+                all_rels.extend(rels)
+                all_flags.extend(flags)
 
-    final_message = _extract_final_message(result)
-    if not final_message:
-        _LOGGER.warning("Agent returned no usable output")
-        return list(deterministic_components), [], []
+    if complex_:
+        _LOGGER.info(
+            "Tier 2 (complex reasoning): %d candidates via %s",
+            len(complex_), model_string,
+        )
+        agent = create_aibom_agent(model_string, llm_config=llm_config)
+        batches = [
+            complex_[i : i + batch_size] for i in range(0, len(complex_), batch_size)
+        ]
+        if len(batches) > 1:
+            _LOGGER.info("Running %d complex batches in parallel", len(batches))
+            enriched, new, rels, flags = asyncio.run(
+                _run_batches_parallel(
+                    agent, middleware, batches,
+                    deterministic_relationships, scan_paths,
+                    all_components=deterministic_components,
+                )
+            )
+            all_enriched.extend(enriched)
+            all_new.extend(new)
+            all_rels.extend(rels)
+            all_flags.extend(flags)
+        else:
+            for idx, batch in enumerate(batches, 1):
+                enriched, new, rels, flags = _run_batch(
+                    agent, middleware, batch,
+                    deterministic_relationships, scan_paths,
+                    idx, len(batches),
+                    all_components=deterministic_components,
+                )
+                all_enriched.extend(enriched)
+                all_new.extend(new)
+                all_rels.extend(rels)
+                all_flags.extend(flags)
 
-    new_components, new_relationships, risk_flags = middleware.extract_findings(
-        final_message
-    )
-    enriched = middleware.apply_enrichments(deterministic_components, final_message)
-
-    all_components = enriched + new_components
+    all_components = all_enriched + all_new
 
     _LOGGER.info(
         "Agentic enrichment complete: %d enriched, %d new components, "
         "%d new relationships, %d risk flags",
-        len(enriched),
-        len(new_components),
-        len(new_relationships),
-        len(risk_flags),
+        len(all_enriched),
+        len(all_new),
+        len(all_rels),
+        len(all_flags),
     )
 
-    return all_components, new_relationships, risk_flags
+    return all_components, all_rels, all_flags
+
+
+_CODE_CONTEXT_RADIUS = 15
+
+
+def _read_code_window(file_path: str, line: int) -> str | None:
+    """Read a window of source code around *line* (±15 lines)."""
+    from pathlib import Path
+
+    p = Path(file_path)
+    if not p.is_file():
+        return None
+    try:
+        lines = p.read_text(errors="replace").splitlines()
+    except OSError:
+        return None
+    start = max(0, line - _CODE_CONTEXT_RADIUS - 1)
+    end = min(len(lines), line + _CODE_CONTEXT_RADIUS)
+    numbered = [f"{i + 1:>5}| {lines[i]}" for i in range(start, end)]
+    return "\n".join(numbered)
+
+
+def _component_to_summary(
+    c: AIComponent,
+    *,
+    include_code: bool = False,
+    enrich_target: bool = False,
+) -> dict[str, Any]:
+    """Serialize a single component for the agent prompt."""
+    entry: dict[str, Any] = {
+        "instance_id": c.instance_id,
+        "name": c.name,
+        "type": c.component_type.value,
+        "file": c.file_path,
+        "line": c.line_number,
+        "framework": c.framework,
+    }
+    if c.model_name:
+        entry["model_name"] = c.model_name
+    if c.metadata:
+        entry["metadata"] = c.metadata
+    if enrich_target:
+        entry["ENRICH"] = True
+
+    if include_code and c.file_path and c.line_number:
+        snippet = _read_code_window(c.file_path, c.line_number)
+        if snippet:
+            entry["code_context"] = snippet
+
+    return entry
 
 
 def _build_context_message(
-    components: list[AIComponent],
+    batch: list[AIComponent],
     relationships: list[ComponentRelationship],
     scan_paths: list[str],
+    all_components: list[AIComponent] | None = None,
 ) -> str:
-    """Build the user message that seeds the agent with deterministic results."""
-    comp_summaries = []
-    for c in components:
-        entry: dict[str, Any] = {
-            "instance_id": c.instance_id,
-            "name": c.name,
-            "type": c.component_type.value,
-            "file": c.file_path,
-            "line": c.line_number,
-            "framework": c.framework,
-        }
-        if c.model_name:
-            entry["model_name"] = c.model_name
-        if c.metadata:
-            entry["metadata"] = c.metadata
-        comp_summaries.append(entry)
+    """Build the user message that seeds the agent with deterministic results.
+
+    *batch* — components the agent must enrich (with code context).
+    *all_components* — full scan results for situational awareness (without
+    code context, to keep the prompt compact).
+    """
+    batch_ids = {c.instance_id for c in batch}
+
+    enrich_summaries = [
+        _component_to_summary(c, include_code=True, enrich_target=True)
+        for c in batch
+    ]
+
+    context_summaries: list[dict[str, Any]] = []
+    if all_components:
+        context_summaries = [
+            _component_to_summary(c)
+            for c in all_components
+            if c.instance_id not in batch_ids
+        ]
 
     rel_summaries = [
         {
@@ -211,17 +564,19 @@ def _build_context_message(
         for r in relationships
     ]
 
-    context = {
+    context: dict[str, Any] = {
         "scan_paths": scan_paths,
-        "total_components": len(components),
-        "total_relationships": len(relationships),
-        "components": comp_summaries,
+        "enrich_these": enrich_summaries,
+        "other_detected_components": context_summaries,
         "relationships": rel_summaries,
     }
 
     return (
-        "Here are the deterministic scan results from the AIBOM scanners. "
-        "Please enrich these findings following the workflow in your instructions.\n\n"
+        "Below are the deterministic scan results. Components in "
+        "`enrich_these` (marked ENRICH=true) need your analysis — each "
+        "includes a code_context window. `other_detected_components` shows "
+        "everything else already found; use it to discover relationships and "
+        "missing components but do NOT re-enrich those.\n\n"
         f"```json\n{json.dumps(context, indent=2)}\n```"
     )
 
@@ -237,3 +592,172 @@ def _extract_final_message(result: Any) -> Optional[str]:
     if isinstance(last, dict):
         return str(last.get("content", ""))
     return str(last)
+
+
+_CROSS_REPO_COORDINATOR_PROMPT = """\
+You are an AI-BOM cross-repository coordinator. You have received scan results
+from multiple repositories. Your job is to resolve cross-repo references that
+individual per-repo scans could not resolve on their own.
+
+Focus on:
+1. **Env var resolution**: If repo A uses os.getenv("MODEL_NAME") and repo B
+   sets MODEL_NAME=gpt-4o in docker-compose.yaml, link them.
+2. **Shared model references**: If multiple repos reference the same model
+   by different names or through env vars, unify them.
+3. **Service-to-service links**: If repo A calls POST /api/predict and repo B
+   serves that endpoint, create a relationship.
+4. **Shared dependencies**: If repos share internal packages via git references
+   or local paths, note the cross-repo dependency.
+
+Return a JSON object:
+```json
+{
+  "resolved_references": [
+    {
+      "source_repo": "...",
+      "target_repo": "...",
+      "reference_type": "env_var|model|service|dependency",
+      "source_component_id": "...",
+      "resolved_value": "...",
+      "explanation": "..."
+    }
+  ],
+  "new_relationships": [
+    {
+      "source_name": "...",
+      "target_name": "...",
+      "relationship_type": "USES_MODEL|DEPENDS_ON|CALLS_SERVICE|..."
+    }
+  ],
+  "risk_findings": [
+    {
+      "flag": "cross_repo_env_var_mismatch|...",
+      "description": "...",
+      "severity": "high|medium|low|info"
+    }
+  ]
+}
+```
+"""
+
+
+def run_cross_repo_coordination(
+    model_string: str,
+    per_repo_results: dict[str, dict[str, Any]],
+    llm_config: dict[str, Any] | None = None,
+) -> tuple[list[ComponentRelationship], list[RiskFlag]]:
+    """Coordinate findings across multiple repos using an LLM.
+
+    After all per-repo scans are complete, this function invokes the agent
+    to resolve cross-repo references (env vars, shared models, service links)
+    that individual scans could not resolve.
+
+    Parameters
+    ----------
+    model_string:
+        LLM model identifier.
+    per_repo_results:
+        Dict mapping source name → scan output dict (must contain
+        ``components`` and optionally ``_unresolved_env_vars``).
+    llm_config:
+        LLM connection config.
+
+    Returns
+    -------
+    Tuple of (new_cross_repo_relationships, risk_flags).
+    """
+    if len(per_repo_results) < 2:
+        return [], []
+
+    repo_summaries: list[dict[str, Any]] = []
+    for source, data in per_repo_results.items():
+        components = data.get("components", [])
+        comp_list = []
+        for c in components:
+            if hasattr(c, "model_dump"):
+                comp_list.append({
+                    "name": c.name,
+                    "type": c.component_type.value,
+                    "model_name": c.model_name,
+                    "file": c.file_path,
+                    "metadata": c.metadata,
+                })
+            elif isinstance(c, dict):
+                comp_list.append(c)
+
+        unresolved = data.get("_unresolved_env_vars", [])
+        repo_summaries.append({
+            "repo": source,
+            "component_count": len(comp_list),
+            "components": comp_list[:50],
+            "unresolved_env_vars": unresolved[:20],
+        })
+
+    context = json.dumps(repo_summaries, indent=2, default=str)
+    prompt = (
+        "Here are scan results from multiple repositories. "
+        "Please identify cross-repo references and resolve them.\n\n"
+        f"```json\n{context}\n```"
+    )
+
+    _LOGGER.info(
+        "Running cross-repo coordination across %d repos with %s",
+        len(per_repo_results), model_string,
+    )
+
+    try:
+        agent = create_aibom_agent(
+            model_string,
+            llm_config=llm_config,
+            system_prompt=_CROSS_REPO_COORDINATOR_PROMPT,
+        )
+        result = agent.invoke(
+            {"messages": [{"role": "user", "content": prompt}]}
+        )
+    except Exception as exc:
+        _LOGGER.warning("Cross-repo coordination failed: %s", exc)
+        return [], []
+
+    final = _extract_final_message(result)
+    if not final:
+        return [], []
+
+    middleware = AIBOMScannerMiddleware()
+    data = middleware._parse_json(final)
+    if not data:
+        return [], []
+
+    rels: list[ComponentRelationship] = []
+    for item in data.get("new_relationships", []):
+        try:
+            rel_type = RelationshipType(item.get("relationship_type", "CUSTOM"))
+        except ValueError:
+            rel_type = RelationshipType.CUSTOM
+        rels.append(ComponentRelationship(
+            source_instance_id="",
+            target_instance_id="",
+            source_name=item.get("source_name", ""),
+            target_name=item.get("target_name", ""),
+            relationship_type=rel_type,
+        ))
+
+    from ..models import Severity as Sev
+
+    flags: list[RiskFlag] = []
+    for item in data.get("risk_findings", []):
+        try:
+            sev = Sev(item.get("severity", "info"))
+        except ValueError:
+            sev = Sev.INFO
+        flags.append(RiskFlag(
+            flag=item.get("flag", "cross_repo_issue"),
+            severity=sev,
+            weight=5,
+            description=item.get("description", ""),
+        ))
+
+    _LOGGER.info(
+        "Cross-repo coordination: %d relationships, %d risk flags",
+        len(rels), len(flags),
+    )
+    return rels, flags

--- a/aibom/src/aibom/agentic/cross_repo.py
+++ b/aibom/src/aibom/agentic/cross_repo.py
@@ -46,9 +46,7 @@ __all__ = [
     "resolve_iac_ref_tool",
 ]
 
-_SKIP_DIR_NAMES = frozenset(
-    {"node_modules", ".git", ".venv", "venv", "__pycache__", ".tox"}
-)
+from ..utils.path_filter import should_skip_dir
 
 _TF_DEFAULT_STR = re.compile(
     r"default\s*=\s*(\"([^\"\\]*(?:\\.[^\"\\]*)*)\"|'([^'\\]*(?:\\.[^'\\]*)*)')",
@@ -95,7 +93,7 @@ class CrossRepoSummaryArgs(BaseModel):
 
 
 def _should_skip_path(path: Path) -> bool:
-    return any(p in _SKIP_DIR_NAMES for p in path.parts)
+    return any(should_skip_dir(p) for p in path.parts)
 
 
 def _iter_files(paths: list[str], suffixes: tuple[str, ...] | None = None) -> Iterator[Path]:

--- a/aibom/src/aibom/agentic/middleware.py
+++ b/aibom/src/aibom/agentic/middleware.py
@@ -142,7 +142,18 @@ class AIBOMScannerMiddleware:
     @staticmethod
     def _parse_json(text: str) -> dict[str, Any] | None:
         """Best-effort extraction of JSON from agent text output."""
+        import re as _re
+
         text = text.strip()
+
+        for fence in _re.finditer(r"```(?:json)?\s*\n(.*?)```", text, _re.DOTALL):
+            block = fence.group(1).strip()
+            if block.startswith("{"):
+                try:
+                    return json.loads(block)
+                except json.JSONDecodeError:
+                    continue
+
         start = text.find("{")
         if start == -1:
             _LOGGER.warning("Agent output contains no JSON object")

--- a/aibom/src/aibom/agentic/prompts.py
+++ b/aibom/src/aibom/agentic/prompts.py
@@ -18,77 +18,86 @@
 
 from __future__ import annotations
 
-# SYNC: The asset category list in step 6 below must match
-# AIComponentType in models/enums.py. Update both when adding new types.
+# SYNC: The asset category list in the PROTECTED CATEGORIES section below must
+# match AIComponentType in models/enums.py. Update both when adding new types.
 AIBOM_AGENT_SYSTEM_PROMPT = """\
-You are an expert AI Bill of Materials (AIBOM) analyst working for Cisco AI Defense.
-Your job is to enrich and improve the results of an automated code scan that has
-already been run against the user's codebase.
+You are an expert AI Bill of Materials (AIBOM) analyst for Cisco AI Defense.
+You enrich and verify results from an automated code scan.
 
-## Your capabilities
+## CRITICAL: Be efficient
 
-You have the following tools available:
+You have a LIMITED number of tool-calling rounds. Each component already
+includes a `code_context` window showing ~30 lines of source code around the
+detection site. Use that context FIRST before reaching for any tool.
 
-- **scan_directory**: Run all deterministic scanners against a directory path.
-  Use this when you need to scan a path that hasn't been analyzed yet or when
-  you want to re-scan with different parameters.
-- **resolve_env_var**: Search for environment variable definitions across
-  multiple paths.  Use this when you encounter unresolved `os.environ["X"]`
-  or `os.getenv("X")` references in scan results.
-- **lookup_model**: Query model registries (LiteLLM, HuggingFace Hub, built-in)
-  for metadata about a model identifier.  Use this to enrich detected model
-  names with provider, license, deprecation status, and documentation links.
-- **analyze_imports**: Run deep import analysis on a single Python file using
-  LibCST.  Use this to disambiguate symbols that could belong to multiple
-  frameworks.
-- **trace_data_flow**: Follow a variable through assignments in a file to
-  resolve its concrete value (e.g., model name passed through multiple variables).
-- **search_codebase**: Search across all input paths using regex or literal
-  patterns.  Use this to find definitions, usages, or cross-references.
+The deterministic scan has ALREADY run — do NOT re-scan directories.
 
-## Enrichment workflow
+## Tools (use only when code_context is insufficient)
 
-You receive the deterministic scan results as your first message.  Your task:
+- **lookup_model** — Verify a model identifier against registries. Call once
+  per unique model name.
+- **resolve_env_var** — Resolve an env var (os.getenv/os.environ) to its
+  concrete value. Call only for unresolved env var references.
+- **trace_data_flow** — Follow a variable through assignments to find its
+  value. Call only when a model name is assigned through multiple variables.
+- **analyze_imports** — Deep import analysis on a Python file. Call only when
+  you cannot determine the framework from code_context alone.
+- **search_codebase** — Regex search across directories. Use as a LAST RESORT
+  only. Prefer the other targeted tools.
 
-1. **Review model references**: For each detected model, call `lookup_model`
-   to add provider, license, deprecation status, and model card URL.
-2. **Resolve unresolved references**: For any component where the model name
-   is an environment variable reference or an indirect value, call
-   `resolve_env_var` or `trace_data_flow` to find the concrete value.
-3. **Disambiguate frameworks**: When a component could belong to multiple
-   frameworks (e.g., `Agent` from LangChain vs CrewAI), call `analyze_imports`
-   on the containing file to determine the correct attribution.
-4. **Discover relationships**: Look for patterns where components interact
-   (agent uses tool, chain uses model, retriever uses vector store) and
-   report the relationships.
-5. **Flag risks**: Identify hardcoded API keys that were missed, deprecated
-   models, unpinned model versions, and shadow AI usage.
-6. **Prune false positives**: Review all components for misclassification.
-   Flag chains, document loaders, text splitters, and other pure utility
-   classes that are NOT true AI assets and should be removed from the
-   AIBOM.  Also reclassify any components where the type is wrong (e.g., a
-   retriever classified as vector_store, a memory classified as vector_store,
-   a text splitter classified as a tool).
-   **IMPORTANT**: The following are ALL valid AI asset categories and must
-   NOT be pruned or removed:
-   - model, agent, tool, prompt, embedding, vector_store, retriever, memory
-   - dataset, training_run, hyperparameter, model_artifact
-   - experiment_tracker, model_registry, data_versioning, ml_pipeline
-   - mcp_server, mcp_client, skill, guardrail, secret, dependency
-   Prompts (PromptTemplate, ChatPromptTemplate, SystemMessage, etc.) are
-   first-class AI assets that define system behavior — always keep them.
-   Only prune components that are genuinely NOT AI assets (e.g., a plain
-   HTTP utility class, a logging helper, a text splitter with no AI context).
+## Input structure
+
+You receive two lists:
+- **`enrich_these`**: Components marked `ENRICH=true` that need your analysis.
+  Each includes a `code_context` window showing ~30 lines of source.
+- **`other_detected_components`**: Everything else the deterministic scanner
+  already found. Use these to discover relationships and find gaps, but do
+  NOT re-enrich them.
+
+## Workflow (follow in order, then STOP)
+
+1. **Wrapper tracing (DISCOVERY candidates)**: Some components have an
+   `agentic_hint` saying "trace the wrapper chain." For these:
+   - Read the `code_context` to find what class is instantiated
+   - Use `analyze_imports` on the file to trace the wrapper module
+   - Determine: is the wrapper class actually an AI asset (model, agent,
+     tool, embedding, etc.) or something unrelated?
+   - If confirmed: `reclassify_components` with the correct type
+   - If false positive: `remove_components` with reason
+2. **Model verification**: For each model name in `enrich_these`, call
+   `lookup_model` ONCE. You may batch multiple names in your first round.
+3. **Env var resolution**: For any component whose metadata contains
+   `env` or `env_var_ref`, or whose model_name looks like an env var, call
+   `resolve_env_var` ONCE.
+4. **Classification review**: Using the code_context, verify each component's
+   type is correct. Reclassify or flag false positives.
+5. **Relationship discovery**: Using both `enrich_these` AND
+   `other_detected_components`, identify relationships (agent uses model,
+   chain uses tool, service calls embedding, etc.) and report them.
+6. **Gap analysis**: If the code_context reveals AI assets NOT present in
+   either list (e.g., a prompt template, an agent class, a tool), add them
+   to `new_components`.
+7. **Output your JSON** — then STOP. Do not continue searching.
+
+## Protected asset categories (do NOT prune)
+
+- model, agent, tool, prompt, embedding, vector_store, retriever, memory
+- dataset, training_run, hyperparameter, model_artifact
+- experiment_tracker, model_registry, data_versioning, ml_pipeline
+- mcp_server, mcp_client, skill, guardrail, secret, dependency
+
+Prompts (PromptTemplate, ChatPromptTemplate, SystemMessage, etc.) are
+first-class AI assets — always keep them.
 
 ## Output format
 
-Return your findings as a JSON object with this structure:
+Return a SINGLE JSON object:
 
 ```json
 {
   "enriched_components": [
     {
-      "instance_id": "<existing component instance_id>",
+      "instance_id": "<existing instance_id>",
       "updates": {
         "model_name": "<resolved value>",
         "metadata": {"license": "...", "deprecated": false, "model_card_url": "..."}
@@ -108,15 +117,15 @@ Return your findings as a JSON object with this structure:
   ],
   "remove_components": [
     {
-      "instance_id": "<existing component instance_id>",
-      "reason": "Explanation of why this is a false positive"
+      "instance_id": "<existing instance_id>",
+      "reason": "Why this is a false positive"
     }
   ],
   "reclassify_components": [
     {
-      "instance_id": "<existing component instance_id>",
+      "instance_id": "<existing instance_id>",
       "new_type": "memory|retriever|tool|...",
-      "reason": "Explanation of correct classification"
+      "reason": "Correct classification"
     }
   ],
   "new_relationships": [
@@ -138,14 +147,15 @@ Return your findings as a JSON object with this structure:
 }
 ```
 
-## Guidelines
+## Rules
 
-- Be thorough but efficient.  Do not re-scan directories that have already
-  been scanned unless you have a specific reason.
-- Do not hallucinate findings.  Every enrichment must be backed by a tool call
-  result.
-- Prefer concrete values over guesses.  If you cannot resolve a reference,
-  say so rather than guessing.
-- Focus on high-value enrichments: model metadata, resolved env vars,
-  cross-file relationships.
+- Do NOT hallucinate. Every enrichment must be backed by a tool result or
+  visible in code_context.
+- Prefer concrete values. If you cannot resolve a reference, say so.
+- **CRITICAL**: Your FINAL message MUST contain ONLY the JSON object above
+  (optionally inside a ```json fence). No prose before or after. If you have
+  nothing to report, return the JSON with empty arrays.
+- After outputting JSON, STOP. Do not make additional tool calls.
+- When using search_codebase or resolve_env_var, ONLY pass paths from the
+  `scan_paths` field in the input. NEVER search outside those directories.
 """

--- a/aibom/src/aibom/agentic/tools.py
+++ b/aibom/src/aibom/agentic/tools.py
@@ -25,12 +25,107 @@ from __future__ import annotations
 import json
 import logging
 import re
+import time
 from pathlib import Path
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
 _LOGGER = logging.getLogger(__name__)
+
+import contextvars
+
+_batch_tool_stats: contextvars.ContextVar[dict[str, dict[str, Any]]] = (
+    contextvars.ContextVar("_batch_tool_stats")
+)
+
+_allowed_search_roots: list[str] = []
+
+
+def set_allowed_search_roots(paths: list[str]) -> None:
+    """Restrict all tool search operations to these directories."""
+    _allowed_search_roots.clear()
+    _allowed_search_roots.extend(paths)
+
+
+def _clamp_paths(requested: list[str]) -> list[str]:
+    """Return only those paths that fall under an allowed search root.
+
+    If no roots are configured, returns *requested* unchanged (backward compat).
+    """
+    if not _allowed_search_roots:
+        return requested
+    clamped: list[str] = []
+    for p in requested:
+        rp = str(Path(p).resolve())
+        for root in _allowed_search_roots:
+            if rp == root or rp.startswith(root + "/"):
+                clamped.append(p)
+                break
+    if not clamped:
+        return list(_allowed_search_roots)
+    return clamped
+
+
+def _reset_tool_stats() -> None:
+    _batch_tool_stats.set({})
+
+
+def get_tool_stats() -> dict[str, dict[str, Any]]:
+    try:
+        return dict(_batch_tool_stats.get())
+    except LookupError:
+        return {}
+
+
+def _get_stats_dict() -> dict[str, dict[str, Any]]:
+    try:
+        return _batch_tool_stats.get()
+    except LookupError:
+        d: dict[str, dict[str, Any]] = {}
+        _batch_tool_stats.set(d)
+        return d
+
+
+def _track_tool(name: str):
+    """Decorator that logs and tracks timing for each tool invocation."""
+    def decorator(fn):
+        def wrapper(*args, **kwargs):
+            _LOGGER.info("Tool call: %s (args=%s)", name, _summarize_args(args, kwargs))
+            t0 = time.monotonic()
+            try:
+                result = fn(*args, **kwargs)
+                elapsed = time.monotonic() - t0
+                _LOGGER.info("Tool done: %s — %.2fs", name, elapsed)
+                stats = _get_stats_dict()
+                entry = stats.setdefault(name, {"calls": 0, "total_s": 0.0, "errors": 0})
+                entry["calls"] += 1
+                entry["total_s"] += elapsed
+                return result
+            except Exception as exc:
+                elapsed = time.monotonic() - t0
+                _LOGGER.warning("Tool error: %s — %.2fs — %s", name, elapsed, exc)
+                stats = _get_stats_dict()
+                entry = stats.setdefault(name, {"calls": 0, "total_s": 0.0, "errors": 0})
+                entry["calls"] += 1
+                entry["total_s"] += elapsed
+                entry["errors"] += 1
+                raise
+        wrapper.__name__ = fn.__name__
+        wrapper.__doc__ = fn.__doc__
+        return wrapper
+    return decorator
+
+
+def _summarize_args(args: tuple, kwargs: dict) -> str:
+    parts = []
+    for a in args:
+        s = str(a)
+        parts.append(s[:80] + "…" if len(s) > 80 else s)
+    for k, v in kwargs.items():
+        s = str(v)
+        parts.append(f"{k}={s[:60]}…" if len(s) > 60 else f"{k}={s}")
+    return ", ".join(parts) or "(none)"
 
 
 # ---------------------------------------------------------------------------
@@ -90,6 +185,7 @@ _ENV_CONFIG_GLOBS = (
 )
 
 
+@_track_tool("scan_directory")
 def scan_directory_impl(path: str) -> str:
     """Run all registered scanners on *path* and return JSON summary."""
     from ..models import ScanContext
@@ -128,8 +224,10 @@ def scan_directory_impl(path: str) -> str:
     return json.dumps(result, indent=2)
 
 
+@_track_tool("resolve_env_var")
 def resolve_env_var_impl(var_name: str, search_paths: list[str]) -> str:
     """Search for *var_name* definitions in env files and configs."""
+    search_paths = _clamp_paths(search_paths)
     import yaml
 
     found: list[dict[str, Any]] = []
@@ -199,6 +297,7 @@ def _search_yaml_for_key(
             _search_yaml_for_key(item, key, file_path, found, f"{prefix}[{i}]")
 
 
+@_track_tool("lookup_model")
 def lookup_model_impl(identifier: str) -> str:
     """Query model registries for metadata about *identifier*."""
     from ..scanners.model_detector import _registry_lookup
@@ -226,6 +325,7 @@ def lookup_model_impl(identifier: str) -> str:
     return json.dumps(result)
 
 
+@_track_tool("analyze_imports")
 def analyze_imports_impl(file_path: str) -> str:
     """Run LibCST deep import analysis on a single Python file."""
     from ..cst_parser import parse_source_code
@@ -264,6 +364,7 @@ def analyze_imports_impl(file_path: str) -> str:
     })
 
 
+@_track_tool("trace_data_flow")
 def trace_data_flow_impl(symbol: str, file_path: str) -> str:
     """Trace a variable through assignments to resolve its concrete value."""
     p = Path(file_path)
@@ -311,10 +412,12 @@ def trace_data_flow_impl(symbol: str, file_path: str) -> str:
     })
 
 
+@_track_tool("search_codebase")
 def search_codebase_impl(
     pattern: str, search_paths: list[str], literal: bool = False
 ) -> str:
     """Search across directories for a regex or literal pattern."""
+    search_paths = _clamp_paths(search_paths)
     if literal:
         regex = re.compile(re.escape(pattern), re.IGNORECASE)
     else:
@@ -371,19 +474,14 @@ def build_tools() -> list[Any]:
 
     This function is called lazily only when ``--agent-model`` is specified,
     so the ``langchain_core`` import happens only when needed.
+
+    ``scan_directory`` is intentionally excluded: the deterministic scan has
+    already run and its results are pre-fed in the prompt.  Re-scanning is
+    redundant and expensive (~3-4 s per call).
     """
     from langchain_core.tools import StructuredTool
 
     return [
-        StructuredTool.from_function(
-            name="scan_directory",
-            description=(
-                "Run all AIBOM deterministic scanners on a directory. "
-                "Returns detected AI components and relationships as JSON."
-            ),
-            func=scan_directory_impl,
-            args_schema=ScanDirectoryArgs,
-        ),
         StructuredTool.from_function(
             name="resolve_env_var",
             description=(
@@ -429,7 +527,8 @@ def build_tools() -> list[Any]:
             description=(
                 "Search across all input directories for a regex or literal "
                 "pattern. Returns matching file paths, line numbers, and "
-                "context snippets."
+                "context snippets. Use sparingly — only when other tools "
+                "cannot answer your question."
             ),
             func=search_codebase_impl,
             args_schema=SearchCodebaseArgs,

--- a/aibom/src/aibom/catalog_db.py
+++ b/aibom/src/aibom/catalog_db.py
@@ -4,6 +4,10 @@
 
 """DuckDB catalog access for the prebuilt knowledge base.
 
+Uses an in-memory DuckDB connection with the catalog file ATTACHed as
+read-only.  A last-segment token table enables O(S+K) hash-join lookups
+instead of the previous O(S*N) ``LIKE '%suffix'`` full-scan pattern.
+
 Precedence: DuckDB > custom.  Excluded IDs are filtered out.
 """
 
@@ -17,6 +21,8 @@ import duckdb
 
 LOGGER = logging.getLogger(__name__)
 
+_CATALOG_COLS = "id, label, concept, framework, sig_name, type, catalog_label"
+
 
 def is_excluded(name: str, patterns: List[str]) -> bool:
     """Return True if *name* suffix-matches or equals any pattern in *patterns*."""
@@ -28,18 +34,29 @@ def is_excluded(name: str, patterns: List[str]) -> bool:
 
 class CatalogDB:
     """Provides read-only access to the DuckDB component catalog,
-    augmented with user-defined custom entries from ``.aibom.yaml``."""
+    augmented with user-defined custom entries from ``.aibom.yaml``.
+
+    The catalog file is ATTACHed read-only to an in-memory DuckDB
+    connection so that temporary tables (for the last-segment token
+    index) can be created without modifying the catalog file.
+    """
 
     def __init__(self, db_path: Path) -> None:
         self._db_path = Path(db_path)
         if not self._db_path.exists():
             raise FileNotFoundError(f"DuckDB catalog not found at {self._db_path}")
-        try:
-            self._connection = duckdb.connect(str(self._db_path), read_only=True)
-        except TypeError:
-            self._connection = duckdb.connect(str(self._db_path))
+
+        self._connection = duckdb.connect()
+        safe_path = str(self._db_path).replace("'", "''")
+        self._connection.execute(f"ATTACH '{safe_path}' AS kb (READ_ONLY)")
+
+        self._connection.execute(
+            f"CREATE VIEW component_catalog AS SELECT * FROM kb.component_catalog"
+        )
+
         self._custom_index: Dict[str, Dict[str, Any]] = {}
         self._excludes: List[str] = []
+        self._token_table: str | None = None
 
     def __enter__(self) -> "CatalogDB":
         return self
@@ -50,8 +67,49 @@ class CatalogDB:
     def close(self) -> None:
         """Close the DuckDB connection (idempotent)."""
         if self._connection is not None:
+            try:
+                self._connection.execute("DETACH kb")
+            except Exception:  # noqa: BLE001
+                pass
             self._connection.close()
             self._connection = None
+
+    # ------------------------------------------------------------------
+    # Token table management
+    # ------------------------------------------------------------------
+
+    def _ensure_token_table(self) -> str:
+        """Lazily initialise the last-segment token table.
+
+        If the catalog already ships a pre-built
+        ``component_catalog_last_seg`` table (new KBs), use it directly.
+        Otherwise build a temporary table from ``kb.component_catalog``.
+
+        Returns the qualified table name to use in queries.
+        """
+        if self._token_table is not None:
+            return self._token_table
+
+        try:
+            self._connection.execute(
+                "SELECT 1 FROM kb.component_catalog_last_seg LIMIT 1"
+            )
+            self._token_table = "kb.component_catalog_last_seg"
+            LOGGER.debug("Using pre-built token table from catalog")
+        except duckdb.CatalogException:
+            LOGGER.debug("Building temp last-segment token table")
+            self._connection.execute(
+                "CREATE TEMP TABLE _last_seg AS "
+                "SELECT id, split_part(id, '.', -1) AS last_seg "
+                "FROM kb.component_catalog"
+            )
+            self._token_table = "_last_seg"
+
+        return self._token_table
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     def add_custom_entries(self, entries: List[Dict[str, Any]]) -> None:
         """Merge user-provided custom catalog entries.
@@ -93,8 +151,16 @@ class CatalogDB:
         rows = self._connection.execute(query, params).fetchall()
         return [r[0] for r in rows]
 
-    def find_components_by_suffixes(self, suffixes: Sequence[str]) -> List[Dict[str, Any]]:
-        """Return catalog entries whose IDs end with any of the provided suffixes.
+    def find_components_by_suffixes(
+        self, suffixes: Sequence[str],
+    ) -> List[Dict[str, Any]]:
+        """Return catalog entries whose IDs match any of the provided suffixes.
+
+        Uses a two-tier strategy for O(S+K) performance:
+
+        1. **Full-path suffixes** (contain a dot): exact ``id IN (...)`` match.
+        2. **Single-token suffixes** (no dot): ``last_seg IN (...)`` hash join
+           against the pre-built token table.
 
         Results are drawn from the DuckDB catalog and user custom entries.
         Precedence: DuckDB > custom.  Excluded IDs are filtered out.
@@ -102,29 +168,59 @@ class CatalogDB:
         if not suffixes:
             return []
 
-        where_clause = " OR ".join("id LIKE ?" for _ in suffixes)
-        params = [f"%{suffix}" for suffix in suffixes]
-        query = f"""
-            SELECT id, label, concept, framework, sig_name, type, catalog_label
-            FROM component_catalog
-            WHERE {where_clause}
-        """
+        token_tbl = self._ensure_token_table()
 
-        cursor = self._connection.execute(query, params)
-        columns = [desc[0] for desc in cursor.description]
-        db_results = [dict(zip(columns, row)) for row in cursor.fetchall()]
+        full_paths: list[str] = []
+        tokens: set[str] = set()
+        for s in suffixes:
+            if "." in s:
+                full_paths.append(s)
+                tokens.add(s.rsplit(".", 1)[-1])
+            else:
+                tokens.add(s)
+
+        matched_ids: set[str] = set()
+
+        if full_paths:
+            rows = self._connection.execute(
+                "SELECT id FROM kb.component_catalog "
+                "WHERE id IN (SELECT UNNEST(?))",
+                [full_paths],
+            ).fetchall()
+            matched_ids.update(r[0] for r in rows)
+
+        if tokens:
+            token_list = list(tokens)
+            rows = self._connection.execute(
+                f"SELECT DISTINCT id FROM {token_tbl} "
+                "WHERE last_seg IN (SELECT UNNEST(?))",
+                [token_list],
+            ).fetchall()
+            matched_ids.update(r[0] for r in rows)
+
+        if matched_ids:
+            id_list = list(matched_ids)
+            cursor = self._connection.execute(
+                f"SELECT {_CATALOG_COLS} FROM kb.component_catalog "
+                "WHERE id IN (SELECT UNNEST(?))",
+                [id_list],
+            )
+            columns = [desc[0] for desc in cursor.description]
+            db_results = [dict(zip(columns, row)) for row in cursor.fetchall()]
+        else:
+            db_results = []
 
         seen_ids = {row["id"] for row in db_results}
 
-        # Add custom entries (lower precedence than DuckDB)
-        for suffix in suffixes:
+        for s in suffixes:
             for entry_id, entry in self._custom_index.items():
-                if entry_id.endswith(suffix) and entry_id not in seen_ids:
+                if entry_id.endswith(s) and entry_id not in seen_ids:
                     db_results.append(entry)
                     seen_ids.add(entry_id)
 
-        # Apply exclude filtering
         if self._excludes:
-            db_results = [r for r in db_results if not self._is_excluded(r["id"])]
+            db_results = [
+                r for r in db_results if not self._is_excluded(r["id"])
+            ]
 
         return db_results

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -129,6 +129,39 @@ def _utcnow_iso() -> str:
     return datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
 
 
+def _print_timing_table(console: "rich.console.Console", result: "PipelineResult") -> None:  # type: ignore[name-defined]
+    from rich.table import Table
+
+    from .scanners import scanner_timings
+
+    table = Table(title="Pipeline Timing", show_footer=True)
+    table.add_column("Stage", footer="Total")
+    table.add_column("Elapsed", justify="right", footer=f"{result.total_elapsed_s:.2f}s")
+    table.add_column("%", justify="right")
+    table.add_column("Detail")
+
+    for st in result.timings:
+        pct = (st.elapsed_s / result.total_elapsed_s * 100) if result.total_elapsed_s else 0
+        table.add_row(st.name, f"{st.elapsed_s:.2f}s", f"{pct:.1f}%", st.detail)
+
+    console.print(table)
+
+    if scanner_timings:
+        sc_table = Table(title="Per-Scanner Timing")
+        sc_table.add_column("Scanner")
+        sc_table.add_column("Elapsed", justify="right")
+        sc_table.add_column("%", justify="right")
+
+        scan_stage = next((t for t in result.timings if t.name == "scan"), None)
+        scan_total = scan_stage.elapsed_s if scan_stage else 1.0
+        for name, elapsed in sorted(scanner_timings.items(), key=lambda x: -x[1]):
+            pct = (elapsed / scan_total * 100) if scan_total else 0
+            table_style = "bold red" if pct > 30 else ""
+            sc_table.add_row(name, f"{elapsed:.2f}s", f"{pct:.1f}%", style=table_style)
+
+        console.print(sc_table)
+
+
 def _record_analysis_error(
     run_errors: List[Dict[str, Any]],
     source_summary: Optional[Dict[str, Any]],
@@ -857,6 +890,42 @@ def analyze(
         "--strict",
         help="Only emit high-confidence detections; suppress items that need agentic reasoning.",
     ),
+    timing: bool = typer.Option(
+        False,
+        "--timing",
+        help="Print a per-stage and per-scanner timing breakdown after analysis.",
+    ),
+    agentic_scope: str = typer.Option(
+        "candidates",
+        "--agentic-scope",
+        help=(
+            "Which components to send to the LLM for agentic enrichment. "
+            "'candidates' (default) sends only needs_agentic items; "
+            "'all' sends every component."
+        ),
+    ),
+    agentic_batch_size: int = typer.Option(
+        5,
+        "--agentic-batch-size",
+        help="Max components per agentic LLM invocation (default 5).",
+    ),
+    agentic_fast_model: Optional[str] = typer.Option(
+        None,
+        "--agentic-fast-model",
+        help=(
+            "Cheaper/faster LLM for simple confirmations (model lookups, "
+            "dependency checks). Falls back to --llm-model if not set."
+        ),
+    ),
+    cache_dir: Optional[Path] = typer.Option(
+        None,
+        "--cache-dir",
+        help=(
+            "Directory for caching scan results keyed by repo@commit_sha. "
+            "Repeated scans of the same codebase at the same revision are instant. "
+            "Use 'cisco-aibom cache clear' to purge."
+        ),
+    ),
     validate: bool = typer.Option(
         False,
         "--validate",
@@ -917,6 +986,23 @@ def analyze(
         "--repo-topic",
         help="Filter discovered repos by topic/tag.",
     ),
+    max_repos: Optional[int] = typer.Option(
+        None,
+        "--max-repos",
+        help=(
+            "Maximum number of repos to scan when using --discover-repos, "
+            "--github-org, --gitlab-group, or --repos-file.  Repos are sorted "
+            "by last-push date (most recent first)."
+        ),
+    ),
+    parallel_repos: int = typer.Option(
+        1,
+        "--parallel-repos",
+        help=(
+            "Number of repositories to scan in parallel (default 1 = sequential).  "
+            "Higher values speed up org-scale scans but require more memory."
+        ),
+    ),
     legacy_mode: bool = typer.Option(
         False,
         "--legacy-mode",
@@ -942,6 +1028,12 @@ def analyze(
     if output_format not in _VALID_OUTPUT_FORMATS:
         valid = ", ".join(sorted(_VALID_OUTPUT_FORMATS))
         logging.error(f"Invalid output format '{output_format}'. Must be one of: {valid}")
+        raise typer.Exit(code=1)
+
+    if agentic_scope not in ("candidates", "all"):
+        logging.error(
+            f"Invalid --agentic-scope '{agentic_scope}'. Must be: candidates, all"
+        )
         raise typer.Exit(code=1)
 
     # Validate severity options
@@ -1030,6 +1122,45 @@ def analyze(
                 console.print(
                     f"[yellow]Warning: {plat} discovery failed: {exc}[/]"
                 )
+
+    if len(sources_to_process) > 1 and llm_model:
+        from .repo_triage import RepoTriager
+
+        triage_llm_cfg = {"model": llm_model}
+        if llm_base:
+            triage_llm_cfg["api_base"] = llm_base
+        if llm_key:
+            triage_llm_cfg["api_key"] = llm_key
+
+        triager = RepoTriager(llm_config=triage_llm_cfg)
+        triage_results = triager.triage_repos(sources_to_process)
+
+        deep = [t.repo_path for t in triage_results if t.decision == "deep-scan"]
+        clone = [t.repo_path for t in triage_results if t.decision == "needs-clone"]
+        skipped = [t.repo_path for t in triage_results if t.decision == "skip"]
+
+        if skipped:
+            console.print(
+                f"  [dim]Repo triage: skipping {len(skipped)} non-AI repo(s)[/]"
+            )
+            for t in triage_results:
+                if t.decision == "skip":
+                    _LOGGER.info("Triage skip: %s — %s (%s)", t.repo_path, t.reason, t.method)
+
+        sources_to_process = deep + clone
+
+    if max_repos and len(sources_to_process) > max_repos:
+        console.print(
+            f"  [dim]Limiting to {max_repos} of {len(sources_to_process)} "
+            f"discovered repos (--max-repos)[/]"
+        )
+        sources_to_process = sources_to_process[:max_repos]
+
+    if parallel_repos > 1 and len(sources_to_process) > 1:
+        console.print(
+            f"  [dim]Scanning {len(sources_to_process)} repos with "
+            f"--parallel-repos={parallel_repos}[/]"
+        )
 
     if not sources_to_process:
         logging.error("No sources provided. Please specify a path or an images file.")
@@ -1146,6 +1277,21 @@ def analyze(
             from .scan_pipeline import ScanPipeline
 
             scan_path = str(path_to_analyze)
+
+            _scan_cache_hit = False
+            if cache_dir:
+                from .scan_cache import cache_key, load_cached, save_cached
+
+                _ck = cache_key([scan_path])
+                cached = load_cached(cache_dir, _ck)
+                if cached:
+                    _scan_cache_hit = True
+                    console.print(f"[green]Cache hit[/] for {source} ({_ck[:12]}…)")
+                    all_analysis_outputs[source] = cached
+                    if temp_dir:
+                        shutil.rmtree(temp_dir)
+                    continue
+
             pipeline = ScanPipeline(
                 scan_paths=[scan_path],
                 output_format=output_format,
@@ -1155,6 +1301,9 @@ def analyze(
                 fail_on=fail_on_severity,
                 min_severity=severity_filter,
                 strict=strict,
+                agentic_scope=agentic_scope,
+                agentic_batch_size=agentic_batch_size,
+                agentic_fast_model=agentic_fast_model,
             )
             with console.status(f"[cyan]Scanning {source} (v2 pipeline)"):
                 result = pipeline.run()
@@ -1190,13 +1339,34 @@ def analyze(
                         border_style="yellow",
                     ))
 
-            all_analysis_outputs[source] = {
+            if timing and result.timings:
+                _print_timing_table(console, result)
+
+            output_data: dict[str, Any] = {
                 "_v2": True,
                 "components": result.components,
                 "relationships": result.relationships,
                 "_agentic_risk_flags": result.agentic_risk_flags,
                 "_agentic_candidate_count": result.agentic_candidate_count,
             }
+            all_analysis_outputs[source] = output_data
+
+            if cache_dir and not _scan_cache_hit:
+                from .scan_cache import cache_key, save_cached
+
+                _ck = cache_key([scan_path])
+                _serializable = {
+                    "_v2": True,
+                    "components": [c.model_dump(mode="json") for c in result.components],
+                    "relationships": [r.model_dump(mode="json") for r in result.relationships],
+                    "_agentic_risk_flags": [
+                        f.model_dump(mode="json") if hasattr(f, "model_dump") else str(f)
+                        for f in result.agentic_risk_flags
+                    ],
+                    "_agentic_candidate_count": result.agentic_candidate_count,
+                }
+                save_cached(cache_dir, _ck, _serializable)
+
             source_summary["assets_discovered"] = len(result.components)
             source_summary["last_generated_at"] = _utcnow_iso()
             if source_summary["status"] == "in_progress":
@@ -1324,6 +1494,38 @@ def analyze(
         run_metadata["status"] = "completed_with_errors"
     else:
         run_metadata["status"] = "completed"
+
+    # Cross-repo coordination (agentic, multi-source only)
+    v2_outputs = {
+        k: v for k, v in all_analysis_outputs.items()
+        if isinstance(v, dict) and v.get("_v2")
+    }
+    if llm_config and len(v2_outputs) > 1:
+        try:
+            from .agentic.agent import run_cross_repo_coordination
+
+            console.print(
+                f"  [cyan]Cross-repo coordination across "
+                f"{len(v2_outputs)} repos…[/]"
+            )
+            xrepo_rels, xrepo_flags = run_cross_repo_coordination(
+                model_string=llm_config["model"],
+                per_repo_results=v2_outputs,
+                llm_config=llm_config,
+            )
+            if xrepo_rels or xrepo_flags:
+                first_key = next(iter(v2_outputs))
+                first = all_analysis_outputs[first_key]
+                first.setdefault("relationships", []).extend(xrepo_rels)
+                first.setdefault("_agentic_risk_flags", []).extend(xrepo_flags)
+                console.print(
+                    f"  [magenta]Cross-repo: {len(xrepo_rels)} relationships, "
+                    f"{len(xrepo_flags)} risk flags[/]"
+                )
+        except ImportError:
+            pass
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.warning("Cross-repo coordination failed: %s", exc)
 
     # Phase 4: Generate the report
     report_data = None
@@ -1481,6 +1683,94 @@ def analyze(
 
 kb_app = typer.Typer(help="Manage the AIBOM knowledge base.", no_args_is_help=True)
 app.add_typer(kb_app, name="kb")
+
+
+# ---------------------------------------------------------------------------
+# cisco-aibom cache  — manage scan result cache
+# ---------------------------------------------------------------------------
+
+cache_app = typer.Typer(help="Manage the scan result cache.", no_args_is_help=True)
+app.add_typer(cache_app, name="cache")
+
+
+@cache_app.command("clear")
+def cache_clear(
+    cache_dir: Path = typer.Option(
+        Path.home() / ".aibom" / "cache",
+        "--cache-dir",
+        help="Directory where cached scan results are stored.",
+    ),
+) -> None:
+    """Remove all cached scan results."""
+    from .scan_cache import clear_cache as _clear
+
+    removed = _clear(cache_dir)
+    console.print(f"[green]Removed {removed} cached scan result(s) from {cache_dir}[/]")
+
+
+@cache_app.command("list")
+def cache_list(
+    cache_dir: Path = typer.Option(
+        Path.home() / ".aibom" / "cache",
+        "--cache-dir",
+        help="Directory where cached scan results are stored.",
+    ),
+) -> None:
+    """List all cached scan results."""
+    from rich.table import Table
+
+    from .scan_cache import cache_info
+
+    entries = cache_info(cache_dir)
+    if not entries:
+        console.print("[dim]No cached scan results found.[/]")
+        return
+
+    table = Table(title=f"Scan Cache ({cache_dir})")
+    table.add_column("Key")
+    table.add_column("Cached At")
+    table.add_column("Size", justify="right")
+    for e in entries:
+        table.add_row(e["key"][:16] + "…", e["cached_at"], f"{e['size_kb']} KB")
+    console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# cisco-aibom plugin  — discover and manage plugins
+# ---------------------------------------------------------------------------
+
+plugin_app = typer.Typer(help="Discover and manage AIBOM plugins.", no_args_is_help=True)
+app.add_typer(plugin_app, name="plugin")
+
+
+@plugin_app.command("list")
+def plugin_list() -> None:
+    """List all discovered plugins (entry_points, MCP servers, manifests)."""
+    from rich.table import Table
+
+    from .plugins import list_plugins
+
+    plugins = list_plugins()
+
+    for category, items in plugins.items():
+        if not items:
+            continue
+        table = Table(title=f"{category.replace('_', ' ').title()}")
+        if items:
+            for col in items[0]:
+                table.add_column(col.replace("_", " ").title())
+            for item in items:
+                table.add_row(*item.values())
+        console.print(table)
+
+    total = sum(len(v) for v in plugins.values())
+    if total == 0:
+        console.print("[dim]No plugins discovered.[/]")
+        console.print(
+            "\n[dim]To create a scanner plugin, add to your pyproject.toml:[/]\n"
+            '  [project.entry-points."aibom.scanners"]\n'
+            '  my_scanner = "my_package:MyScannerClass"\n'
+        )
 
 
 @kb_app.command("download")

--- a/aibom/src/aibom/models/scan.py
+++ b/aibom/src/aibom/models/scan.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field
@@ -127,6 +128,8 @@ class SourceResult(BaseModel):
 class ScanContext(BaseModel):
     """Input context for a scan run."""
 
+    model_config = {"arbitrary_types_allowed": True}
+
     paths: list[str]
     exclude_patterns: list[str] = Field(default_factory=list)
     output_format: str = "json"
@@ -136,6 +139,69 @@ class ScanContext(BaseModel):
     llm_config: Optional[dict[str, Any]] = None
     fail_on: Optional[Severity] = None
     min_severity: Severity = Severity.INFO
+    ai_package_set: Optional[frozenset[str]] = None
+
+    _file_index: Optional[dict[str, list["_IndexedFile"]]] = None
+
+    def file_index(self) -> dict[str, list["_IndexedFile"]]:
+        """Shared file listing built once and reused by all scanners.
+
+        Returns a dict keyed by file extension (e.g. ``".py"``, ``".yaml"``),
+        with values being lists of ``_IndexedFile(path, root)`` tuples.
+        Files matching exclude patterns or skip segments are pre-filtered.
+        """
+        if self._file_index is not None:
+            return self._file_index
+
+        from pathlib import Path
+        from pathspec import PathSpec
+
+        spec: Optional[PathSpec] = None
+        if self.exclude_patterns:
+            spec = PathSpec.from_lines("gitwildmatch", self.exclude_patterns)
+
+        from ..utils.path_filter import should_skip_dir
+
+        idx: dict[str, list[_IndexedFile]] = {}
+
+        for scan_root in self.paths:
+            root = Path(scan_root)
+            if not root.exists():
+                continue
+            if root.is_file():
+                ext = root.suffix.lower()
+                idx.setdefault(ext, []).append(_IndexedFile(root, root.parent))
+                continue
+            base = root.resolve()
+            for dirpath_s, dirnames, filenames in os.walk(base):
+                dirpath = Path(dirpath_s)
+                dirnames[:] = [
+                    d for d in dirnames
+                    if not should_skip_dir(d)
+                ]
+                for fn in filenames:
+                    fpath = dirpath / fn
+                    if spec:
+                        try:
+                            rel = fpath.relative_to(base).as_posix()
+                            if spec.match_file(rel):
+                                continue
+                        except ValueError:
+                            pass
+                    ext = fpath.suffix.lower()
+                    idx.setdefault(ext, []).append(_IndexedFile(fpath, base))
+
+        self._file_index = idx
+        return idx
+
+
+class _IndexedFile:
+    """Lightweight container for a file path and its scan root."""
+    __slots__ = ("path", "root")
+
+    def __init__(self, path: "Any", root: "Any") -> None:
+        self.path = path
+        self.root = root
 
 
 class ScanResult(BaseModel):

--- a/aibom/src/aibom/plugins.py
+++ b/aibom/src/aibom/plugins.py
@@ -1,0 +1,207 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Plugin discovery and management for AIBOM.
+
+Tiered extensibility:
+
+  1. **Catalog Extensions** — ``.aibom.yaml`` (existing).
+  2. **Scanner Plugins** — Python ``entry_points`` group ``aibom.scanners``.
+  3. **Reporter Plugins** — Python ``entry_points`` group ``aibom.reporters``.
+  4. **Agentic Tools** — MCP servers via ``.mcp.json`` discovery.
+  5. **Full Plugins** — Python packages with a ``manifest.yaml``.
+
+Plugins are loaded lazily on first call to :func:`discover_scanner_plugins`
+or :func:`discover_reporter_plugins`.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+_LOGGER = logging.getLogger(__name__)
+
+_ENTRY_GROUP_SCANNERS = "aibom.scanners"
+_ENTRY_GROUP_REPORTERS = "aibom.reporters"
+
+
+def discover_scanner_plugins() -> list[type]:
+    """Load scanner classes from installed entry_points.
+
+    Third-party packages declare scanner plugins like::
+
+        [project.entry-points."aibom.scanners"]
+        terraform = "my_plugin:TerraformScanner"
+
+    Returns a list of scanner classes (subclasses of BaseScanner).
+    """
+    return _load_entry_points(_ENTRY_GROUP_SCANNERS)
+
+
+def discover_reporter_plugins() -> list[type]:
+    """Load reporter classes from installed entry_points.
+
+    Third-party packages declare reporter plugins like::
+
+        [project.entry-points."aibom.reporters"]
+        grafana = "my_plugin:GrafanaReporter"
+
+    Returns a list of reporter classes.
+    """
+    return _load_entry_points(_ENTRY_GROUP_REPORTERS)
+
+
+def _load_entry_points(group: str) -> list[type]:
+    plugins: list[type] = []
+    try:
+        eps = importlib.metadata.entry_points(group=group)
+    except TypeError:
+        eps = importlib.metadata.entry_points().get(group, [])
+
+    for ep in eps:
+        try:
+            cls = ep.load()
+            plugins.append(cls)
+            _LOGGER.info("Loaded plugin %s from %s", ep.name, ep.value)
+        except Exception:
+            _LOGGER.warning("Failed to load plugin %s (%s)", ep.name, ep.value, exc_info=True)
+    return plugins
+
+
+def discover_mcp_configs() -> list[dict[str, Any]]:
+    """Discover MCP server configs from standard locations.
+
+    Searches in order:
+      1. ``~/.aibom/.mcp.json`` (user-level)
+      2. ``.aibom/.mcp.json`` (project-level, relative to CWD)
+
+    Returns a list of MCP server configs (dicts with ``name``, ``command``, etc.).
+    """
+    import json
+
+    configs: list[dict[str, Any]] = []
+    candidates = [
+        Path.home() / ".aibom" / ".mcp.json",
+        Path.cwd() / ".aibom" / ".mcp.json",
+    ]
+    for p in candidates:
+        if not p.is_file():
+            continue
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+            servers = data.get("mcpServers", data.get("servers", {}))
+            for name, cfg in servers.items():
+                cfg["_name"] = name
+                cfg["_source"] = str(p)
+                configs.append(cfg)
+            _LOGGER.info("Loaded %d MCP server(s) from %s", len(servers), p)
+        except (json.JSONDecodeError, OSError) as exc:
+            _LOGGER.warning("Failed to parse MCP config %s: %s", p, exc)
+    return configs
+
+
+def load_plugin_manifest(manifest_path: Path) -> Optional[dict[str, Any]]:
+    """Parse a plugin manifest YAML file.
+
+    Expected format::
+
+        name: my-terraform-scanner
+        version: 1.0.0
+        type: scanner  # or reporter, tool, enricher
+        entry_point: my_plugin:TerraformScanner
+        capabilities:
+          - file_extensions: [".tf", ".tfvars"]
+          - component_types: [model, endpoint]
+    """
+    if not manifest_path.is_file():
+        return None
+    try:
+        data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or "name" not in data:
+            _LOGGER.warning("Invalid plugin manifest: %s", manifest_path)
+            return None
+        data["_manifest_path"] = str(manifest_path)
+        return data
+    except (yaml.YAMLError, OSError) as exc:
+        _LOGGER.warning("Failed to load manifest %s: %s", manifest_path, exc)
+        return None
+
+
+def discover_plugin_manifests(
+    search_dirs: list[Path] | None = None,
+) -> list[dict[str, Any]]:
+    """Discover plugin manifests from standard directories.
+
+    Searches:
+      - ``~/.aibom/plugins/*/manifest.yaml``
+      - Any additional *search_dirs* provided.
+    """
+    dirs = [Path.home() / ".aibom" / "plugins"]
+    if search_dirs:
+        dirs.extend(search_dirs)
+
+    manifests: list[dict[str, Any]] = []
+    for d in dirs:
+        if not d.is_dir():
+            continue
+        for manifest_file in d.glob("*/manifest.yaml"):
+            m = load_plugin_manifest(manifest_file)
+            if m:
+                manifests.append(m)
+    return manifests
+
+
+def list_plugins() -> dict[str, list[dict[str, str]]]:
+    """List all discovered plugins by category."""
+    result: dict[str, list[dict[str, str]]] = {
+        "scanners": [],
+        "reporters": [],
+        "mcp_servers": [],
+        "manifests": [],
+    }
+
+    for cls in discover_scanner_plugins():
+        result["scanners"].append({
+            "name": getattr(cls, "name", cls.__name__),
+            "class": f"{cls.__module__}:{cls.__name__}",
+        })
+
+    for cls in discover_reporter_plugins():
+        result["reporters"].append({
+            "name": getattr(cls, "name", cls.__name__),
+            "class": f"{cls.__module__}:{cls.__name__}",
+        })
+
+    for cfg in discover_mcp_configs():
+        result["mcp_servers"].append({
+            "name": cfg.get("_name", "unknown"),
+            "source": cfg.get("_source", "unknown"),
+        })
+
+    for m in discover_plugin_manifests():
+        result["manifests"].append({
+            "name": m.get("name", "unknown"),
+            "type": m.get("type", "unknown"),
+            "version": m.get("version", "unknown"),
+            "path": m.get("_manifest_path", "unknown"),
+        })
+
+    return result

--- a/aibom/src/aibom/repo_triage.py
+++ b/aibom/src/aibom/repo_triage.py
@@ -1,0 +1,241 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Agentic repo triage for org-scale scanning.
+
+Instead of blindly scanning every repository or truncating with --max-repos,
+this module lets the LLM reason about each repo's manifests and README to
+decide: **deep-scan**, **skip**, or **needs-clone**.
+
+Deterministic fast-path: If a manifest contains any known AI package from
+``dependency_scanner.AI_PACKAGES``, the repo is auto-promoted to deep-scan
+without spending an LLM call.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+_LOGGER = logging.getLogger(__name__)
+
+_TRIAGE_SYSTEM_PROMPT = """\
+You are an AI-BOM repo triage assistant.  Given a repo's manifest files and
+README, decide whether the repository contains AI/ML assets worth scanning.
+
+Respond ONLY with a JSON object:
+{"decision": "deep-scan" | "skip" | "needs-clone", "reason": "<one sentence>"}
+
+- **deep-scan**: The repo clearly uses AI/ML frameworks, models, agents, or
+  MCP servers.
+- **skip**: The repo has no AI/ML relevance (pure infrastructure, frontend, etc.).
+- **needs-clone**: Not enough info in manifests/README to decide; a full clone
+  is required for deeper analysis.
+"""
+
+
+@dataclass
+class TriageResult:
+    repo_path: str
+    decision: str  # "deep-scan" | "skip" | "needs-clone"
+    reason: str
+    method: str = ""  # "deterministic" or "agentic"
+
+
+@dataclass
+class RepoTriager:
+    """Triage repos for AI relevance using a deterministic + agentic approach."""
+
+    llm_config: Optional[dict] = None
+    results: list[TriageResult] = field(default_factory=list)
+
+    def triage_repos(self, repo_paths: list[str]) -> list[TriageResult]:
+        from .scanners.dependency_scanner import AI_PACKAGES
+
+        all_ai_pkgs: set[str] = set()
+        for ecosystem_pkgs in AI_PACKAGES.values():
+            all_ai_pkgs.update(p.lower() for p in ecosystem_pkgs)
+
+        deterministic: list[TriageResult] = []
+        needs_llm: list[str] = []
+
+        for repo_path in repo_paths:
+            root = Path(repo_path)
+            if not root.exists():
+                deterministic.append(
+                    TriageResult(repo_path, "skip", "path does not exist", "deterministic")
+                )
+                continue
+
+            manifest_ai = self._check_manifests_for_ai(root, all_ai_pkgs)
+            if manifest_ai:
+                deterministic.append(
+                    TriageResult(
+                        repo_path, "deep-scan",
+                        f"manifest contains AI packages: {', '.join(sorted(manifest_ai)[:5])}",
+                        "deterministic",
+                    )
+                )
+            else:
+                needs_llm.append(repo_path)
+
+        agentic: list[TriageResult] = []
+        if needs_llm and self.llm_config:
+            agentic = self._agentic_triage(needs_llm)
+        elif needs_llm:
+            for rp in needs_llm:
+                agentic.append(
+                    TriageResult(
+                        rp, "needs-clone",
+                        "no AI packages in manifest; agentic mode not available",
+                        "deterministic",
+                    )
+                )
+
+        self.results = deterministic + agentic
+        return self.results
+
+    def _check_manifests_for_ai(
+        self, root: Path, all_ai_pkgs: set[str]
+    ) -> set[str]:
+        """Fast structural check: parse manifests for known AI packages."""
+        found: set[str] = set()
+
+        manifest_names = {
+            "requirements.txt", "pyproject.toml", "setup.py", "setup.cfg",
+            "pipfile", "poetry.lock", "uv.lock",
+            "package.json", "package-lock.json",
+            "go.mod", "cargo.toml", "gemfile",
+            "pom.xml", "build.gradle", "build.gradle.kts",
+        }
+
+        for child in root.iterdir():
+            if child.name.lower() in manifest_names:
+                try:
+                    text = child.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    continue
+                text_lower = text.lower()
+                for pkg in all_ai_pkgs:
+                    if pkg in text_lower:
+                        found.add(pkg)
+            if found:
+                break
+
+        return found
+
+    def _agentic_triage(self, repo_paths: list[str]) -> list[TriageResult]:
+        """Use LLM to reason about repos that lack obvious AI manifest entries."""
+        results: list[TriageResult] = []
+
+        try:
+            from litellm import completion
+        except ImportError:
+            _LOGGER.warning("litellm not available; falling back to needs-clone for all")
+            return [
+                TriageResult(rp, "needs-clone", "litellm unavailable", "deterministic")
+                for rp in repo_paths
+            ]
+
+        summaries: list[tuple[str, str]] = []
+        for rp in repo_paths:
+            root = Path(rp)
+            summary = self._build_repo_summary(root)
+            summaries.append((rp, summary))
+
+        batch_prompt = "Triage the following repositories. For each, respond with a JSON array of objects.\n\n"
+        for i, (rp, summary) in enumerate(summaries):
+            batch_prompt += f"### Repo {i + 1}: {Path(rp).name}\n{summary}\n\n"
+
+        batch_prompt += (
+            "\nRespond with a JSON array of objects, one per repo, in order:\n"
+            '[{"decision": "...", "reason": "..."}, ...]\n'
+        )
+
+        try:
+            resp = completion(
+                messages=[
+                    {"role": "system", "content": _TRIAGE_SYSTEM_PROMPT},
+                    {"role": "user", "content": batch_prompt},
+                ],
+                **self.llm_config,
+            )
+            raw = resp.choices[0].message.content.strip()
+            start = raw.find("[")
+            end = raw.rfind("]")
+            if start >= 0 and end > start:
+                decisions = json.loads(raw[start : end + 1])
+            else:
+                decisions = [json.loads(raw)]
+
+            for (rp, _), dec in zip(summaries, decisions):
+                results.append(
+                    TriageResult(
+                        rp,
+                        dec.get("decision", "needs-clone"),
+                        dec.get("reason", ""),
+                        "agentic",
+                    )
+                )
+        except Exception:
+            _LOGGER.warning("Agentic triage failed; defaulting to needs-clone", exc_info=True)
+            results = [
+                TriageResult(rp, "needs-clone", "agentic triage failed", "deterministic")
+                for rp in repo_paths
+            ]
+
+        return results
+
+    def _build_repo_summary(self, root: Path) -> str:
+        """Build a compact summary of the repo for the LLM."""
+        parts: list[str] = []
+
+        readme_names = ["README.md", "readme.md", "README.rst", "README.txt", "README"]
+        for rn in readme_names:
+            rp = root / rn
+            if rp.is_file():
+                try:
+                    text = rp.read_text(encoding="utf-8", errors="replace")
+                    parts.append(f"**README** (first 500 chars):\n{text[:500]}")
+                except OSError:
+                    pass
+                break
+
+        manifest_names = [
+            "requirements.txt", "pyproject.toml", "package.json", "go.mod",
+            "Cargo.toml", "Gemfile", "pom.xml", "build.gradle",
+        ]
+        for mn in manifest_names:
+            mp = root / mn
+            if mp.is_file():
+                try:
+                    text = mp.read_text(encoding="utf-8", errors="replace")
+                    parts.append(f"**{mn}** (first 1000 chars):\n{text[:1000]}")
+                except OSError:
+                    pass
+
+        if not parts:
+            try:
+                top = sorted(root.iterdir())[:30]
+                names = [f.name for f in top]
+                parts.append(f"**Top-level files**: {', '.join(names)}")
+            except OSError:
+                parts.append("(empty or unreadable)")
+
+        return "\n".join(parts)

--- a/aibom/src/aibom/scan_cache.py
+++ b/aibom/src/aibom/scan_cache.py
@@ -1,0 +1,153 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optional on-disk cache for scan results.
+
+Keyed by ``repo_url@commit_sha`` or ``path@mtime_hash`` so repeated scans
+of the same codebase at the same revision can skip the full pipeline.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+_LOGGER = logging.getLogger(__name__)
+
+_CACHE_VERSION = 1
+
+
+def _git_info(path: str) -> tuple[str, str] | None:
+    """Return (remote_url, commit_sha) if *path* is inside a git repo."""
+    try:
+        sha = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=path,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        url = subprocess.check_output(
+            ["git", "config", "--get", "remote.origin.url"],
+            cwd=path,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        return url, sha
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _mtime_hash(path: str) -> str:
+    """Compute a fast hash of mtimes for all files under *path*."""
+    h = hashlib.sha256()
+    root = Path(path)
+    if root.is_file():
+        h.update(f"{root}:{root.stat().st_mtime_ns}".encode())
+    else:
+        for f in sorted(root.rglob("*")):
+            if f.is_file():
+                try:
+                    h.update(f"{f}:{f.stat().st_mtime_ns}".encode())
+                except OSError:
+                    continue
+    return h.hexdigest()[:16]
+
+
+def cache_key(scan_paths: list[str]) -> str:
+    """Derive a cache key from the scan paths."""
+    parts: list[str] = []
+    for p in sorted(scan_paths):
+        info = _git_info(p)
+        if info:
+            url, sha = info
+            parts.append(f"{url}@{sha}")
+        else:
+            parts.append(f"{p}@{_mtime_hash(p)}")
+    combined = "|".join(parts)
+    return hashlib.sha256(combined.encode()).hexdigest()[:32]
+
+
+def _cache_path(cache_dir: Path, key: str) -> Path:
+    return cache_dir / f"{key}.json"
+
+
+def load_cached(cache_dir: Path, key: str) -> Optional[dict[str, Any]]:
+    """Load a cached scan result. Returns None on miss or version mismatch."""
+    p = _cache_path(cache_dir, key)
+    if not p.exists():
+        return None
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        if data.get("_cache_version") != _CACHE_VERSION:
+            _LOGGER.debug("Cache version mismatch for %s", key)
+            return None
+        _LOGGER.info("Cache hit: %s (cached %s)", key[:12], data.get("_cached_at", "?"))
+        return data
+    except (json.JSONDecodeError, OSError) as exc:
+        _LOGGER.debug("Cache load error for %s: %s", key, exc)
+        return None
+
+
+def save_cached(cache_dir: Path, key: str, data: dict[str, Any]) -> None:
+    """Persist a scan result to the cache."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        **data,
+        "_cache_version": _CACHE_VERSION,
+        "_cache_key": key,
+        "_cached_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    p = _cache_path(cache_dir, key)
+    p.write_text(json.dumps(payload, default=str), encoding="utf-8")
+    _LOGGER.info("Cached result: %s → %s", key[:12], p)
+
+
+def clear_cache(cache_dir: Path) -> int:
+    """Remove all cached scan results. Returns count of files removed."""
+    if not cache_dir.exists():
+        return 0
+    count = 0
+    for f in cache_dir.glob("*.json"):
+        try:
+            f.unlink()
+            count += 1
+        except OSError:
+            pass
+    return count
+
+
+def cache_info(cache_dir: Path) -> list[dict[str, Any]]:
+    """List all cached entries with metadata."""
+    if not cache_dir.exists():
+        return []
+    entries = []
+    for f in sorted(cache_dir.glob("*.json")):
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+            entries.append({
+                "key": data.get("_cache_key", f.stem),
+                "cached_at": data.get("_cached_at", "unknown"),
+                "size_kb": round(f.stat().st_size / 1024, 1),
+                "path": str(f),
+            })
+        except (json.JSONDecodeError, OSError):
+            continue
+    return entries

--- a/aibom/src/aibom/scan_pipeline.py
+++ b/aibom/src/aibom/scan_pipeline.py
@@ -26,6 +26,7 @@ Stages:
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -40,8 +41,18 @@ from .cross_ref import (
 from .models import ScanContext
 from .models.scan import AIComponent, ComponentRelationship
 from .scanners import run_scanners
+from .scanners.file_cache import cache_stats, clear_cache
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class StageTiming:
+    """Wall-clock elapsed time for a single pipeline stage."""
+
+    name: str
+    elapsed_s: float
+    detail: str = ""
 
 
 @dataclass
@@ -55,6 +66,8 @@ class PipelineResult:
     env_index: CrossRefIndex | None = None
     pkg_index: CrossRefIndex | None = None
     external_deps: list[ExternalRepoDep] = field(default_factory=list)
+    timings: list[StageTiming] = field(default_factory=list)
+    total_elapsed_s: float = 0.0
 
 
 class ScanPipeline:
@@ -72,6 +85,9 @@ class ScanPipeline:
         min_severity: Any | None = None,
         strict: bool = False,
         exclude_patterns: list[str] | None = None,
+        agentic_scope: str = "candidates",
+        agentic_batch_size: int = 5,
+        agentic_fast_model: str | None = None,
     ) -> None:
         self.scan_paths = scan_paths
         self.output_format = output_format
@@ -82,8 +98,15 @@ class ScanPipeline:
         self.min_severity = min_severity
         self.strict = strict
         self.exclude_patterns = exclude_patterns or []
+        self.agentic_scope = agentic_scope
+        self.agentic_batch_size = agentic_batch_size
+        self.agentic_fast_model = agentic_fast_model
 
     def run(self) -> PipelineResult:
+        clear_cache()
+        pipeline_start = time.monotonic()
+        timings: list[StageTiming] = []
+
         ctx_kwargs: dict[str, Any] = {
             "paths": self.scan_paths,
             "output_format": self.output_format,
@@ -101,14 +124,46 @@ class ScanPipeline:
             ctx_kwargs["min_severity"] = self.min_severity
         ctx = ScanContext(**ctx_kwargs)
 
+        t0 = time.monotonic()
         components, relationships = self._stage_scan(ctx)
+        elapsed = time.monotonic() - t0
+        fc = cache_stats()
+        timings.append(StageTiming(
+            "scan", elapsed,
+            f"{len(components)} components, {len(relationships)} relationships, "
+            f"file cache {fc['hits']} hits / {fc['misses']} misses",
+        ))
+
+        t0 = time.monotonic()
         components, env_idx, pkg_idx, ext_deps = self._stage_cross_ref(
             components
         )
+        elapsed = time.monotonic() - t0
+        timings.append(StageTiming(
+            "cross_ref", elapsed,
+            f"{sum(len(v) for v in env_idx.env.values())} env vars, "
+            f"{len(pkg_idx.packages)} packages, {len(ext_deps)} external deps",
+        ))
+
+        t0 = time.monotonic()
         components, relationships, agentic_flags = self._stage_agentic(
             components, relationships
         )
+        elapsed = time.monotonic() - t0
+        skipped = not self.llm_config
+        timings.append(StageTiming(
+            "agentic", elapsed,
+            "skipped (no --llm-model)" if skipped else f"{len(agentic_flags)} risk flags",
+        ))
+
+        t0 = time.monotonic()
         components, agentic_count = self._stage_assemble(components)
+        elapsed = time.monotonic() - t0
+        timings.append(StageTiming(
+            "assemble", elapsed, f"{len(components)} final, {agentic_count} agentic",
+        ))
+
+        total_elapsed = time.monotonic() - pipeline_start
 
         return PipelineResult(
             components=components,
@@ -118,17 +173,61 @@ class ScanPipeline:
             env_index=env_idx,
             pkg_index=pkg_idx,
             external_deps=ext_deps,
+            timings=timings,
+            total_elapsed_s=total_elapsed,
         )
 
     # ------------------------------------------------------------------
-    # Stage 1: Run all registered scanners
+    # Stage 1: Two-pass scanning
+    #   Pass 1 — manifest + config (structural, zero FPs) → ai_package_set
+    #   Pass 2 — all other scanners scoped by the discovered package set
     # ------------------------------------------------------------------
 
     def _stage_scan(
         self, ctx: ScanContext
     ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
         _LOGGER.info("Stage 1/4 — scanning %d path(s)", len(self.scan_paths))
-        return run_scanners(ctx)
+
+        from .scanners.dependency_scanner import discover_ai_package_set
+
+        ai_pkgs = discover_ai_package_set(ctx)
+        if ai_pkgs:
+            _LOGGER.info(
+                "Pass 1: discovered %d AI package(s) from manifests: %s",
+                len(ai_pkgs),
+                ", ".join(sorted(ai_pkgs)[:10])
+                + ("…" if len(ai_pkgs) > 10 else ""),
+            )
+        else:
+            _LOGGER.debug("Pass 1: no AI packages found in manifests")
+
+        ctx_pass2 = ctx.model_copy(update={"ai_package_set": ai_pkgs})
+
+        idx = ctx_pass2.file_index()
+        if idx:
+            import asyncio
+            from .scanners.file_cache import warm_cache_async
+
+            all_paths = [e.path for entries in idx.values() for e in entries]
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+
+            if loop and loop.is_running():
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor(1) as pool:
+                    warmed = pool.submit(
+                        asyncio.run, warm_cache_async(all_paths)
+                    ).result()
+            else:
+                warmed = asyncio.run(warm_cache_async(all_paths))
+            _LOGGER.info(
+                "Pass 2 prep: pre-cached %d / %d files via async I/O",
+                warmed, len(all_paths),
+            )
+
+        return run_scanners(ctx_pass2)
 
     # ------------------------------------------------------------------
     # Stage 2: Cross-reference resolution
@@ -175,27 +274,55 @@ class ScanPipeline:
         if not self.llm_config or not components:
             return components, relationships, []
 
-        _LOGGER.info("Stage 3/4 — agentic enrichment")
+        candidates = [c for c in components if c.needs_agentic]
+        confirmed = [c for c in components if not c.needs_agentic]
+
+        if self.agentic_scope == "candidates":
+            to_enrich = candidates
+            _LOGGER.info(
+                "Stage 3/4 — agentic enrichment (%d candidates of %d total)",
+                len(to_enrich), len(components),
+            )
+        else:
+            to_enrich = components
+            _LOGGER.info(
+                "Stage 3/4 — agentic enrichment (all %d components)", len(components),
+            )
+
+        if not to_enrich:
+            _LOGGER.info("Stage 3/4 — no agentic candidates, skipping LLM calls")
+            return components, relationships, []
+
         try:
             from .agentic.agent import run_agentic_enrichment
-
-            model_str = self.llm_config["model"]
-            components, agentic_rels, agentic_flags = run_agentic_enrichment(
-                model_string=model_str,
-                deterministic_components=components,
-                deterministic_relationships=relationships,
-                scan_paths=self.scan_paths,
-                llm_config=self.llm_config,
-            )
-            relationships = relationships + agentic_rels
-            return components, relationships, agentic_flags
-
         except ImportError:
             _LOGGER.warning(
                 "Agentic enrichment requires 'cisco-aibom[agentic]'. Skipping."
             )
+            return components, relationships, []
+
+        try:
+            model_str = self.llm_config["model"]
+            enriched, agentic_rels, agentic_flags = run_agentic_enrichment(
+                model_string=model_str,
+                deterministic_components=to_enrich,
+                deterministic_relationships=relationships,
+                scan_paths=self.scan_paths,
+                llm_config=self.llm_config,
+                batch_size=self.agentic_batch_size,
+                fast_model=self.agentic_fast_model,
+            )
+            relationships = relationships + agentic_rels
+
+            if self.agentic_scope == "candidates":
+                components = confirmed + enriched
+            else:
+                components = enriched
+
+            return components, relationships, agentic_flags
+
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.warning("Agentic enrichment failed: %s", exc)
+            _LOGGER.warning("Agentic enrichment failed: %s", exc, exc_info=True)
 
         return components, relationships, []
 

--- a/aibom/src/aibom/scanners/__init__.py
+++ b/aibom/src/aibom/scanners/__init__.py
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .base import BaseScanner, scanner_registry, run_scanners
+from .base import BaseScanner, scanner_registry, scanner_timings, run_scanners
 from .config_scanner import ConfigScanner
 from .deployment_detector import DeploymentDetector
 from .dependency_scanner import DependencyScanner
@@ -59,5 +59,6 @@ __all__ = [
     "Vulnerability",
     "run_scanners",
     "scanner_registry",
+    "scanner_timings",
     "vuln_provider_registry",
 ]

--- a/aibom/src/aibom/scanners/base.py
+++ b/aibom/src/aibom/scanners/base.py
@@ -16,9 +16,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Optional
 
@@ -27,6 +28,8 @@ from pathspec import PathSpec
 from ..models import AIComponent, ComponentRelationship, ScanContext
 
 _LOGGER = logging.getLogger(__name__)
+
+scanner_timings: dict[str, float] = {}
 
 scanner_registry: list[type["BaseScanner"]] = []
 
@@ -71,15 +74,21 @@ def _load_aibomignore(paths: list[str]) -> Optional[PathSpec]:
     return None
 
 
-def run_scanners(
+async def _async_timed_scan(
+    scanner: BaseScanner, ctx: ScanContext,
+) -> tuple[str, float, list[AIComponent], list[ComponentRelationship]]:
+    """Run a scanner in a thread (to release the event loop) and time it."""
+    t0 = time.monotonic()
+    comps, rels = await asyncio.to_thread(scanner.scan, ctx)
+    elapsed = time.monotonic() - t0
+    return scanner.name, elapsed, comps, rels
+
+
+async def _run_scanners_async(
     context: ScanContext,
-    workers: int = 4,
     extra_scanners: Optional[list[type[BaseScanner]]] = None,
 ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
-    """Instantiate and run all registered scanners in parallel.
-
-    Returns the merged component and relationship lists.
-    """
+    """Run all applicable scanners concurrently using asyncio."""
     ignore_spec = _load_aibomignore(context.paths)
     if ignore_spec:
         merged = list(context.exclude_patterns)
@@ -87,6 +96,16 @@ def run_scanners(
         context = context.model_copy(update={"exclude_patterns": merged})
 
     all_scanner_types = list(scanner_registry)
+
+    try:
+        from ..plugins import discover_scanner_plugins
+
+        for plugin_cls in discover_scanner_plugins():
+            if plugin_cls not in all_scanner_types:
+                all_scanner_types.append(plugin_cls)
+    except Exception:
+        _LOGGER.debug("Plugin discovery failed", exc_info=True)
+
     if extra_scanners:
         all_scanner_types.extend(extra_scanners)
 
@@ -102,24 +121,48 @@ def run_scanners(
 
     all_components: list[AIComponent] = []
     all_relationships: list[ComponentRelationship] = []
+    scanner_timings.clear()
 
-    if len(applicable) == 1:
-        comps, rels = applicable[0].scan(context)
-        return comps, rels
+    tasks = [_async_timed_scan(s, context) for s in applicable]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
 
-    with ThreadPoolExecutor(max_workers=min(workers, len(applicable))) as pool:
-        futures = {pool.submit(s.scan, context): s for s in applicable}
-        for future in as_completed(futures):
-            scanner = futures[future]
-            try:
-                comps, rels = future.result()
-                all_components.extend(comps)
-                all_relationships.extend(rels)
-            except Exception:
-                _LOGGER.exception("Scanner %s failed", scanner.name)
+    for i, result in enumerate(results):
+        if isinstance(result, Exception):
+            _LOGGER.exception("Scanner %s failed", applicable[i].name, exc_info=result)
+            continue
+        name, elapsed, comps, rels = result
+        scanner_timings[name] = elapsed
+        all_components.extend(comps)
+        all_relationships.extend(rels)
 
     all_components = _merge_model_duplicates(all_components)
     return all_components, all_relationships
+
+
+def run_scanners(
+    context: ScanContext,
+    workers: int = 4,
+    extra_scanners: Optional[list[type[BaseScanner]]] = None,
+) -> tuple[list[AIComponent], list[ComponentRelationship]]:
+    """Instantiate and run all registered scanners concurrently via asyncio.
+
+    Uses ``asyncio.to_thread`` per scanner to release the GIL for I/O-heavy
+    scanners while still allowing true concurrency for native async work.
+    The *workers* parameter is retained for API compatibility but no longer
+    controls a thread pool size — asyncio manages scheduling.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(asyncio.run, _run_scanners_async(context, extra_scanners))
+            return future.result()
+
+    return asyncio.run(_run_scanners_async(context, extra_scanners))
 
 
 _MERGE_LINE_PROXIMITY = 5

--- a/aibom/src/aibom/scanners/config_scanner.py
+++ b/aibom/src/aibom/scanners/config_scanner.py
@@ -33,7 +33,7 @@ from .base import BaseScanner
 
 _LOGGER = logging.getLogger(__name__)
 
-_SKIP_DIR_NAMES = frozenset({"node_modules", ".git", ".venv", "venv", "__pycache__"})
+from ..utils.path_filter import should_skip_dir
 
 _AI_COMPOSE_IMAGE_MARKERS = (
     "ollama/ollama",
@@ -142,6 +142,14 @@ def _is_config_target(name: str) -> bool:
 
 
 def _iter_config_files(context: ScanContext) -> Iterator[tuple[Path, Path]]:
+    idx = context.file_index()
+    if idx:
+        for entries in idx.values():
+            for entry in entries:
+                if _is_config_target(entry.path.name):
+                    yield entry.path, entry.root
+        return
+
     spec = _load_exclude_spec(context)
     for root_str in context.paths:
         root = Path(root_str).resolve()
@@ -161,9 +169,9 @@ def _iter_config_files(context: ScanContext) -> Iterator[tuple[Path, Path]]:
             dirnames[:] = [
                 d
                 for d in dirnames
-                if d not in _SKIP_DIR_NAMES
+                if not should_skip_dir(d)
                 and not any(
-                    p in _SKIP_DIR_NAMES for p in (rel_root + "/" + d).split("/") if p
+                    should_skip_dir(p) for p in (rel_root + "/" + d).split("/") if p
                 )
             ]
             for fn in filenames:
@@ -176,16 +184,12 @@ def _iter_config_files(context: ScanContext) -> Iterator[tuple[Path, Path]]:
 
 
 def _read_text(path: Path) -> Optional[str]:
+    from .file_cache import read_text_cached
+
     try:
-        raw = path.read_bytes()
+        return read_text_cached(path)
     except OSError as e:
         _LOGGER.debug("Unreadable %s: %s", path, e)
-        return None
-    if b"\x00" in raw[:8192]:
-        return None
-    try:
-        return raw.decode("utf-8")
-    except UnicodeDecodeError:
         return None
 
 

--- a/aibom/src/aibom/scanners/dependency_scanner.py
+++ b/aibom/src/aibom/scanners/dependency_scanner.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from pathlib import Path
 from typing import Callable, Iterator, Optional
@@ -858,6 +859,8 @@ def _display_name(ecosystem: str, name: str) -> str:
 
 
 def _iter_scan_paths(context: ScanContext) -> Iterator[Path]:
+    from ..utils.path_filter import should_skip_dir
+
     spec: Optional[PathSpec] = None
     if context.exclude_patterns:
         spec = PathSpec.from_lines("gitwildmatch", context.exclude_patterns)
@@ -872,16 +875,19 @@ def _iter_scan_paths(context: ScanContext) -> Iterator[Path]:
                     continue
             yield root
             continue
-        for f in root.rglob("*"):
-            if not f.is_file():
-                continue
-            try:
-                rel = f.relative_to(root).as_posix()
-            except ValueError:
-                rel = str(f)
-            if spec and spec.match_file(rel):
-                continue
-            yield f
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [
+                d for d in dirnames if not should_skip_dir(d)
+            ]
+            for fname in filenames:
+                f = Path(dirpath) / fname
+                try:
+                    rel = f.relative_to(root).as_posix()
+                except ValueError:
+                    rel = str(f)
+                if spec and spec.match_file(rel):
+                    continue
+                yield f
 
 
 def _parse_manifest(path: Path) -> list[tuple[str, str, int, Optional[str], str]]:
@@ -900,6 +906,28 @@ def _parse_manifest(path: Path) -> list[tuple[str, str, int, Optional[str], str]
     except OSError:
         return []
     return parser(path, text)
+
+
+def discover_ai_package_set(context: ScanContext) -> frozenset[str]:
+    """Run a fast manifest-only pass and return the set of AI package names.
+
+    This is Pass 1 of the two-pass pipeline: structural parsing of manifests
+    (requirements.txt, pyproject.toml, poetry.lock, package.json, go.mod, etc.)
+    to discover which AI packages the project actually uses.  The result is
+    used to scope Pass 2 scanners so they only deep-scan relevant files.
+
+    Package names are normalised (lowered, hyphens/underscores unified for PyPI).
+    """
+    pkgs: set[str] = set()
+    for path in _iter_scan_paths(context):
+        key = path.name.lower()
+        if key not in _MANIFEST_PARSERS and not key.endswith(".csproj"):
+            continue
+        for name, _spec, _line, _ver, ecosystem in _parse_manifest(path):
+            if not _is_ai(ecosystem, name):
+                continue
+            pkgs.add(_display_name(ecosystem, name))
+    return frozenset(pkgs)
 
 
 class DependencyScanner(BaseScanner):

--- a/aibom/src/aibom/scanners/deployment_detector.py
+++ b/aibom/src/aibom/scanners/deployment_detector.py
@@ -29,12 +29,11 @@ from pathspec import PathSpec
 from ..models import AIComponent, ComponentRelationship, ScanContext
 from ..models.enums import AIComponentType, DetectionSource
 from .base import BaseScanner
+from .file_cache import read_text_cached
 
 _LOGGER = logging.getLogger(__name__)
 
-_SKIP_DIR_NAMES = frozenset(
-    {"node_modules", ".git", ".venv", "venv", "__pycache__", ".tox"}
-)
+from ..utils.path_filter import should_skip_dir
 
 _AWS_AI_RESOURCES: frozenset[str] = frozenset(
     {
@@ -282,10 +281,17 @@ def _path_has_skip_segment(path: Path, root: Path) -> bool:
         rel = path.relative_to(root)
     except ValueError:
         return False
-    return any(p in _SKIP_DIR_NAMES for p in rel.parts[:-1])
+    return any(should_skip_dir(p) for p in rel.parts[:-1])
 
 
 def _iter_target_files(context: ScanContext) -> Iterator[tuple[Path, Path]]:
+    idx = context.file_index()
+    if idx:
+        for entries in idx.values():
+            for entry in entries:
+                yield entry.path, entry.root
+        return
+
     spec = _build_pathspec(context.exclude_patterns)
     for scan_root in context.paths:
         root = Path(scan_root)
@@ -1046,7 +1052,7 @@ def _process_file(path: Path) -> list[AIComponent]:
     name_lower = path.name.lower()
 
     try:
-        content = path.read_text(encoding="utf-8", errors="replace")
+        content = read_text_cached(path)
     except OSError as e:
         _LOGGER.debug("skip unreadable %s: %s", path, e)
         return []

--- a/aibom/src/aibom/scanners/env_var_resolver.py
+++ b/aibom/src/aibom/scanners/env_var_resolver.py
@@ -34,6 +34,7 @@ from pathspec import PathSpec
 from ..models import AIComponent, ComponentRelationship, ScanContext
 from ..models.enums import AIComponentType, DetectionSource
 from .base import BaseScanner
+from .file_cache import read_text_cached
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -131,6 +132,17 @@ def _build_pathspec(patterns: list[str] | tuple[str, ...]) -> PathSpec | None:
 
 
 def _iter_files(context: ScanContext) -> Iterator[tuple[Path, str]]:
+    idx = context.file_index()
+    if idx:
+        for entries in idx.values():
+            for entry in entries:
+                try:
+                    rel = entry.path.relative_to(entry.root).as_posix()
+                except ValueError:
+                    rel = entry.path.as_posix()
+                yield entry.path, rel
+        return
+
     spec = _build_pathspec(context.exclude_patterns)
     for scan_root in context.paths:
         root = Path(scan_root)
@@ -253,7 +265,7 @@ class EnvVarResolver(BaseScanner):
                 continue
 
             try:
-                text = fpath.read_text(encoding="utf-8", errors="replace")
+                text = read_text_cached(fpath)
             except OSError:
                 continue
 

--- a/aibom/src/aibom/scanners/file_cache.py
+++ b/aibom/src/aibom/scanners/file_cache.py
@@ -1,0 +1,139 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Thread-safe file content cache shared across scanners.
+
+Multiple scanners read the same files during a single pipeline run.
+This cache deduplicates I/O so each file is read at most once.
+Provides both sync (``read_text_cached``) and async (``read_text_cached_async``)
+entry points; both share the same cache.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+
+_lock = threading.Lock()
+_cache: dict[str, str] = {}
+_miss_count = 0
+_hit_count = 0
+
+
+def read_text_cached(path: Path | str, *, encoding: str = "utf-8", errors: str = "replace") -> str:
+    """Read a file's text content, returning a cached copy on subsequent calls."""
+    global _miss_count, _hit_count
+    key = str(path)
+    with _lock:
+        if key in _cache:
+            _hit_count += 1
+            return _cache[key]
+
+    text = Path(key).read_text(encoding=encoding, errors=errors)
+    with _lock:
+        _cache[key] = text
+        _miss_count += 1
+    return text
+
+
+async def read_text_cached_async(
+    path: Path | str, *, encoding: str = "utf-8", errors: str = "replace",
+) -> str:
+    """Async variant — checks the shared cache, falls back to ``aiofiles``."""
+    global _miss_count, _hit_count
+    key = str(path)
+    with _lock:
+        if key in _cache:
+            _hit_count += 1
+            return _cache[key]
+
+    try:
+        import aiofiles
+        async with aiofiles.open(key, encoding=encoding, errors=errors) as f:
+            text = await f.read()
+    except ImportError:
+        text = await asyncio.to_thread(Path(key).read_text, encoding=encoding, errors=errors)
+
+    with _lock:
+        _cache[key] = text
+        _miss_count += 1
+    return text
+
+
+async def warm_cache_async(
+    paths: list[Path | str],
+    *,
+    encoding: str = "utf-8",
+    errors: str = "replace",
+    concurrency: int = 64,
+) -> int:
+    """Pre-populate the cache by reading *paths* concurrently with aiofiles.
+
+    Returns the number of files successfully cached.  Files already in the
+    cache are skipped.  This should be called once at pipeline start so that
+    all subsequent sync ``read_text_cached`` calls are instant cache hits.
+    """
+    uncached = []
+    with _lock:
+        for p in paths:
+            key = str(p)
+            if key not in _cache:
+                uncached.append(key)
+
+    if not uncached:
+        return 0
+
+    sem = asyncio.Semaphore(concurrency)
+    loaded = 0
+
+    async def _read_one(key: str) -> None:
+        nonlocal loaded
+        async with sem:
+            try:
+                import aiofiles
+                async with aiofiles.open(key, encoding=encoding, errors=errors) as f:
+                    text = await f.read()
+            except ImportError:
+                text = await asyncio.to_thread(
+                    Path(key).read_text, encoding=encoding, errors=errors,
+                )
+            except OSError:
+                return
+            global _miss_count
+            with _lock:
+                if key not in _cache:
+                    _cache[key] = text
+                    _miss_count += 1
+                    loaded += 1
+
+    await asyncio.gather(*[_read_one(k) for k in uncached])
+    return loaded
+
+
+def cache_stats() -> dict[str, int]:
+    """Return hit/miss statistics for diagnostics."""
+    with _lock:
+        return {"hits": _hit_count, "misses": _miss_count, "entries": len(_cache)}
+
+
+def clear_cache() -> None:
+    """Reset the cache between runs (useful for testing)."""
+    global _miss_count, _hit_count
+    with _lock:
+        _cache.clear()
+        _miss_count = 0
+        _hit_count = 0

--- a/aibom/src/aibom/scanners/kb_enrichment_scanner.py
+++ b/aibom/src/aibom/scanners/kb_enrichment_scanner.py
@@ -27,6 +27,8 @@ carry the workload.
 from __future__ import annotations
 
 import logging
+import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
@@ -42,6 +44,7 @@ from ..models import (
 )
 from ..structures import CodeAnalysisResult
 from .base import BaseScanner
+from .file_cache import read_text_cached
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -173,6 +176,44 @@ _STATIC_PROMPT_PATTERNS: frozenset[str] = frozenset({
     "PromptTemplate", "ChatPromptTemplate",
     "FewShotPromptTemplate", "FewShotChatMessagePromptTemplate",
 })
+
+@dataclass(frozen=True, slots=True)
+class _MatchResult:
+    """Outcome of matching an observation against the KB."""
+
+    entry: dict[str, Any] | None = None
+    partial_kb_id: str | None = None
+    partial_kb_framework: str | None = None
+    obs_module: str = ""
+
+    @property
+    def is_confirmed(self) -> bool:
+        return self.entry is not None and self.partial_kb_id is None
+
+    @property
+    def is_partial(self) -> bool:
+        return self.entry is None and self.partial_kb_id is not None
+
+
+_AI_SUGGESTIVE_DIR_SEGMENTS: frozenset[str] = frozenset({
+    "models", "agents", "tools", "prompts", "embeddings", "llm",
+    "inference", "ai", "ml", "vectorstores", "vector_stores",
+    "retrievers", "memory", "chains", "chatbots",
+})
+
+_AI_SUGGESTIVE_IMPORT_SEGMENTS: frozenset[str] = frozenset({
+    "llm", "openai", "anthropic", "embedding", "vector", "agent",
+    "model", "inference", "chat", "completion", "bedrock", "vertex",
+    "huggingface", "transformers", "torch", "tensorflow", "keras",
+    "ollama", "cohere", "mistral", "gemini",
+})
+
+_AI_INDICATIVE_CLASS_RE: re.Pattern[str] = re.compile(
+    r"(LLM|Model|Agent|Embedding|Vector|Chain|Tool|Prompt|Memory|Chat|"
+    r"Retriever|Completion|Inference|Tokenizer)",
+    re.IGNORECASE,
+)
+
 
 _GENERIC_CLASS_NAMES: frozenset[str] = frozenset({
     "ABC", "Any", "Dict", "List", "Optional", "Tuple", "Set", "Type",
@@ -368,16 +409,63 @@ class KBEnrichmentScanner(BaseScanner):
 
             kb_patterns = _build_kb_patterns(db)
             kb_fw_prefixes = _build_kb_framework_prefixes(db)
+            kb_fw_names = _build_kb_framework_names(db)
 
-            for py_file in _find_python_files(context):
+            if context.ai_package_set:
+                combined = set(kb_fw_names)
+                for pkg in context.ai_package_set:
+                    combined.add(pkg)
+                    combined.add(pkg.replace("-", "_"))
+                filter_set = frozenset(combined)
+            else:
+                filter_set = kb_fw_names
+
+            all_py_files = _find_python_files(context)
+            tier1_files: list[tuple[Path, str]] = []
+            suggestive_files: list[tuple[Path, str]] = []
+
+            for py_file in all_py_files:
                 try:
-                    source = py_file.read_text(encoding="utf-8")
+                    source = read_text_cached(py_file)
+                except Exception:  # noqa: BLE001
+                    continue
+                if _file_has_kb_framework_import(source, filter_set):
+                    tier1_files.append((py_file, source))
+                elif _has_suggestive_signal(py_file, source):
+                    suggestive_files.append((py_file, source))
+
+            _LOGGER.debug(
+                "KB enrichment: %d Tier 1 (framework import), "
+                "%d suggestive (wrapper), %d skipped of %d total",
+                len(tier1_files), len(suggestive_files),
+                len(all_py_files) - len(tier1_files) - len(suggestive_files),
+                len(all_py_files),
+            )
+
+            parsed_results: list[CodeAnalysisResult] = []
+            all_symbols: set[str] = set()
+            all_files = tier1_files + suggestive_files
+            for py_file, source in all_files:
+                try:
                     result = parse_source_code(str(py_file), source)
-                    components.extend(
-                        _process_file(result, db, kb_patterns, kb_fw_prefixes)
-                    )
+                    parsed_results.append(result)
+                    _collect_symbols(result, all_symbols)
                 except Exception:  # noqa: BLE001
                     _LOGGER.debug("KB enrichment: failed to parse %s", py_file, exc_info=True)
+
+            kb_entries = _batch_kb_lookup(db, all_symbols) if all_symbols else {}
+
+            for result in parsed_results:
+                components.extend(
+                    _process_file_with_cache(
+                        result, kb_entries, kb_patterns, kb_fw_prefixes,
+                    )
+                )
+
+            for py_file, source in suggestive_files:
+                components.extend(
+                    _emit_suggestive_candidates(py_file, source)
+                )
 
         return components, []
 
@@ -387,7 +475,175 @@ class KBEnrichmentScanner(BaseScanner):
 # ---------------------------------------------------------------------------
 
 
+def _build_kb_framework_names(db: CatalogDB) -> frozenset[str]:
+    """Query the KB for the full set of framework package names.
+
+    Returns both the raw framework values (``langchain_community``) **and**
+    their root prefixes (``langchain``), giving us a complete allowlist
+    derived from the KB — no hardcoded guessing.
+    """
+    try:
+        rows = db._connection.execute(  # noqa: SLF001
+            "SELECT DISTINCT framework FROM component_catalog WHERE framework IS NOT NULL"
+        ).fetchall()
+        names: set[str] = set()
+        for (fw,) in rows:
+            if fw:
+                names.add(fw)
+                names.add(fw.split("_")[0].split("-")[0])
+        if names:
+            return frozenset(names)
+    except Exception:  # noqa: BLE001
+        pass
+    return frozenset()
+
+
+_AMBIGUOUS_TOP_LEVEL = frozenset({
+    "google", "aws", "azure", "microsoft", "com", "org", "io", "ai",
+})
+
+
+def _import_matches_framework(dotted_path: str, kb_frameworks: frozenset[str]) -> bool:
+    """Check if a dotted import path matches any known framework.
+
+    Strategy:
+    - Single-segment (``torch``): direct check + root-prefix check.
+    - Multi-dot (``google.cloud.aiplatform``): build progressive underscore
+      joins (``google_cloud``, ``google_cloud_aiplatform``) and check each.
+      The bare first segment is only accepted if it is NOT in
+      ``_AMBIGUOUS_TOP_LEVEL`` — so ``langchain.agents`` matches (first
+      segment ``langchain`` is specific) but ``google.protobuf`` does not
+      (``google`` is ambiguous without deeper context).
+    """
+    segments = dotted_path.split(".")
+
+    if len(segments) == 1:
+        pkg = segments[0]
+        if pkg in kb_frameworks:
+            return True
+        root = pkg.split("_")[0].split("-")[0]
+        return root in kb_frameworks
+
+    first = segments[0]
+    if first not in _AMBIGUOUS_TOP_LEVEL and first in kb_frameworks:
+        return True
+
+    accumulated = ""
+    for i, seg in enumerate(segments):
+        accumulated = f"{accumulated}_{seg}" if accumulated else seg
+        if i == 0:
+            continue
+        if accumulated in kb_frameworks:
+            return True
+
+    return False
+
+
+def _file_has_kb_framework_import(
+    source: str, kb_frameworks: frozenset[str],
+) -> bool:
+    """Return True if *source* contains an ``import`` or ``from`` statement
+    referencing any framework known to the KB.
+
+    This is a cheap structural check — it only looks at lines that start with
+    ``import `` or ``from `` (after stripping whitespace) and checks the full
+    dotted import path progressively against the framework set.
+    """
+    for line in source.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("from "):
+            parts = stripped.split(None, 2)
+            if len(parts) >= 2:
+                if _import_matches_framework(parts[1], kb_frameworks):
+                    return True
+        elif stripped.startswith("import "):
+            parts = stripped.split(None, 2)
+            if len(parts) >= 2:
+                for mod in parts[1].split(","):
+                    dotted = mod.strip().split(" ")[0]
+                    if _import_matches_framework(dotted, kb_frameworks):
+                        return True
+    return False
+
+
+def _has_suggestive_signal(py_file: Path, source: str) -> bool:
+    """Return True if the file has AI-suggestive directory path or import path.
+
+    This is the bypass for wrapper libraries that don't directly import known
+    frameworks but live in directories or import modules whose names suggest
+    AI involvement (e.g., ``models/llm/openai.py``).
+    """
+    parts = py_file.parts
+    for part in parts:
+        if part.lower() in _AI_SUGGESTIVE_DIR_SEGMENTS:
+            return True
+
+    for line in source.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith(("from ", "import ")):
+            lower = stripped.lower()
+            for seg in _AI_SUGGESTIVE_IMPORT_SEGMENTS:
+                if seg in lower:
+                    return True
+    return False
+
+
+def _emit_suggestive_candidates(
+    py_file: Path, source: str,
+) -> list[AIComponent]:
+    """Emit low-confidence agentic candidates for AI-indicative class names.
+
+    Only fires for files that passed the suggestive-signal check but failed
+    the framework import check.  The agent will trace the wrapper chain.
+    """
+    candidates: list[AIComponent] = []
+    seen_lines: set[int] = set()
+    for i, line in enumerate(source.splitlines(), 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        assign_match = re.match(
+            r"(\w+)\s*=\s*([A-Z]\w+)\s*\(", stripped,
+        )
+        if not assign_match:
+            continue
+        _target, class_name = assign_match.group(1), assign_match.group(2)
+        if class_name in _GENERIC_CLASS_NAMES:
+            continue
+        if not _AI_INDICATIVE_CLASS_RE.search(class_name):
+            continue
+        if i in seen_lines:
+            continue
+        seen_lines.add(i)
+        candidates.append(
+            AIComponent(
+                name=class_name,
+                component_type=AIComponentType.MODEL,
+                file_path=str(py_file),
+                line_number=i,
+                framework="",
+                detection_source=DetectionSource.KB_ENRICHMENT,
+                confidence=0.2,
+                needs_agentic=True,
+                agentic_hint=(
+                    f"Class '{class_name}' in suggestive path "
+                    f"'{py_file.parent.name}/' has AI-indicative name. "
+                    f"Agent should read this file and trace imports to confirm."
+                ),
+                metadata={
+                    "suggestive_signal": True,
+                    "parent_dir": py_file.parent.name,
+                },
+            )
+        )
+    return candidates
+
+
 def _find_python_files(context: ScanContext) -> list[Path]:
+    idx = context.file_index()
+    if idx:
+        return [e.path for e in idx.get(".py", [])]
+
     files: list[Path] = []
     for p in context.paths:
         path = Path(p)
@@ -396,6 +652,247 @@ def _find_python_files(context: ScanContext) -> list[Path]:
         elif path.is_dir():
             files.extend(sorted(path.rglob("*.py")))
     return files
+
+
+def _collect_symbols(result: CodeAnalysisResult, symbols: set[str]) -> None:
+    """Gather all symbols from a parsed file result into the shared set."""
+    variable_map: dict[str, str] = {}
+    for assignment in result.assignments:
+        if assignment.target_qualified_name and assignment.call.qualified_name:
+            variable_map[assignment.target_qualified_name] = assignment.call.qualified_name
+
+    for assignment in result.assignments:
+        name = _resolve_chain(assignment.call.qualified_name, variable_map)
+        symbols.add(name)
+    for dec in result.decorators:
+        name = dec.decorator_qualified_name
+        if dec.instance_variable and dec.instance_variable in variable_map:
+            base = variable_map[dec.instance_variable]
+            attr = name.split(".", 1)[-1] if "." in name else name
+            name = f"{base}.{attr}"
+        name = _resolve_chain(name, variable_map)
+        symbols.add(name)
+    for ctx in result.context_managers:
+        if ctx.context_expr_qualified_name:
+            symbols.add(_resolve_chain(ctx.context_expr_qualified_name, variable_map))
+
+
+def _batch_kb_lookup(
+    db: CatalogDB, symbols: set[str],
+) -> dict[str, dict[str, Any]]:
+    """Query DuckDB for symbols via the token-based hash-join index.
+
+    Returns a filtered ``kb_by_id`` dict containing only entries whose concept
+    is in :data:`ALLOWED_CONCEPTS`.
+    """
+    query_suffixes: set[str] = set(symbols)
+    for s in symbols:
+        if "." in s:
+            query_suffixes.add(s.rsplit(".", 1)[-1])
+            cls = _extract_class_segment(s)
+            if cls:
+                query_suffixes.add(cls)
+
+    matched = db.find_components_by_suffixes(list(query_suffixes))
+
+    kb_by_id: dict[str, dict[str, Any]] = {}
+    for entry in matched:
+        concept = (entry.get("concept") or "").lower()
+        if concept not in ALLOWED_CONCEPTS:
+            continue
+        eid = entry["id"]
+        if eid not in kb_by_id:
+            kb_by_id[eid] = entry
+
+    return kb_by_id
+
+
+def _process_file_with_cache(
+    result: CodeAnalysisResult,
+    kb_by_id: dict[str, dict[str, Any]],
+    kb_patterns: dict[AIComponentType, frozenset[str]] | None = None,
+    kb_fw_prefixes: frozenset[str] | None = None,
+) -> list[AIComponent]:
+    """Match one file using pre-fetched KB entries (no per-file DB query)."""
+    variable_map: dict[str, str] = {}
+    for assignment in result.assignments:
+        if assignment.target_qualified_name and assignment.call.qualified_name:
+            variable_map[assignment.target_qualified_name] = assignment.call.qualified_name
+
+    observations: list[dict[str, Any]] = []
+    components: list[AIComponent] = []
+    seen: set[tuple[str, int]] = set()
+
+    for assignment in result.assignments:
+        name = _resolve_chain(assignment.call.qualified_name, variable_map)
+        observations.append(
+            _obs(name, result.file_path, assignment.line_number, "assignment",
+                 args=assignment.call.arguments,
+                 assigned_target=assignment.target_qualified_name)
+        )
+
+    for dec in result.decorators:
+        name = dec.decorator_qualified_name
+        if dec.instance_variable and dec.instance_variable in variable_map:
+            base = variable_map[dec.instance_variable]
+            attr = name.split(".", 1)[-1] if "." in name else name
+            name = f"{base}.{attr}"
+        name = _resolve_chain(name, variable_map)
+        observations.append(
+            _obs(name, result.file_path, dec.line_number, "decorator",
+                 decorated=dec.decorated_function_name)
+        )
+
+    for ctx in result.context_managers:
+        if not ctx.context_expr_qualified_name:
+            continue
+        name = _resolve_chain(ctx.context_expr_qualified_name, variable_map)
+        observations.append(
+            _obs(name, result.file_path, ctx.line_number, "context_manager")
+        )
+
+    imports = getattr(result, "imports", []) or []
+
+    fw_prefixes = kb_fw_prefixes or _AGENT_FRAMEWORK_PREFIXES
+    pat = kb_patterns or {}
+    _call_pattern_map: list[tuple[frozenset[str], frozenset[str], AIComponentType]] = [
+        (pat.get(AIComponentType.AGENT, _AGENT_CREATION_PATTERNS), fw_prefixes, AIComponentType.AGENT),
+        (pat.get(AIComponentType.TOOL, _STATIC_TOOL_PATTERNS), fw_prefixes, AIComponentType.TOOL),
+        (pat.get(AIComponentType.MEMORY, _STATIC_MEMORY_PATTERNS), fw_prefixes, AIComponentType.MEMORY),
+        (pat.get(AIComponentType.PROMPT, _STATIC_PROMPT_PATTERNS), fw_prefixes, AIComponentType.PROMPT),
+    ]
+
+    for call_obs in result.calls:
+        qn = _resolve_chain(call_obs.qualified_name, variable_map)
+        for patterns, fw_pref, comp_type in _call_pattern_map:
+            if _is_known_call(qn, imports, patterns, fw_pref):
+                key = (result.file_path, call_obs.line_number)
+                if key not in seen:
+                    short = qn.rsplit(".", 1)[-1] if "." in qn else qn
+                    components.append(
+                        AIComponent(
+                            name=short,
+                            component_type=comp_type,
+                            file_path=result.file_path,
+                            line_number=call_obs.line_number,
+                            framework=qn.split(".")[0] if "." in qn else "",
+                            detection_source=DetectionSource.CODE_ANALYSIS,
+                            metadata={"call_pattern": qn},
+                        )
+                    )
+                    seen.add(key)
+                break
+
+    for assignment in result.assignments:
+        qn = _resolve_chain(assignment.call.qualified_name, variable_map)
+        for patterns, fw_pref, comp_type in _call_pattern_map:
+            if _is_known_call(qn, imports, patterns, fw_pref):
+                key = (result.file_path, assignment.line_number)
+                if key not in seen:
+                    target = assignment.target_qualified_name or qn
+                    short = target.rsplit(".", 1)[-1] if "." in target else target
+                    components.append(
+                        AIComponent(
+                            name=short,
+                            component_type=comp_type,
+                            file_path=result.file_path,
+                            line_number=assignment.line_number,
+                            framework=qn.split(".")[0] if "." in qn else "",
+                            detection_source=DetectionSource.CODE_ANALYSIS,
+                            metadata={"call_pattern": qn, "assigned_to": target},
+                        )
+                    )
+                    seen.add(key)
+                break
+
+    suffix_idx = _build_suffix_index(kb_by_id)
+    imported_frameworks = _extract_frameworks_from_imports(imports)
+
+    for obs_data in observations:
+        key = (obs_data["file"], obs_data["line"])
+        if key in seen:
+            continue
+
+        match = _match_observation_rich(
+            obs_data["name"], kb_by_id, imported_frameworks, suffix_idx,
+        )
+
+        if match.is_confirmed:
+            kb_entry = match.entry
+            assert kb_entry is not None  # noqa: S101
+            concept = kb_entry["concept"].lower()
+            comp_type = _CONCEPT_TO_TYPE.get(concept)
+            if not comp_type:
+                continue
+            comp_type = _refine_type_from_kb_id(kb_entry["id"], comp_type)
+            if comp_type is None:
+                continue
+
+            meta: dict[str, Any] = {"kb_id": kb_entry["id"]}
+            if obs_data.get("assigned_target"):
+                meta["assigned_target"] = obs_data["assigned_target"]
+            if obs_data.get("decorated"):
+                meta["decorated_function"] = obs_data["decorated"]
+            if obs_data.get("args"):
+                meta["arguments"] = obs_data["args"]
+
+            display_name = obs_data["name"]
+            if obs_data.get("type") == "decorator" and obs_data.get("decorated"):
+                display_name = obs_data["decorated"]
+
+            components.append(
+                AIComponent(
+                    name=display_name,
+                    component_type=comp_type,
+                    file_path=obs_data["file"],
+                    line_number=obs_data["line"],
+                    framework=kb_entry.get("framework", ""),
+                    detection_source=DetectionSource.KB_ENRICHMENT,
+                    kb_concept=concept,
+                    kb_label=kb_entry.get("label", ""),
+                    metadata=meta,
+                )
+            )
+            seen.add(key)
+
+        elif match.is_partial:
+            if match.obs_module in imported_frameworks:
+                continue
+            class_seg = _extract_class_segment(obs_data["name"])
+            display_name = class_seg or obs_data["name"]
+            if obs_data.get("type") == "decorator" and obs_data.get("decorated"):
+                display_name = obs_data["decorated"]
+            hint = (
+                f"Class '{display_name}' matches KB entry '{match.partial_kb_id}' "
+                f"but import module '{match.obs_module}' differs from KB "
+                f"framework '{match.partial_kb_framework}'. "
+                f"Agent should trace the wrapper chain to confirm."
+            )
+            meta_partial: dict[str, Any] = {
+                "partial_kb_id": match.partial_kb_id,
+                "obs_module": match.obs_module,
+            }
+            if obs_data.get("assigned_target"):
+                meta_partial["assigned_target"] = obs_data["assigned_target"]
+            if obs_data.get("args"):
+                meta_partial["arguments"] = obs_data["args"]
+            components.append(
+                AIComponent(
+                    name=display_name,
+                    component_type=AIComponentType.MODEL,
+                    file_path=obs_data["file"],
+                    line_number=obs_data["line"],
+                    framework=match.obs_module,
+                    detection_source=DetectionSource.KB_ENRICHMENT,
+                    confidence=0.3,
+                    needs_agentic=True,
+                    agentic_hint=hint,
+                    metadata=meta_partial,
+                )
+            )
+            seen.add(key)
+
+    return components
 
 
 def _process_file(
@@ -523,6 +1020,7 @@ def _process_file(
         if eid not in kb_by_id:
             kb_by_id[eid] = entry
 
+    suffix_idx = _build_suffix_index(kb_by_id)
     imported_frameworks = _extract_frameworks_from_imports(imports)
 
     for obs_data in observations:
@@ -530,41 +1028,74 @@ def _process_file(
         if key in seen:
             continue
 
-        kb_entry = _match_observation(obs_data["name"], kb_by_id, imported_frameworks)
-        if not kb_entry:
-            continue
+        match = _match_observation_rich(obs_data["name"], kb_by_id, imported_frameworks, suffix_idx)
 
-        concept = kb_entry["concept"].lower()
-        comp_type = _CONCEPT_TO_TYPE.get(concept)
-        if not comp_type:
-            continue
+        if match.is_confirmed:
+            kb_entry = match.entry
+            assert kb_entry is not None  # noqa: S101
+            concept = kb_entry["concept"].lower()
+            comp_type = _CONCEPT_TO_TYPE.get(concept)
+            if not comp_type:
+                continue
+            comp_type = _refine_type_from_kb_id(kb_entry["id"], comp_type)
+            if comp_type is None:
+                continue
 
-        comp_type = _refine_type_from_kb_id(kb_entry["id"], comp_type)
-        if comp_type is None:
-            continue
+            seen.add(key)
 
-        seen.add(key)
+            display_name = obs_data["name"]
+            if obs_data["type"] == "decorator" and obs_data.get("decorated"):
+                display_name = obs_data["decorated"]
 
-        display_name = obs_data["name"]
-        if obs_data["type"] == "decorator" and obs_data.get("decorated"):
-            display_name = obs_data["decorated"]
-
-        components.append(
-            AIComponent(
-                name=display_name,
-                component_type=comp_type,
-                file_path=obs_data["file"],
-                line_number=obs_data["line"],
-                framework=kb_entry.get("framework", ""),
-                detection_source=DetectionSource.KB_ENRICHMENT,
-                kb_concept=concept,
-                kb_label=kb_entry.get("label", ""),
-                metadata={
-                    "kb_id": kb_entry["id"],
-                    "observation_type": obs_data["type"],
-                },
+            components.append(
+                AIComponent(
+                    name=display_name,
+                    component_type=comp_type,
+                    file_path=obs_data["file"],
+                    line_number=obs_data["line"],
+                    framework=kb_entry.get("framework", ""),
+                    detection_source=DetectionSource.KB_ENRICHMENT,
+                    kb_concept=concept,
+                    kb_label=kb_entry.get("label", ""),
+                    metadata={
+                        "kb_id": kb_entry["id"],
+                        "observation_type": obs_data["type"],
+                    },
+                )
             )
-        )
+
+        elif match.is_partial:
+            if match.obs_module in imported_frameworks:
+                continue
+            class_seg = _extract_class_segment(obs_data["name"])
+            display_name = class_seg or obs_data["name"]
+            if obs_data["type"] == "decorator" and obs_data.get("decorated"):
+                display_name = obs_data["decorated"]
+            hint = (
+                f"Class '{display_name}' matches KB entry '{match.partial_kb_id}' "
+                f"but import module '{match.obs_module}' differs from KB "
+                f"framework '{match.partial_kb_framework}'. "
+                f"Agent should trace the wrapper chain to confirm."
+            )
+            components.append(
+                AIComponent(
+                    name=display_name,
+                    component_type=AIComponentType.MODEL,
+                    file_path=obs_data["file"],
+                    line_number=obs_data["line"],
+                    framework=match.obs_module,
+                    detection_source=DetectionSource.KB_ENRICHMENT,
+                    confidence=0.3,
+                    needs_agentic=True,
+                    agentic_hint=hint,
+                    metadata={
+                        "partial_kb_id": match.partial_kb_id,
+                        "obs_module": match.obs_module,
+                        "observation_type": obs_data["type"],
+                    },
+                )
+            )
+            seen.add(key)
 
     return components
 
@@ -599,62 +1130,112 @@ def _resolve_chain(name: str, variable_map: dict[str, str]) -> str:
     return name
 
 
-def _match_observation(
+def _build_suffix_index(
+    kb_by_id: dict[str, dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Build a suffix→entries index to avoid O(n) scans in _match_observation.
+
+    Keys are each dot-delimited suffix of the KB id.  E.g. for
+    ``langchain_community.vectorstores.faiss.FAISS`` we index entries under
+    ``FAISS``, ``faiss.FAISS``, ``vectorstores.faiss.FAISS``, etc.
+    """
+    idx: dict[str, list[dict[str, Any]]] = {}
+    for kb_id, entry in kb_by_id.items():
+        parts = kb_id.split(".")
+        for i in range(1, len(parts) + 1):
+            suffix = ".".join(parts[-i:])
+            idx.setdefault(suffix, []).append(entry)
+    return idx
+
+
+def _match_observation_rich(
     obs_name: str,
     kb_by_id: dict[str, dict[str, Any]],
     imported_frameworks: set[str],
-) -> Optional[dict[str, Any]]:
-    """Return the best KB entry for *obs_name*, or ``None``.
+    suffix_index: dict[str, list[dict[str, Any]]] | None = None,
+) -> _MatchResult:
+    """Match an observation against the KB, returning confirmed, partial, or empty.
 
-    Tier 1: exact match on KB id.
-    Tier 2: suffix match on full qualified name.
-    Tier 3: suffix match on the SHORT class/function name (last dot-segment),
-            disambiguated by imported frameworks.  This handles the common case
-            where a wrapper package (``langchain_openai``) re-exports from an
-            implementation package (``langchain_community``).
+    Tier 1: exact match on KB id → confirmed.
+    Tier 2: suffix match on full qualified name, framework-related → confirmed.
+    Tier 3: suffix match on SHORT class name, framework-related → confirmed.
+    Partial: leaf class exists in KB suffix index but framework guard rejected.
+    Empty: no KB overlap at all.
     """
-    # Tier 1 -- exact
     if obs_name in kb_by_id:
-        return kb_by_id[obs_name]
+        return _MatchResult(entry=kb_by_id[obs_name])
 
     obs_module = obs_name.split(".")[0] if "." in obs_name else ""
 
-    # Tier 2 -- full qualified suffix, validated against framework family.
-    # Without this check ``openai.OpenAI`` would match
-    # ``langchain_community.llms.openai.OpenAI`` via the coincidental
-    # ``.openai.OpenAI`` submodule path.
+    if suffix_index is not None:
+        all_candidates = suffix_index.get(obs_name, [])
+        fw_candidates = [
+            e for e in all_candidates
+            if not obs_module or _frameworks_related(obs_module, e.get("framework", ""))
+        ]
+        if fw_candidates:
+            return _MatchResult(entry=_pick_best(fw_candidates, imported_frameworks, obs_module))
+
+        if all_candidates and obs_module:
+            best = _pick_best(all_candidates, imported_frameworks, obs_module)
+            return _MatchResult(
+                partial_kb_id=best.get("id", ""),
+                partial_kb_framework=best.get("framework", ""),
+                obs_module=obs_module,
+            )
+
+        class_name = _extract_class_segment(obs_name)
+        if class_name:
+            all_cls_candidates = suffix_index.get(class_name, [])
+            if all_cls_candidates:
+                best = _pick_best(all_cls_candidates, imported_frameworks, obs_module)
+                if not obs_module or _frameworks_related(obs_module, best.get("framework", "")):
+                    return _MatchResult(entry=best)
+                return _MatchResult(
+                    partial_kb_id=best.get("id", ""),
+                    partial_kb_framework=best.get("framework", ""),
+                    obs_module=obs_module,
+                )
+        return _MatchResult()
+
     candidates: list[dict[str, Any]] = []
+    all_suffix_candidates: list[dict[str, Any]] = []
     for kb_id, entry in kb_by_id.items():
         if kb_id.endswith("." + obs_name):
+            all_suffix_candidates.append(entry)
             if not obs_module or _frameworks_related(obs_module, entry.get("framework", "")):
                 candidates.append(entry)
 
     if candidates:
-        return _pick_best(candidates, imported_frameworks, obs_module)
+        return _MatchResult(entry=_pick_best(candidates, imported_frameworks, obs_module))
+    if all_suffix_candidates and obs_module:
+        best = _pick_best(all_suffix_candidates, imported_frameworks, obs_module)
+        return _MatchResult(
+            partial_kb_id=best.get("id", ""),
+            partial_kb_framework=best.get("framework", ""),
+            obs_module=obs_module,
+        )
 
-    # Tier 3 -- short-name suffix using the nearest class-like (uppercase)
-    # segment from the observation name.  This handles wrapper re-exports
-    # (``langchain_openai.ChatOpenAI`` → KB has ``langchain_community.*.ChatOpenAI``)
-    # and factory calls (``FAISS.from_texts`` → class segment ``FAISS``).
     class_name = _extract_class_segment(obs_name)
     if not class_name:
-        return None
+        return _MatchResult()
 
+    all_cls: list[dict[str, Any]] = []
     for kb_id, entry in kb_by_id.items():
         if kb_id.endswith("." + class_name):
-            candidates.append(entry)
+            all_cls.append(entry)
 
-    if not candidates:
-        return None
+    if not all_cls:
+        return _MatchResult()
 
-    # Tier 3 is the loosest match; require the best candidate's framework to
-    # share a package-family prefix with the observation's module so that
-    # ``openai.OpenAI.chat.completions.create`` doesn't match a
-    # ``langchain_community`` entry just because both have an ``OpenAI`` class.
-    best = _pick_best(candidates, imported_frameworks, obs_module)
-    if obs_module and not _frameworks_related(obs_module, best.get("framework", "")):
-        return None
-    return best
+    best = _pick_best(all_cls, imported_frameworks, obs_module)
+    if not obs_module or _frameworks_related(obs_module, best.get("framework", "")):
+        return _MatchResult(entry=best)
+    return _MatchResult(
+        partial_kb_id=best.get("id", ""),
+        partial_kb_framework=best.get("framework", ""),
+        obs_module=obs_module,
+    )
 
 
 def _extract_class_segment(obs_name: str) -> Optional[str]:
@@ -701,7 +1282,8 @@ def _pick_best(
     """From a set of KB candidates, prefer the one whose framework matches best.
 
     Priority: framework matches the observation's module prefix > framework is
-    imported > first candidate.
+    imported > deterministic fallback (prefer entries where path override agrees
+    with KB concept).
     """
     if len(candidates) == 1:
         return candidates[0]
@@ -719,4 +1301,17 @@ def _pick_best(
         if fw in imported_frameworks or fw_top in imported_frameworks:
             return c
 
+    def _path_override_score(c: dict[str, Any]) -> tuple[int, str]:
+        kid = c.get("id", "")
+        concept = c.get("concept", "")
+        concept_type = _CONCEPT_TO_TYPE.get(concept)
+        if concept_type:
+            refined = _refine_type_from_kb_id(kid, concept_type)
+            if refined is None:
+                return (2, kid)
+            if refined != concept_type:
+                return (1, kid)
+        return (0, kid)
+
+    candidates.sort(key=_path_override_score)
     return candidates[0]

--- a/aibom/src/aibom/scanners/mcp_detector.py
+++ b/aibom/src/aibom/scanners/mcp_detector.py
@@ -28,6 +28,7 @@ from pathspec import PathSpec
 from ..models import AIComponent, ComponentRelationship, ScanContext
 from ..models.enums import AIComponentType, DetectionSource
 from .base import BaseScanner
+from .file_cache import read_text_cached
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -134,7 +135,7 @@ def _server_metadata(server: dict[str, Any]) -> dict[str, Any]:
 
 def _parse_config_file(path: Path) -> tuple[Optional[dict[str, Any]], bool]:
     try:
-        text = path.read_text(encoding="utf-8", errors="replace")
+        text = read_text_cached(path)
         data = json.loads(text)
     except (OSError, json.JSONDecodeError):
         return None, False
@@ -183,7 +184,7 @@ def _first_match_line(pattern: re.Pattern[str], text: str) -> Optional[int]:
 
 def _components_from_python(path: Path) -> list[AIComponent]:
     try:
-        text = path.read_text(encoding="utf-8", errors="replace")
+        text = read_text_cached(path)
     except OSError:
         return []
     fp = str(path.resolve())
@@ -327,18 +328,25 @@ class McpDetector(BaseScanner):
     def scan(
         self, context: ScanContext
     ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
-        spec = _load_exclude_spec(context.exclude_patterns)
         components: list[AIComponent] = []
         config_paths_seen: set[str] = set()
 
-        for raw in context.paths:
-            root = Path(raw).expanduser()
-            for file_path in _iter_files_under(root, spec):
-                if _is_mcp_config_path(file_path):
-                    config_paths_seen.add(str(file_path.resolve()))
-                    components.extend(_components_from_config(file_path))
-                elif file_path.suffix == ".py":
-                    components.extend(_components_from_python(file_path))
+        idx = context.file_index()
+        if idx:
+            all_files = [e.path for entries in idx.values() for e in entries]
+        else:
+            spec = _load_exclude_spec(context.exclude_patterns)
+            all_files = []
+            for raw in context.paths:
+                root = Path(raw).expanduser()
+                all_files.extend(_iter_files_under(root, spec))
+
+        for file_path in all_files:
+            if _is_mcp_config_path(file_path):
+                config_paths_seen.add(str(file_path.resolve()))
+                components.extend(_components_from_config(file_path))
+            elif file_path.suffix == ".py":
+                components.extend(_components_from_python(file_path))
 
         if config_paths_seen:
             _run_optional_yara_on_configs(sorted(config_paths_seen))

--- a/aibom/src/aibom/scanners/ml_lifecycle_detector.py
+++ b/aibom/src/aibom/scanners/ml_lifecycle_detector.py
@@ -27,6 +27,7 @@ from pathspec import PathSpec
 from ..models import AIComponent, ComponentRelationship, ScanContext
 from ..models.enums import AIComponentType, DetectionSource
 from .base import BaseScanner
+from .file_cache import read_text_cached
 from .import_context import has_any_ai_imports, has_data_imports, has_ml_imports
 
 
@@ -45,6 +46,17 @@ def _build_pathspec(patterns: list[str]) -> Optional[PathSpec]:
 
 
 def _iter_files(context: ScanContext) -> Iterator[tuple[Path, str]]:
+    idx = context.file_index()
+    if idx:
+        for entries in idx.values():
+            for entry in entries:
+                try:
+                    rel = entry.path.relative_to(entry.root).as_posix()
+                except ValueError:
+                    rel = entry.path.as_posix()
+                yield entry.path, rel
+        return
+
     spec = _build_pathspec(context.exclude_patterns)
     for scan_root in context.paths:
         root = Path(scan_root)
@@ -431,7 +443,7 @@ class MLLifecycleDetector(BaseScanner):
             name_lower = fpath.name.lower()
 
             try:
-                text = fpath.read_text(encoding="utf-8", errors="replace")
+                text = read_text_cached(fpath)
             except OSError:
                 continue
 

--- a/aibom/src/aibom/scanners/model_detector.py
+++ b/aibom/src/aibom/scanners/model_detector.py
@@ -28,6 +28,8 @@ import yaml
 from pathspec import PathSpec
 from platformdirs import user_cache_dir
 
+from .file_cache import read_text_cached
+
 from ..models import AIComponent, ComponentRelationship, ScanContext
 from ..models.enums import AIComponentType, DetectionSource
 from .base import BaseScanner
@@ -542,26 +544,40 @@ def _is_plausible_model_id(s: str) -> bool:
     return True
 
 
+_registry_cache: dict[str, dict[str, Any] | None] = {}
+_SENTINEL = object()
+
+
 def _registry_lookup(model_id: str) -> Optional[dict[str, Any]]:
     key = model_id.strip()
+    cached = _registry_cache.get(key, _SENTINEL)
+    if cached is not _SENTINEL:
+        return dict(cached) if cached is not None else None
 
     # Tier 1: LiteLLM commercial API catalog
     live = _get_live_registry()
     hit = live.get(key.lower())
     if hit:
-        return dict(hit)
+        result = dict(hit)
+        _registry_cache[key] = result
+        return result
 
     # Tier 2 (offline): builtin regex patterns
     for pat, meta in _COMPILED_REGISTRY:
         if pat.search(key):
-            return dict(meta)
+            result = dict(meta)
+            _registry_cache[key] = result
+            return result
 
     # Tier 3: HuggingFace Hub for org/model-name slugs
     if _is_hf_model_id(key):
         hf = _query_hf_hub(key)
         if hf:
-            return dict(hf)
+            result = dict(hf)
+            _registry_cache[key] = result
+            return result
 
+    _registry_cache[key] = None
     return None
 
 
@@ -572,6 +588,17 @@ def _build_pathspec(patterns: list[str]) -> Optional[PathSpec]:
 
 
 def _iter_files(context: ScanContext) -> Iterator[tuple[Path, str]]:
+    idx = context.file_index()
+    if idx:
+        for entries in idx.values():
+            for entry in entries:
+                try:
+                    rel = entry.path.relative_to(entry.root).as_posix()
+                except ValueError:
+                    rel = entry.path.as_posix()
+                yield entry.path, rel
+        return
+
     spec = _build_pathspec(context.exclude_patterns)
     for scan_root in context.paths:
         root = Path(scan_root)
@@ -765,7 +792,7 @@ class ModelDetector(BaseScanner):
             suffix = fpath.suffix.lower()
             name_lower = fpath.name.lower()
             try:
-                text = fpath.read_text(encoding="utf-8", errors="replace")
+                text = read_text_cached(fpath)
             except OSError:
                 continue
 

--- a/aibom/src/aibom/scanners/multi_language_scanner.py
+++ b/aibom/src/aibom/scanners/multi_language_scanner.py
@@ -25,6 +25,7 @@ from pathspec import PathSpec
 from ..models import AIComponent, ComponentRelationship, ScanContext
 from ..models.enums import AIComponentType, DetectionSource
 from .base import BaseScanner
+from .file_cache import read_text_cached
 
 try:
     from tree_sitter import Language as _TSLanguage
@@ -846,8 +847,25 @@ def _regex_scan_file(
 
 
 def _iter_scan_files(context: ScanContext) -> list[tuple[Path, str, str]]:
+    idx = context.file_index()
+    if idx:
+        out: list[tuple[Path, str, str]] = []
+        for ext, entries in idx.items():
+            if ext == ".py":
+                continue
+            lang = _EXTENSION_TO_LANG.get(ext)
+            if lang is None:
+                continue
+            for entry in entries:
+                try:
+                    rel = entry.path.relative_to(entry.root).as_posix()
+                except ValueError:
+                    rel = entry.path.as_posix()
+                out.append((entry.path, rel, lang))
+        return out
+
     spec = _build_pathspec(context.exclude_patterns)
-    out: list[tuple[Path, str, str]] = []
+    out2: list[tuple[Path, str, str]] = []
     for scan_root in context.paths:
         root = Path(scan_root)
         if not root.exists():
@@ -861,7 +879,7 @@ def _iter_scan_files(context: ScanContext) -> list[tuple[Path, str, str]]:
             rel = root.name
             if spec and spec.match_file(rel):
                 continue
-            out.append((root.resolve(), rel, lang))
+            out2.append((root.resolve(), rel, lang))
             continue
         base = root.resolve()
         for f in root.rglob("*"):
@@ -878,8 +896,8 @@ def _iter_scan_files(context: ScanContext) -> list[tuple[Path, str, str]]:
                 rel = f.as_posix()
             if spec and spec.match_file(rel):
                 continue
-            out.append((f.resolve(), rel, lang))
-    return out
+            out2.append((f.resolve(), rel, lang))
+    return out2
 
 
 class MultiLanguageScanner(BaseScanner):
@@ -894,7 +912,7 @@ class MultiLanguageScanner(BaseScanner):
         components: list[AIComponent] = []
         for path, rel, lang in _iter_scan_files(context):
             try:
-                text = path.read_text(encoding="utf-8", errors="replace")
+                text = read_text_cached(path)
             except OSError:
                 continue
             components.extend(_regex_scan_file(path, rel, lang, text))

--- a/aibom/src/aibom/scanners/secret_detector.py
+++ b/aibom/src/aibom/scanners/secret_detector.py
@@ -33,6 +33,7 @@ from pathspec import PathSpec
 from ..models import AIComponent, ComponentRelationship, ScanContext
 from ..models.enums import AIComponentType, DetectionSource, Severity
 from .base import BaseScanner
+from .file_cache import read_text_cached
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -140,8 +141,9 @@ AI_KEY_PATTERNS: list[AIKeyPattern] = [
 ]
 
 
+from ..utils.path_filter import should_skip_dir
+
 _SKIP_NAME_SUFFIXES = (".pyc", ".lock", ".min.js")
-_SKIP_DIR_NAMES = frozenset({"node_modules", ".git"})
 
 
 def _slugify_type(label: str) -> str:
@@ -151,7 +153,7 @@ def _slugify_type(label: str) -> str:
 
 def _path_should_skip(rel_posix: str, name: str) -> bool:
     parts = rel_posix.split("/")
-    if any(p in _SKIP_DIR_NAMES for p in parts):
+    if any(should_skip_dir(p) for p in parts):
         return True
     low = name.lower()
     if low.endswith(_SKIP_NAME_SUFFIXES):
@@ -176,6 +178,19 @@ def _is_excluded(abs_file: Path, root: Path, spec: Optional[PathSpec]) -> bool:
 
 
 def _iter_scan_files(context: ScanContext) -> Iterator[tuple[Path, Path]]:
+    idx = context.file_index()
+    if idx:
+        for entries in idx.values():
+            for entry in entries:
+                try:
+                    rel = entry.path.relative_to(entry.root).as_posix()
+                except ValueError:
+                    rel = entry.path.name
+                if _path_should_skip(rel, entry.path.name):
+                    continue
+                yield entry.path, entry.root
+        return
+
     spec = _load_exclude_spec(context)
     for root_str in context.paths:
         root = Path(root_str).resolve()
@@ -194,7 +209,7 @@ def _iter_scan_files(context: ScanContext) -> Iterator[tuple[Path, Path]]:
             dirnames[:] = [
                 d
                 for d in dirnames
-                if d not in _SKIP_DIR_NAMES
+                if not should_skip_dir(d)
                 and not _path_should_skip(
                     "/".join(filter(None, [rel_root, d])), d
                 )
@@ -211,15 +226,11 @@ def _iter_scan_files(context: ScanContext) -> Iterator[tuple[Path, Path]]:
 
 def _read_text_lines(path: Path) -> Optional[list[str]]:
     try:
-        raw = path.read_bytes()
+        text = read_text_cached(path)
     except OSError as e:
         _LOGGER.debug("Unreadable file %s: %s", path, e)
         return None
-    if b"\x00" in raw[:8192]:
-        return None
-    try:
-        text = raw.decode("utf-8")
-    except UnicodeDecodeError:
+    if "\x00" in text[:8192]:
         return None
     return text.splitlines()
 

--- a/aibom/src/aibom/scanners/shadow_ai_detector.py
+++ b/aibom/src/aibom/scanners/shadow_ai_detector.py
@@ -25,6 +25,7 @@ from ..models import AIComponent, ComponentRelationship, ScanContext
 from ..models.enums import AIComponentType, DetectionSource
 from .base import BaseScanner
 from .dependency_scanner import AI_PACKAGES, DependencyScanner, _iter_scan_paths
+from .file_cache import read_text_cached
 
 _LANGCHAIN = frozenset({
     "langchain", "langchain-core", "langchain-community", "langchain-openai",
@@ -224,12 +225,12 @@ def _regex_dynamic_hits(
 
 def _collect_py_imports(path: Path) -> list[tuple[int, str, str]]:
     try:
-        raw = path.read_text(encoding="utf-8", errors="replace")
+        raw = read_text_cached(path)
     except OSError:
         return []
     lines = raw.splitlines()
     try:
-        tree = ast.parse(raw)
+        tree = ast.parse(raw, filename=str(path))
     except SyntaxError:
         tree = None
     hits: list[tuple[int, str, str]] = []

--- a/aibom/src/aibom/utils/path_filter.py
+++ b/aibom/src/aibom/utils/path_filter.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared directory/file skip logic used across all scanners."""
+
+from __future__ import annotations
+
+SKIP_DIR_NAMES: frozenset[str] = frozenset({
+    ".git",
+    "__pycache__",
+    "node_modules",
+    ".venv",
+    "venv",
+    ".tox",
+    ".mypy_cache",
+    ".pytest_cache",
+    "dist",
+    "build",
+    ".eggs",
+    "site-packages",
+})
+
+
+def should_skip_dir(name: str) -> bool:
+    """Return True if a directory should be excluded from scanning.
+
+    Matches exact names in SKIP_DIR_NAMES as well as vendored virtualenv
+    patterns (``*_venv``, ``*-venv``) and egg-info directories.
+    """
+    if name in SKIP_DIR_NAMES:
+        return True
+    low = name.lower()
+    return (
+        low.endswith("_venv")
+        or low.endswith("-venv")
+        or low.endswith(".egg-info")
+    )

--- a/aibom/src/aibom/workflow_analyzer.py
+++ b/aibom/src/aibom/workflow_analyzer.py
@@ -182,7 +182,7 @@ def build_workflow_index(python_files: List[Path]) -> WorkflowIndex:
         try:
             source = Path(file_path)
             text = source.read_text(encoding="utf-8")
-            tree = ast.parse(text)
+            tree = ast.parse(text, filename=str(file_path))
         except Exception as exc:  # pragma: no cover - parsing best-effort
             _LOGGER.debug("Skipping %s during workflow index build: %s", file_path, exc)
             continue

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -23,7 +23,7 @@ they test the helper functions and mock the external dependencies.
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -45,7 +45,35 @@ class TestBuildContextMessage:
         msg = _build_context_message(comps, [], ["/tmp/repo"])
         assert "gpt-4o" in msg
         assert "/tmp/repo" in msg
-        assert "deterministic scan results" in msg
+        assert "deterministic scan results" in msg.lower()
+
+    def test_full_context_separates_batch_from_others(self):
+        batch_comp = AIComponent(
+            name="dataset",
+            component_type=AIComponentType.DATASET,
+            file_path="data.py",
+            line_number=5,
+        )
+        other_comp = AIComponent(
+            name="gpt-4o",
+            component_type=AIComponentType.MODEL,
+            file_path="app.py",
+            line_number=10,
+            model_name="gpt-4o",
+        )
+        msg = _build_context_message(
+            [batch_comp], [], ["/tmp"],
+            all_components=[batch_comp, other_comp],
+        )
+        json_start = msg.index("```json\n") + 8
+        json_end = msg.index("\n```", json_start)
+        data = json.loads(msg[json_start:json_end])
+        assert len(data["enrich_these"]) == 1
+        assert data["enrich_these"][0]["name"] == "dataset"
+        assert data["enrich_these"][0]["ENRICH"] is True
+        assert len(data["other_detected_components"]) == 1
+        assert data["other_detected_components"][0]["name"] == "gpt-4o"
+        assert "ENRICH" not in data["other_detected_components"][0]
 
     def test_json_is_parseable(self):
         comps = [
@@ -60,8 +88,46 @@ class TestBuildContextMessage:
         json_start = msg.index("```json\n") + 8
         json_end = msg.index("\n```", json_start)
         data = json.loads(msg[json_start:json_end])
-        assert data["total_components"] == 1
+        assert len(data["enrich_these"]) == 1
+        assert data["enrich_these"][0]["ENRICH"] is True
         assert data["scan_paths"] == ["/code"]
+        assert data["other_detected_components"] == []
+
+    def test_includes_code_context_for_real_file(self, tmp_path):
+        src = tmp_path / "example.py"
+        src.write_text("import openai\nclient = openai.OpenAI()\nresult = client.chat.completions.create(model='gpt-4o')\n")
+        comps = [
+            AIComponent(
+                name="gpt-4o",
+                component_type=AIComponentType.MODEL,
+                file_path=str(src),
+                line_number=3,
+                model_name="gpt-4o",
+            )
+        ]
+        msg = _build_context_message(comps, [], [str(tmp_path)])
+        json_start = msg.index("```json\n") + 8
+        json_end = msg.index("\n```", json_start)
+        data = json.loads(msg[json_start:json_end])
+        comp = data["enrich_these"][0]
+        assert "code_context" in comp
+        assert "import openai" in comp["code_context"]
+        assert "model='gpt-4o'" in comp["code_context"]
+
+    def test_no_code_context_for_missing_file(self):
+        comps = [
+            AIComponent(
+                name="x",
+                component_type=AIComponentType.MODEL,
+                file_path="/nonexistent/path.py",
+                line_number=1,
+            )
+        ]
+        msg = _build_context_message(comps, [], ["/tmp"])
+        json_start = msg.index("```json\n") + 8
+        json_end = msg.index("\n```", json_start)
+        data = json.loads(msg[json_start:json_end])
+        assert "code_context" not in data["enrich_these"][0]
 
 
 class TestExtractFinalMessage:
@@ -158,15 +224,160 @@ class TestRunAgenticEnrichment:
 
     @patch("aibom.agentic.agent.create_aibom_agent")
     def test_handles_agent_failure_gracefully(self, mock_create):
-        from aibom.agentic.agent import AgenticEnrichmentError, run_agentic_enrichment
+        from aibom.agentic.agent import run_agentic_enrichment
 
         mock_create.return_value = MagicMock(
             invoke=MagicMock(side_effect=RuntimeError("LLM unavailable"))
         )
-        with pytest.raises(AgenticEnrichmentError, match="LLM unavailable"):
-            run_agentic_enrichment(
-                model_string="bad-model",
-                deterministic_components=[],
-                deterministic_relationships=[],
-                scan_paths=["/tmp"],
+        comp = AIComponent(
+            name="test-model",
+            component_type=AIComponentType.MODEL,
+            file_path="x.py",
+            line_number=1,
+            model_name="gpt-4o",
+        )
+        comps, rels, flags = run_agentic_enrichment(
+            model_string="bad-model",
+            deterministic_components=[comp],
+            deterministic_relationships=[],
+            scan_paths=["/tmp"],
+        )
+        assert len(comps) == 1
+        assert comps[0].name == "test-model"
+
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_batching_splits_large_input(self, mock_create):
+        from aibom.agentic.agent import run_agentic_enrichment
+
+        mock_agent = MagicMock()
+        mock_msg = MagicMock()
+        mock_msg.content = json.dumps({
+            "enriched_components": [],
+            "new_components": [],
+            "new_relationships": [],
+            "risk_findings": [],
+        })
+        mock_agent.invoke.return_value = {"messages": [mock_msg]}
+        mock_agent.ainvoke = AsyncMock(return_value={"messages": [mock_msg]})
+        mock_create.return_value = mock_agent
+
+        comps = [
+            AIComponent(
+                name=f"model-{i}",
+                component_type=AIComponentType.MODEL,
+                file_path=f"f{i}.py",
+                line_number=i,
+                model_name=f"gpt-{i}",
             )
+            for i in range(12)
+        ]
+        result_comps, _, _ = run_agentic_enrichment(
+            model_string="test-model",
+            deterministic_components=comps,
+            deterministic_relationships=[],
+            scan_paths=["/tmp"],
+            batch_size=5,
+        )
+        assert mock_agent.ainvoke.call_count == 3  # 5 + 5 + 2, parallel
+
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_single_batch_uses_sequential(self, mock_create):
+        """A single batch should use invoke (sequential), not ainvoke."""
+        from aibom.agentic.agent import run_agentic_enrichment
+
+        mock_agent = MagicMock()
+        mock_msg = MagicMock()
+        mock_msg.content = json.dumps({
+            "enriched_components": [],
+            "new_components": [],
+            "new_relationships": [],
+            "risk_findings": [],
+        })
+        mock_agent.invoke.return_value = {"messages": [mock_msg]}
+        mock_create.return_value = mock_agent
+
+        comps = [
+            AIComponent(
+                name="gpt-4o",
+                component_type=AIComponentType.MODEL,
+                file_path="a.py",
+                line_number=1,
+                model_name="gpt-4o",
+            )
+        ]
+        run_agentic_enrichment(
+            model_string="test-model",
+            deterministic_components=comps,
+            deterministic_relationships=[],
+            scan_paths=["/tmp"],
+            batch_size=5,
+        )
+        assert mock_agent.invoke.call_count == 1
+
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_tiered_model_uses_fast_for_simple(self, mock_create):
+        from aibom.agentic.agent import run_agentic_enrichment
+
+        mock_agent = MagicMock()
+        mock_msg = MagicMock()
+        mock_msg.content = json.dumps({
+            "enriched_components": [],
+            "new_components": [],
+            "new_relationships": [],
+            "risk_findings": [],
+        })
+        mock_agent.invoke.return_value = {"messages": [mock_msg]}
+        mock_create.return_value = mock_agent
+
+        simple = AIComponent(
+            name="gpt-4o",
+            component_type=AIComponentType.MODEL,
+            file_path="a.py",
+            line_number=1,
+            model_name="gpt-4o",
+        )
+        complex_ = AIComponent(
+            name="some-agent",
+            component_type=AIComponentType.AGENT,
+            file_path="b.py",
+            line_number=5,
+        )
+        run_agentic_enrichment(
+            model_string="expensive-model",
+            deterministic_components=[simple, complex_],
+            deterministic_relationships=[],
+            scan_paths=["/tmp"],
+            fast_model="cheap-model",
+        )
+        calls = mock_create.call_args_list
+        assert calls[0][0][0] == "cheap-model"
+        assert calls[1][0][0] == "expensive-model"
+
+
+class TestToolStats:
+    def test_tool_stats_isolated_per_reset(self):
+        from aibom.agentic.tools import _reset_tool_stats, get_tool_stats, _get_stats_dict
+
+        _reset_tool_stats()
+        assert get_tool_stats() == {}
+        stats = _get_stats_dict()
+        stats["test_tool"] = {"calls": 1, "total_s": 0.5, "errors": 0}
+        assert get_tool_stats()["test_tool"]["calls"] == 1
+
+        _reset_tool_stats()
+        assert get_tool_stats() == {}
+
+    def test_track_tool_decorator(self):
+        from aibom.agentic.tools import _reset_tool_stats, get_tool_stats, _track_tool
+
+        _reset_tool_stats()
+
+        @_track_tool("my_tool")
+        def dummy(x):
+            return x * 2
+
+        assert dummy(5) == 10
+        stats = get_tool_stats()
+        assert "my_tool" in stats
+        assert stats["my_tool"]["calls"] == 1
+        assert stats["my_tool"]["errors"] == 0

--- a/aibom/tests/test_agentic_cli.py
+++ b/aibom/tests/test_agentic_cli.py
@@ -81,10 +81,11 @@ class TestAgenticEnrichmentViaCLI:
                 "--output-file", str(out),
                 "--llm-model", "test-model",
                 "--llm-api-base", "http://localhost:11434",
+                "--agentic-scope", "all",
             ],
         )
         assert result.exit_code == 0
-        mock_create.assert_called_once()
+        assert mock_create.call_count >= 1
 
     def test_llm_model_with_legacy_mode_skips_agentic(self, sample_dir, tmp_path):
         import duckdb

--- a/aibom/tests/test_agentic_tools.py
+++ b/aibom/tests/test_agentic_tools.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import pytest
 
 from aibom.agentic.tools import (
+    _allowed_search_roots,
     analyze_imports_impl,
     lookup_model_impl,
     resolve_env_var_impl,
@@ -31,6 +32,14 @@ from aibom.agentic.tools import (
     search_codebase_impl,
     trace_data_flow_impl,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_search_roots():
+    """Reset module-level search roots so earlier test files don't pollute."""
+    _allowed_search_roots.clear()
+    yield
+    _allowed_search_roots.clear()
 
 
 class TestScanDirectory:

--- a/aibom/tests/test_catalog_db.py
+++ b/aibom/tests/test_catalog_db.py
@@ -22,7 +22,13 @@ import duckdb
 from aibom.catalog_db import CatalogDB
 
 
-def _create_catalog(path: Path) -> None:
+def _create_catalog(path: Path, *, with_token_table: bool = True) -> None:
+    """Build a minimal test catalog.
+
+    When *with_token_table* is True (the default), the pre-built
+    ``component_catalog_last_seg`` table is included, simulating a
+    new-format KB.  Set to False to test the old-KB fallback path.
+    """
     con = duckdb.connect(str(path))
     con.execute(
         """
@@ -46,6 +52,14 @@ def _create_catalog(path: Path) -> None:
             ('other.Unused', 'Unused', NULL, 'other', 'Unused', 'class', 'Unused');
         """
     )
+    if with_token_table:
+        con.execute(
+            """
+            CREATE TABLE component_catalog_last_seg AS
+            SELECT id, split_part(id, '.', -1) AS last_seg
+            FROM component_catalog;
+            """
+        )
     con.close()
 
 
@@ -136,3 +150,95 @@ def test_excludes_filter_results():
         ids = {row["id"] for row in results}
         assert "pkg.Agent" not in ids
         assert "pkg.Tool.run" in ids
+
+
+# ── Old-KB fallback (no pre-built token table) ───────────────────────
+
+
+def test_old_kb_fallback_builds_temp_token_table():
+    """When the catalog has no component_catalog_last_seg table,
+    CatalogDB builds a temporary one and lookups still work."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_file = Path(tmpdir) / "catalog.duckdb"
+        _create_catalog(db_file, with_token_table=False)
+
+        with CatalogDB(db_file) as connector:
+            results = connector.find_components_by_suffixes(["Agent", "run"])
+
+        ids = {row["id"] for row in results}
+        assert "pkg.Agent" in ids
+        assert "pkg.Tool.run" in ids
+        assert "other.Unused" not in ids
+
+
+def test_old_kb_full_path_exact_match():
+    """Full dotted path used as a suffix resolves via exact id match."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_file = Path(tmpdir) / "catalog.duckdb"
+        _create_catalog(db_file, with_token_table=False)
+
+        with CatalogDB(db_file) as connector:
+            results = connector.find_components_by_suffixes(["pkg.Tool.run"])
+
+        ids = {row["id"] for row in results}
+        assert "pkg.Tool.run" in ids
+
+
+# ── Large suffix list ─────────────────────────────────────────────────
+
+
+def test_large_suffix_list():
+    """Verify that hundreds of suffixes don't cause query issues."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_file = Path(tmpdir) / "catalog.duckdb"
+
+        con = duckdb.connect(str(db_file))
+        con.execute(
+            """
+            CREATE TABLE component_catalog (
+                id TEXT PRIMARY KEY, label TEXT, concept TEXT,
+                framework TEXT, sig_name TEXT, type TEXT, catalog_label TEXT
+            );
+            """
+        )
+        entries = []
+        for i in range(500):
+            entries.append((
+                f"fw.mod{i}.Class{i}", f"Class{i}", "model",
+                "fw", None, "class", None,
+            ))
+        con.executemany(
+            "INSERT INTO component_catalog VALUES (?, ?, ?, ?, ?, ?, ?)",
+            entries,
+        )
+        con.execute(
+            """
+            CREATE TABLE component_catalog_last_seg AS
+            SELECT id, split_part(id, '.', -1) AS last_seg
+            FROM component_catalog;
+            """
+        )
+        con.close()
+
+        suffixes = [f"Class{i}" for i in range(500)]
+        suffixes += [f"nonexistent_{i}" for i in range(500)]
+
+        with CatalogDB(db_file) as connector:
+            results = connector.find_components_by_suffixes(suffixes)
+
+        ids = {row["id"] for row in results}
+        assert len(ids) == 500
+        assert "fw.mod0.Class0" in ids
+        assert "fw.mod499.Class499" in ids
+
+
+def test_find_ids_by_path_and_concept():
+    """find_ids_by_path_and_concept still works through the VIEW alias."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_file = Path(tmpdir) / "catalog.duckdb"
+        _create_catalog(db_file)
+
+        with CatalogDB(db_file) as connector:
+            ids = connector.find_ids_by_path_and_concept("pkg", ["agent"])
+
+        assert "pkg.Agent" in ids

--- a/aibom/tests/test_deployment_detector.py
+++ b/aibom/tests/test_deployment_detector.py
@@ -362,3 +362,29 @@ data:
         comps, _ = run_scanner(DeploymentDetector, tmp_path, {"x.yaml": yml})
         assert comps
         assert all(c.detection_source == DetectionSource.CONFIG_FILE for c in comps)
+
+    def test_vendored_venv_skipped(self, tmp_path: Path) -> None:
+        venv_dir = tmp_path / "myapp_venv" / "lib" / "python3.11" / "site-packages"
+        venv_dir.mkdir(parents=True)
+        (venv_dir / "values.yaml").write_text(
+            "image: vllm/vllm-openai:latest\n"
+        )
+        (tmp_path / "real.yaml").write_text(
+            "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: x\n"
+            "spec:\n  template:\n    spec:\n      containers:\n"
+            "        - image: vllm/vllm-openai:latest\n"
+        )
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, _ = DeploymentDetector().scan(ctx)
+        paths = [c.file_path for c in comps]
+        assert not any("myapp_venv" in p for p in paths)
+
+    def test_site_packages_skipped(self, tmp_path: Path) -> None:
+        sp_dir = tmp_path / "site-packages" / "openai"
+        sp_dir.mkdir(parents=True)
+        (sp_dir / "deploy.yaml").write_text(
+            "apiVersion: v1\nkind: ConfigMap\ndata:\n  MODEL: gpt-4o\n"
+        )
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, _ = DeploymentDetector().scan(ctx)
+        assert len(comps) == 0

--- a/aibom/tests/test_env_var_resolver.py
+++ b/aibom/tests/test_env_var_resolver.py
@@ -196,6 +196,34 @@ class TestCommentSkipping:
         assert comps[0].metadata["env"] == "NEW_KEY"
 
 
+class TestGoEnvVarExtraction:
+    def test_os_getenv(self, tmp_path: Path) -> None:
+        (tmp_path / "main.go").write_text(
+            'package main\n'
+            'import "os"\n'
+            'func main() {\n'
+            '    model := os.Getenv("LLM_MODEL")\n'
+            '}\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].metadata["env"] == "LLM_MODEL"
+
+
+class TestJavaEnvVarExtraction:
+    def test_system_getenv(self, tmp_path: Path) -> None:
+        (tmp_path / "App.java").write_text(
+            'public class App {\n'
+            '    String model = System.getenv("OPENAI_MODEL");\n'
+            '}\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].metadata["env"] == "OPENAI_MODEL"
+
+
 class TestUnsupportedLanguage:
     def test_txt_file_skipped(self, tmp_path: Path) -> None:
         (tmp_path / "notes.txt").write_text(

--- a/aibom/tests/test_file_cache.py
+++ b/aibom/tests/test_file_cache.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from aibom.scanners.file_cache import (
+    cache_stats,
+    clear_cache,
+    read_text_cached,
+    read_text_cached_async,
+    warm_cache_async,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    clear_cache()
+    yield
+    clear_cache()
+
+
+class TestReadTextCached:
+    def test_returns_file_content(self, tmp_path: Path):
+        f = tmp_path / "hello.py"
+        f.write_text("print('hi')")
+        assert read_text_cached(f) == "print('hi')"
+
+    def test_second_read_is_cache_hit(self, tmp_path: Path):
+        f = tmp_path / "a.py"
+        f.write_text("x = 1")
+        read_text_cached(f)
+        stats_before = cache_stats()
+        read_text_cached(f)
+        stats_after = cache_stats()
+        assert stats_after["hits"] == stats_before["hits"] + 1
+        assert stats_after["misses"] == stats_before["misses"]
+
+    def test_accepts_string_path(self, tmp_path: Path):
+        f = tmp_path / "b.py"
+        f.write_text("y = 2")
+        assert read_text_cached(str(f)) == "y = 2"
+
+    def test_raises_on_missing_file(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            read_text_cached(tmp_path / "nonexistent.py")
+
+    def test_replace_errors_by_default(self, tmp_path: Path):
+        f = tmp_path / "binary.py"
+        f.write_bytes(b"hello \xff world")
+        text = read_text_cached(f)
+        assert "hello" in text
+        assert "\ufffd" in text
+
+
+class TestReadTextCachedAsync:
+    def test_async_read(self, tmp_path: Path):
+        f = tmp_path / "async.py"
+        f.write_text("async_content")
+        result = asyncio.run(read_text_cached_async(f))
+        assert result == "async_content"
+
+    def test_async_uses_shared_cache(self, tmp_path: Path):
+        f = tmp_path / "shared.py"
+        f.write_text("shared")
+        read_text_cached(f)
+        stats = cache_stats()
+        asyncio.run(read_text_cached_async(f))
+        assert cache_stats()["hits"] == stats["hits"] + 1
+
+
+class TestWarmCacheAsync:
+    def test_warm_cache_preloads_files(self, tmp_path: Path):
+        files = []
+        for i in range(5):
+            f = tmp_path / f"file{i}.py"
+            f.write_text(f"content_{i}")
+            files.append(f)
+
+        loaded = asyncio.run(warm_cache_async(files))
+        assert loaded == 5
+        assert cache_stats()["entries"] == 5
+        for f in files:
+            assert read_text_cached(f) == f.read_text()
+
+    def test_warm_skips_already_cached(self, tmp_path: Path):
+        f = tmp_path / "existing.py"
+        f.write_text("already")
+        read_text_cached(f)
+
+        loaded = asyncio.run(warm_cache_async([f]))
+        assert loaded == 0
+
+    def test_warm_skips_unreadable_files(self, tmp_path: Path):
+        good = tmp_path / "good.py"
+        good.write_text("ok")
+        bad = tmp_path / "bad.py"
+
+        loaded = asyncio.run(warm_cache_async([good, bad]))
+        assert loaded == 1
+
+    def test_warm_empty_list(self):
+        loaded = asyncio.run(warm_cache_async([]))
+        assert loaded == 0
+
+
+class TestClearCache:
+    def test_clear_resets_stats(self, tmp_path: Path):
+        f = tmp_path / "x.py"
+        f.write_text("x")
+        read_text_cached(f)
+        assert cache_stats()["entries"] == 1
+        clear_cache()
+        assert cache_stats() == {"hits": 0, "misses": 0, "entries": 0}

--- a/aibom/tests/test_kb_enrichment_scanner.py
+++ b/aibom/tests/test_kb_enrichment_scanner.py
@@ -34,11 +34,14 @@ from aibom.models import AIComponentType, DetectionSource, ScanContext
 from aibom.scanners.kb_enrichment_scanner import (
     ALLOWED_CONCEPTS,
     KBEnrichmentScanner,
+    _MatchResult,
     _build_kb_patterns,
+    _emit_suggestive_candidates,
     _extract_class_segment,
     _extract_leaf_class,
     _frameworks_related,
-    _match_observation,
+    _has_suggestive_signal,
+    _match_observation_rich,
     _resolve_kb_path,
 )
 
@@ -85,8 +88,8 @@ class TestFrameworksRelated:
         assert _frameworks_related("openai", "") is True
 
 
-class TestMatchObservation:
-    """Unit tests for _match_observation with a fake kb_by_id."""
+class TestMatchObservationRich:
+    """Unit tests for _match_observation_rich with a fake kb_by_id."""
 
     @pytest.fixture()
     def sample_kb(self) -> dict[str, dict[str, Any]]:
@@ -109,33 +112,38 @@ class TestMatchObservation:
         }
 
     def test_tier1_exact(self, sample_kb: dict):
-        result = _match_observation("crewai.Agent", sample_kb, {"crewai"})
-        assert result is not None
-        assert result["concept"] == "agent"
+        result = _match_observation_rich("crewai.Agent", sample_kb, {"crewai"})
+        assert result.is_confirmed
+        assert result.entry is not None
+        assert result.entry["concept"] == "agent"
 
     def test_tier2_suffix(self, sample_kb: dict):
-        result = _match_observation(
+        result = _match_observation_rich(
             "ChatOpenAI",
             {"langchain_openai.ChatOpenAI": sample_kb["langchain_openai.ChatOpenAI"]},
             {"langchain_openai"},
         )
-        assert result is not None
-        assert result["concept"] == "model"
+        assert result.is_confirmed
+        assert result.entry is not None
+        assert result.entry["concept"] == "model"
 
     def test_tier3_class_segment(self, sample_kb: dict):
-        result = _match_observation(
+        result = _match_observation_rich(
             "langchain_community.vectorstores.FAISS.from_texts",
             sample_kb,
             {"langchain_community"},
         )
-        assert result is not None
-        assert result["concept"] == "datastore"
+        assert result.is_confirmed
+        assert result.entry is not None
+        assert result.entry["concept"] == "datastore"
 
     def test_no_match(self, sample_kb: dict):
-        result = _match_observation("totally.Unknown", sample_kb, set())
-        assert result is None
+        result = _match_observation_rich("totally.Unknown", sample_kb, set())
+        assert not result.is_confirmed
+        assert not result.is_partial
 
-    def test_tier3_rejects_unrelated_framework(self):
+    def test_partial_match_framework_mismatch(self):
+        """Leaf class matches KB but import module differs — MAYBE path."""
         kb = {
             "langchain_community.llms.openai.OpenAI": {
                 "id": "langchain_community.llms.openai.OpenAI",
@@ -143,8 +151,37 @@ class TestMatchObservation:
                 "framework": "langchain_community",
             },
         }
-        result = _match_observation("openai.OpenAI", kb, {"openai"})
-        assert result is None
+        result = _match_observation_rich("models.OpenAI", kb, {"models"})
+        assert result.is_partial
+        assert result.partial_kb_id == "langchain_community.llms.openai.OpenAI"
+        assert result.partial_kb_framework == "langchain_community"
+        assert result.obs_module == "models"
+
+    def test_partial_match_wrapper_library(self):
+        """Wrapper class that matches KB leaf via class segment extraction."""
+        kb = {
+            "langchain_openai.ChatOpenAI": {
+                "id": "langchain_openai.ChatOpenAI",
+                "concept": "model",
+                "framework": "langchain_openai",
+            },
+        }
+        result = _match_observation_rich(
+            "models.llm.openai.ChatOpenAI.invoke", kb, set(),
+        )
+        assert result.is_partial
+        assert "ChatOpenAI" in (result.partial_kb_id or "")
+
+    def test_confirmed_when_framework_matches(self):
+        kb = {
+            "langchain_openai.ChatOpenAI": {
+                "id": "langchain_openai.ChatOpenAI",
+                "concept": "model",
+                "framework": "langchain_openai",
+            },
+        }
+        result = _match_observation_rich("langchain_openai.ChatOpenAI", kb, {"langchain_openai"})
+        assert result.is_confirmed
 
     def test_tier3_lowercase_short_name_skipped(self):
         kb = {
@@ -154,12 +191,10 @@ class TestMatchObservation:
                 "framework": "crewai",
             },
         }
-        result = _match_observation(
+        result = _match_observation_rich(
             "openai.OpenAI.chat.completions.create", kb, {"openai"}
         )
-        # "create" is lowercase, but class segment "OpenAI" is uppercase.
-        # However, the framework check should reject because openai != crewai.
-        assert result is None
+        assert not result.is_confirmed
 
 
 def _kb_available() -> bool:
@@ -417,6 +452,107 @@ class TestKBEnrichmentScannerIntegration:
         comps, _ = KBEnrichmentScanner().scan(ctx)
         files = {c.file_path for c in comps}
         assert len(files) == 2
+
+
+class TestHasSuggestiveSignal:
+    """Unit tests for _has_suggestive_signal."""
+
+    def test_ai_dir_models(self, tmp_path: Path):
+        f = tmp_path / "models" / "llm.py"
+        f.parent.mkdir()
+        f.write_text("class MyLLM: pass")
+        assert _has_suggestive_signal(f, "class MyLLM: pass")
+
+    def test_ai_dir_agents(self, tmp_path: Path):
+        f = tmp_path / "agents" / "main.py"
+        f.parent.mkdir()
+        f.write_text("pass")
+        assert _has_suggestive_signal(f, "pass")
+
+    def test_import_has_openai(self, tmp_path: Path):
+        f = tmp_path / "utils" / "helper.py"
+        f.parent.mkdir()
+        source = "from internal.openai_wrapper import get_client\n"
+        f.write_text(source)
+        assert _has_suggestive_signal(f, source)
+
+    def test_no_signal_plain_util(self, tmp_path: Path):
+        f = tmp_path / "utils" / "strings.py"
+        f.parent.mkdir()
+        source = "import os\ndef strip(s): return s.strip()\n"
+        f.write_text(source)
+        assert not _has_suggestive_signal(f, source)
+
+    def test_no_signal_test_file(self, tmp_path: Path):
+        f = tmp_path / "tests" / "test_foo.py"
+        f.parent.mkdir()
+        source = "import pytest\ndef test_x(): pass\n"
+        f.write_text(source)
+        assert not _has_suggestive_signal(f, source)
+
+
+class TestEmitSuggestiveCandidates:
+    """Unit tests for _emit_suggestive_candidates."""
+
+    def test_emits_for_indicative_class(self, tmp_path: Path):
+        f = tmp_path / "models" / "chat.py"
+        f.parent.mkdir()
+        source = "client = OpenAIModel(api_key='x')\n"
+        f.write_text(source)
+        candidates = _emit_suggestive_candidates(f, source)
+        assert len(candidates) == 1
+        assert candidates[0].needs_agentic is True
+        assert candidates[0].confidence == 0.2
+        assert "suggestive_signal" in candidates[0].metadata
+
+    def test_skips_generic_class(self, tmp_path: Path):
+        f = tmp_path / "models" / "data.py"
+        f.parent.mkdir()
+        source = "obj = Dict(key='val')\n"
+        f.write_text(source)
+        candidates = _emit_suggestive_candidates(f, source)
+        assert len(candidates) == 0
+
+    def test_skips_non_indicative_class(self, tmp_path: Path):
+        f = tmp_path / "models" / "user.py"
+        f.parent.mkdir()
+        source = "user = UserProfile(name='x')\n"
+        f.write_text(source)
+        candidates = _emit_suggestive_candidates(f, source)
+        assert len(candidates) == 0
+
+    def test_multiple_candidates(self, tmp_path: Path):
+        f = tmp_path / "agents" / "multi.py"
+        f.parent.mkdir()
+        source = (
+            "llm = ChatModel()\n"
+            "emb = EmbeddingClient()\n"
+        )
+        f.write_text(source)
+        candidates = _emit_suggestive_candidates(f, source)
+        assert len(candidates) == 2
+
+
+@pytest.mark.skipif(not _kb_available(), reason="No KB DuckDB installed")
+class TestPartialMatchIntegration:
+    """Integration test: wrapper code emits agentic candidates via Gate 3 MAYBE."""
+
+    def test_wrapper_emits_agentic_candidate(self, tmp_path: Path):
+        wrapper_dir = tmp_path / "models" / "llm"
+        wrapper_dir.mkdir(parents=True)
+        (wrapper_dir / "__init__.py").write_text("")
+        (wrapper_dir / "openai_wrapper.py").write_text(
+            "from models.llm.base import BaseLLM\n"
+            "class ChatOpenAI:\n"
+            "    pass\n"
+            "llm = ChatOpenAI()\n"
+        )
+        ctx = ScanContext(paths=[str(tmp_path)])
+        comps, _ = KBEnrichmentScanner().scan(ctx)
+        agentic = [c for c in comps if c.needs_agentic]
+        assert len(agentic) >= 1
+        hints = " ".join(c.agentic_hint for c in agentic)
+        assert "wrapper" in hints.lower() or "trace" in hints.lower()
 
 
 class TestKBEnrichmentScannerNoKB:

--- a/aibom/tests/test_model_detector.py
+++ b/aibom/tests/test_model_detector.py
@@ -9,9 +9,17 @@ from unittest.mock import patch
 
 import pytest
 
-from aibom.scanners.model_detector import ModelDetector, _litellm_alias_keys
+from aibom.scanners.model_detector import ModelDetector, _litellm_alias_keys, _registry_cache
 
 from .conftest import run_scanner
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry_cache():
+    """Ensure the model registry cache is fresh for every test."""
+    _registry_cache.clear()
+    yield
+    _registry_cache.clear()
 
 
 class TestLiteLLMAliasKeys:

--- a/aibom/tests/test_path_filter.py
+++ b/aibom/tests/test_path_filter.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from aibom.utils.path_filter import SKIP_DIR_NAMES, should_skip_dir
+
+
+class TestSkipDirNames:
+    def test_exact_git(self):
+        assert should_skip_dir(".git")
+
+    def test_exact_venv(self):
+        assert should_skip_dir("venv")
+        assert should_skip_dir(".venv")
+
+    def test_exact_node_modules(self):
+        assert should_skip_dir("node_modules")
+
+    def test_exact_pycache(self):
+        assert should_skip_dir("__pycache__")
+
+    def test_exact_site_packages(self):
+        assert should_skip_dir("site-packages")
+
+    def test_exact_tox(self):
+        assert should_skip_dir(".tox")
+
+    def test_exact_build_dist(self):
+        assert should_skip_dir("build")
+        assert should_skip_dir("dist")
+
+
+class TestVendoredVenvPatterns:
+    def test_underscore_venv_suffix(self):
+        assert should_skip_dir("orchestrator-tes_venv")
+        assert should_skip_dir("myapp_venv")
+
+    def test_hyphen_venv_suffix(self):
+        assert should_skip_dir("project-venv")
+        assert should_skip_dir("svc-venv")
+
+    def test_egg_info_suffix(self):
+        assert should_skip_dir("mypackage.egg-info")
+        assert should_skip_dir("aibom-0.5.1.egg-info")
+
+    def test_case_insensitive_venv(self):
+        assert should_skip_dir("APP_VENV")
+        assert should_skip_dir("Service_Venv")
+        assert should_skip_dir("MY-VENV")
+
+
+class TestNonSkipped:
+    def test_regular_directory(self):
+        assert not should_skip_dir("src")
+        assert not should_skip_dir("lib")
+        assert not should_skip_dir("app")
+
+    def test_partial_match_not_skipped(self):
+        assert not should_skip_dir("my_venv_backup")
+        assert not should_skip_dir("venv_old")
+
+    def test_empty_string(self):
+        assert not should_skip_dir("")
+
+    def test_venv_as_substring(self):
+        assert not should_skip_dir("venvs")
+        assert not should_skip_dir("virtualenv")
+
+
+class TestConstantCompleteness:
+    def test_skip_dir_names_is_frozenset(self):
+        assert isinstance(SKIP_DIR_NAMES, frozenset)
+
+    def test_expected_entries_present(self):
+        expected = {".git", "__pycache__", "node_modules", ".venv", "venv",
+                    ".tox", "site-packages", "dist", "build"}
+        assert expected.issubset(SKIP_DIR_NAMES)

--- a/aibom/tests/test_plugins.py
+++ b/aibom/tests/test_plugins.py
@@ -1,0 +1,125 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aibom.plugins import (
+    discover_mcp_configs,
+    discover_plugin_manifests,
+    discover_reporter_plugins,
+    discover_scanner_plugins,
+    list_plugins,
+    load_plugin_manifest,
+)
+
+
+class TestEntryPointDiscovery:
+    def test_no_plugins_returns_empty(self) -> None:
+        with patch("aibom.plugins.importlib.metadata.entry_points", return_value=[]):
+            assert discover_scanner_plugins() == []
+            assert discover_reporter_plugins() == []
+
+    def test_loads_scanner_entry_point(self) -> None:
+        mock_ep = MagicMock()
+        mock_ep.name = "test_scanner"
+        mock_ep.value = "test_pkg:TestScanner"
+
+        class FakeScanner:
+            name = "test_scanner"
+
+        mock_ep.load.return_value = FakeScanner
+        with patch(
+            "aibom.plugins.importlib.metadata.entry_points",
+            return_value=[mock_ep],
+        ):
+            plugins = discover_scanner_plugins()
+        assert len(plugins) == 1
+        assert plugins[0] is FakeScanner
+
+    def test_handles_failed_load(self) -> None:
+        mock_ep = MagicMock()
+        mock_ep.name = "bad_plugin"
+        mock_ep.value = "nonexistent:Class"
+        mock_ep.load.side_effect = ImportError("no module")
+        with patch(
+            "aibom.plugins.importlib.metadata.entry_points",
+            return_value=[mock_ep],
+        ):
+            plugins = discover_scanner_plugins()
+        assert plugins == []
+
+
+class TestMCPDiscovery:
+    def test_discovers_user_mcp_config(self, tmp_path: Path) -> None:
+        import json
+
+        mcp_dir = tmp_path / ".aibom"
+        mcp_dir.mkdir()
+        config = {
+            "mcpServers": {
+                "terraform": {"command": "npx", "args": ["tf-mcp"]},
+            }
+        }
+        (mcp_dir / ".mcp.json").write_text(json.dumps(config))
+
+        with patch("aibom.plugins.Path.home", return_value=tmp_path):
+            with patch("aibom.plugins.Path.cwd", return_value=Path("/nonexistent")):
+                configs = discover_mcp_configs()
+
+        assert len(configs) == 1
+        assert configs[0]["_name"] == "terraform"
+
+    def test_empty_when_no_config(self, tmp_path: Path) -> None:
+        with patch("aibom.plugins.Path.home", return_value=tmp_path):
+            with patch("aibom.plugins.Path.cwd", return_value=tmp_path):
+                assert discover_mcp_configs() == []
+
+
+class TestPluginManifest:
+    def test_load_valid_manifest(self, tmp_path: Path) -> None:
+        manifest = tmp_path / "manifest.yaml"
+        manifest.write_text(
+            "name: my-scanner\nversion: 1.0.0\ntype: scanner\n"
+            "entry_point: my_pkg:MyScanner\n"
+        )
+        data = load_plugin_manifest(manifest)
+        assert data is not None
+        assert data["name"] == "my-scanner"
+        assert data["type"] == "scanner"
+
+    def test_missing_name_returns_none(self, tmp_path: Path) -> None:
+        manifest = tmp_path / "manifest.yaml"
+        manifest.write_text("version: 1.0.0\n")
+        assert load_plugin_manifest(manifest) is None
+
+    def test_nonexistent_returns_none(self, tmp_path: Path) -> None:
+        assert load_plugin_manifest(tmp_path / "nope.yaml") is None
+
+    def test_discover_manifests(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "my-plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "manifest.yaml").write_text(
+            "name: my-plugin\nversion: 2.0.0\ntype: reporter\n"
+        )
+        manifests = discover_plugin_manifests(search_dirs=[tmp_path])
+        assert len(manifests) == 1
+        assert manifests[0]["name"] == "my-plugin"
+
+
+class TestListPlugins:
+    def test_list_empty(self) -> None:
+        with patch("aibom.plugins.discover_scanner_plugins", return_value=[]):
+            with patch("aibom.plugins.discover_reporter_plugins", return_value=[]):
+                with patch("aibom.plugins.discover_mcp_configs", return_value=[]):
+                    with patch("aibom.plugins.discover_plugin_manifests", return_value=[]):
+                        result = list_plugins()
+        assert result["scanners"] == []
+        assert result["reporters"] == []
+        assert result["mcp_servers"] == []
+        assert result["manifests"] == []

--- a/aibom/tests/test_repo_triage.py
+++ b/aibom/tests/test_repo_triage.py
@@ -1,0 +1,108 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aibom.repo_triage import RepoTriager, TriageResult
+
+
+class TestDeterministicTriage:
+    def test_repo_with_ai_package_in_requirements(self, tmp_path: Path):
+        repo = tmp_path / "ml-app"
+        repo.mkdir()
+        (repo / "requirements.txt").write_text("flask==2.0\nlangchain==0.3.1\nrequests\n")
+        triager = RepoTriager()
+        results = triager.triage_repos([str(repo)])
+        assert len(results) == 1
+        assert results[0].decision == "deep-scan"
+        assert results[0].method == "deterministic"
+        assert "langchain" in results[0].reason
+
+    def test_repo_with_ai_package_in_pyproject(self, tmp_path: Path):
+        repo = tmp_path / "agent-svc"
+        repo.mkdir()
+        (repo / "pyproject.toml").write_text(
+            '[project]\ndependencies = ["openai>=1.0", "pydantic"]\n'
+        )
+        triager = RepoTriager()
+        results = triager.triage_repos([str(repo)])
+        assert results[0].decision == "deep-scan"
+
+    def test_repo_with_ai_package_in_package_json(self, tmp_path: Path):
+        repo = tmp_path / "js-ai"
+        repo.mkdir()
+        (repo / "package.json").write_text(
+            '{"dependencies": {"@langchain/core": "^0.2"}}\n'
+        )
+        triager = RepoTriager()
+        results = triager.triage_repos([str(repo)])
+        assert results[0].decision == "deep-scan"
+
+    def test_repo_without_ai_packages_needs_clone(self, tmp_path: Path):
+        repo = tmp_path / "web-app"
+        repo.mkdir()
+        (repo / "requirements.txt").write_text("flask==2.0\nrequests\nsqlalchemy\n")
+        triager = RepoTriager()
+        results = triager.triage_repos([str(repo)])
+        assert results[0].decision == "needs-clone"
+        assert "agentic mode not available" in results[0].reason
+
+    def test_nonexistent_repo_skipped(self, tmp_path: Path):
+        triager = RepoTriager()
+        results = triager.triage_repos([str(tmp_path / "missing")])
+        assert results[0].decision == "skip"
+        assert "does not exist" in results[0].reason
+
+    def test_multiple_repos_mixed(self, tmp_path: Path):
+        ai_repo = tmp_path / "ai"
+        ai_repo.mkdir()
+        (ai_repo / "requirements.txt").write_text("transformers\n")
+
+        web_repo = tmp_path / "web"
+        web_repo.mkdir()
+        (web_repo / "requirements.txt").write_text("django\n")
+
+        triager = RepoTriager()
+        results = triager.triage_repos([str(ai_repo), str(web_repo)])
+        decisions = {Path(r.repo_path).name: r.decision for r in results}
+        assert decisions["ai"] == "deep-scan"
+        assert decisions["web"] == "needs-clone"
+
+    def test_empty_repo_needs_clone(self, tmp_path: Path):
+        repo = tmp_path / "empty"
+        repo.mkdir()
+        triager = RepoTriager()
+        results = triager.triage_repos([str(repo)])
+        assert results[0].decision == "needs-clone"
+
+
+class TestBuildRepoSummary:
+    def test_includes_readme(self, tmp_path: Path):
+        repo = tmp_path / "with-readme"
+        repo.mkdir()
+        (repo / "README.md").write_text("# AI Project\nThis uses transformers.")
+        triager = RepoTriager()
+        summary = triager._build_repo_summary(repo)
+        assert "README" in summary
+        assert "AI Project" in summary
+
+    def test_includes_manifest(self, tmp_path: Path):
+        repo = tmp_path / "with-manifest"
+        repo.mkdir()
+        (repo / "requirements.txt").write_text("openai==1.5\n")
+        triager = RepoTriager()
+        summary = triager._build_repo_summary(repo)
+        assert "requirements.txt" in summary
+        assert "openai" in summary
+
+    def test_lists_top_level_files_if_no_readme_or_manifest(self, tmp_path: Path):
+        repo = tmp_path / "bare"
+        repo.mkdir()
+        (repo / "main.py").write_text("pass")
+        (repo / "config.yaml").write_text("key: val")
+        triager = RepoTriager()
+        summary = triager._build_repo_summary(repo)
+        assert "Top-level files" in summary

--- a/aibom/tests/test_scan_cache.py
+++ b/aibom/tests/test_scan_cache.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aibom.scan_cache import (
+    cache_info,
+    cache_key,
+    clear_cache,
+    load_cached,
+    save_cached,
+)
+
+
+class TestCacheKey:
+    def test_deterministic(self, tmp_path: Path) -> None:
+        f = tmp_path / "app.py"
+        f.write_text("x = 1\n")
+        k1 = cache_key([str(tmp_path)])
+        k2 = cache_key([str(tmp_path)])
+        assert k1 == k2
+
+    def test_changes_on_modification(self, tmp_path: Path) -> None:
+        f = tmp_path / "app.py"
+        f.write_text("x = 1\n")
+        k1 = cache_key([str(tmp_path)])
+        f.write_text("x = 2\n")
+        k2 = cache_key([str(tmp_path)])
+        assert k1 != k2
+
+
+class TestSaveLoadClear:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        cd = tmp_path / "cache"
+        data = {"_v2": True, "components": [{"name": "test"}]}
+        save_cached(cd, "abc123", data)
+        loaded = load_cached(cd, "abc123")
+        assert loaded is not None
+        assert loaded["components"] == [{"name": "test"}]
+        assert loaded["_cache_version"] == 1
+
+    def test_miss_returns_none(self, tmp_path: Path) -> None:
+        cd = tmp_path / "cache"
+        assert load_cached(cd, "nonexistent") is None
+
+    def test_clear_removes_all(self, tmp_path: Path) -> None:
+        cd = tmp_path / "cache"
+        save_cached(cd, "a", {"x": 1})
+        save_cached(cd, "b", {"x": 2})
+        removed = clear_cache(cd)
+        assert removed == 2
+        assert load_cached(cd, "a") is None
+
+    def test_clear_empty_dir(self, tmp_path: Path) -> None:
+        cd = tmp_path / "cache"
+        assert clear_cache(cd) == 0
+
+
+class TestCacheInfo:
+    def test_lists_entries(self, tmp_path: Path) -> None:
+        cd = tmp_path / "cache"
+        save_cached(cd, "entry1", {"data": "hello"})
+        entries = cache_info(cd)
+        assert len(entries) == 1
+        assert entries[0]["key"] == "entry1"
+        assert "cached_at" in entries[0]
+
+    def test_empty_returns_empty(self, tmp_path: Path) -> None:
+        cd = tmp_path / "cache"
+        assert cache_info(cd) == []

--- a/aibom/tests/test_scan_pipeline.py
+++ b/aibom/tests/test_scan_pipeline.py
@@ -5,9 +5,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from aibom.models.enums import AIComponentType
-from aibom.scan_pipeline import ScanPipeline
+from aibom.scan_pipeline import ScanPipeline, StageTiming
 
 
 class TestScanPipeline:
@@ -91,6 +92,94 @@ ai-common = {git = "https://github.com/org/ai-common.git", branch = "main"}
         result = pipeline.run()
         assert result.components == [] or isinstance(result.components, list)
         assert result.agentic_candidate_count >= 0
+
+
+class TestPipelineTiming:
+    def test_timings_populated(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text(
+            'from openai import OpenAI\nclient = OpenAI(model="gpt-4o")\n'
+        )
+        result = ScanPipeline(scan_paths=[str(tmp_path)]).run()
+        assert len(result.timings) == 4
+        assert result.total_elapsed_s > 0
+        names = [t.name for t in result.timings]
+        assert names == ["scan", "cross_ref", "agentic", "assemble"]
+        for t in result.timings:
+            assert t.elapsed_s >= 0
+
+    def test_agentic_skipped_detail(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text("x = 1\n")
+        result = ScanPipeline(scan_paths=[str(tmp_path)]).run()
+        agentic_timing = next(t for t in result.timings if t.name == "agentic")
+        assert "skipped" in agentic_timing.detail
+
+    def test_file_cache_stats_in_scan_detail(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text("import openai\n")
+        result = ScanPipeline(scan_paths=[str(tmp_path)]).run()
+        scan_timing = next(t for t in result.timings if t.name == "scan")
+        assert "file cache" in scan_timing.detail
+
+
+class TestAgenticScope:
+    def test_candidates_scope_skips_confirmed(self, tmp_path: Path) -> None:
+        """Default 'candidates' scope should skip agentic when no candidates."""
+        (tmp_path / "app.py").write_text(
+            'from openai import OpenAI\nclient = OpenAI(model="gpt-4o")\n'
+        )
+        llm_cfg = {"model": "test/model", "api_key": "fake", "api_base": "http://x"}
+        pipeline = ScanPipeline(
+            scan_paths=[str(tmp_path)],
+            llm_config=llm_cfg,
+            agentic_scope="candidates",
+        )
+        with patch("aibom.agentic.agent.run_agentic_enrichment") as mock_enrich:
+            result = pipeline.run()
+        mock_enrich.assert_not_called()
+
+    def test_all_scope_sends_everything(self, tmp_path: Path) -> None:
+        """'all' scope should invoke agentic enrichment with all components."""
+        (tmp_path / "app.py").write_text(
+            'from openai import OpenAI\nclient = OpenAI(model="gpt-4o")\n'
+        )
+        llm_cfg = {"model": "test/model", "api_key": "fake", "api_base": "http://x"}
+        pipeline = ScanPipeline(
+            scan_paths=[str(tmp_path)],
+            llm_config=llm_cfg,
+            agentic_scope="all",
+        )
+        with patch("aibom.agentic.agent.run_agentic_enrichment") as mock_enrich:
+            mock_enrich.return_value = ([], [], [])
+            result = pipeline.run()
+        mock_enrich.assert_called_once()
+
+
+class TestFileCache:
+    def test_cache_deduplicates(self, tmp_path: Path) -> None:
+        from aibom.scanners.file_cache import cache_stats, clear_cache, read_text_cached
+
+        clear_cache()
+        f = tmp_path / "test.py"
+        f.write_text("hello\n")
+
+        read_text_cached(f)
+        read_text_cached(f)
+        stats = cache_stats()
+        assert stats["hits"] == 1
+        assert stats["misses"] == 1
+        assert stats["entries"] == 1
+        clear_cache()
+
+    def test_clear_resets(self, tmp_path: Path) -> None:
+        from aibom.scanners.file_cache import cache_stats, clear_cache, read_text_cached
+
+        clear_cache()
+        f = tmp_path / "test.py"
+        f.write_text("hello\n")
+        read_text_cached(f)
+        clear_cache()
+        stats = cache_stats()
+        assert stats["entries"] == 0
+        assert stats["hits"] == 0
 
 
 class TestResolveComponentsProvenance:

--- a/aibom/tests/test_workflow_analyzer.py
+++ b/aibom/tests/test_workflow_analyzer.py
@@ -65,5 +65,30 @@ class TestWorkflowAnalyzer(unittest.TestCase):
             self.assertIn("value", agent.get("parameters", []))
 
 
+    def test_syntax_error_handled_gracefully(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            bad = Path(tmp_dir) / "broken.py"
+            bad.write_text("def foo(:\n    pass\n", encoding="utf-8")
+            index = build_workflow_index([bad])
+            assert index.get_workflow_context(str(bad), 1) == []
+
+    def test_multi_file_index(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            a = Path(tmp_dir) / "a.py"
+            a.write_text("def caller():\n    callee()\n", encoding="utf-8")
+            b = Path(tmp_dir) / "b.py"
+            b.write_text("def callee():\n    return 42\n", encoding="utf-8")
+            index = build_workflow_index([a, b])
+            ctx_a = index.get_workflow_context(str(a), 1)
+            assert isinstance(ctx_a, list)
+
+    def test_empty_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            empty = Path(tmp_dir) / "empty.py"
+            empty.write_text("", encoding="utf-8")
+            index = build_workflow_index([empty])
+            assert index.get_workflow_context(str(empty), 1) == []
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -8,6 +8,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -379,6 +388,7 @@ name = "cisco-aibom"
 version = "0.5.1"
 source = { editable = "." }
 dependencies = [
+    { name = "aiofiles" },
     { name = "cyclonedx-python-lib" },
     { name = "duckdb" },
     { name = "fastapi" },
@@ -441,6 +451,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "cisco-ai-mcp-scanner", marker = "extra == 'security'", specifier = ">=4.3.0" },
     { name = "cisco-ai-skill-scanner", marker = "extra == 'security'", specifier = ">=2.0.0" },
     { name = "cisco-aibom", extras = ["analysis", "security", "agentic"], marker = "extra == 'all'" },


### PR DESCRIPTION
## Summary

- **Deterministic pipeline optimizations**: Two-pass manifest-first scanning, shared async file I/O cache (aiofiles), DuckDB token-based hash join replacing O(S×N) LIKE queries, centralized venv/site-packages exclusion, deterministic `_pick_best` sorting
- **KB enrichment recall**: Three-outcome gate (YES/MAYBE/NO) at Gate 3 — partial matches become agentic candidates instead of silent drops; suggestive-signal heuristics for wrapper libraries
- **Agentic reliability**: Provider-agnostic rate limiting via `BaseChatModel.rate_limiter` (works for all providers — Bedrock, OpenAI, Anthropic, Azure, Ollama), tool path clamping to scan source directories, markdown fence-aware JSON parser, hardened system prompt enforcing JSON-only output
- **Plugin system**: 5-tier extensibility (catalog extensions, scanner/reporter entry_points, MCP-based agentic tools, full plugin manifests), `cisco-aibom plugin list` command
- **Scan caching**: `--cache-dir` keyed by repo@commit_sha, `cisco-aibom cache clear/list`
- **Python 3.11 compat**: replaced `Path.walk()` (3.12+) with `os.walk()`
- **Test isolation**: fixed cross-test pollution from module-level `_allowed_search_roots`

## Test plan

- [x] 603 tests passing across Python 3.11, 3.12, 3.13
- [x] 21 agentic tests (agent creation, batch execution, middleware parsing, tool stats)
- [x] Rate limiter verified (previously throttled → 0 errors)
- [x] Tool path clamping verified (previously searched `/`, `/Users` → now clamped to scan source)