### PR TITLE
feat: harden false-positive filtering and add explainable report workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ docs/    # Documentation (CLI reference, guides, API docs)
 # Install uv (if not already installed)
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# Core CLI
-uv tool install --python 3.13 cisco-aibom
-
-# With agentic enrichment (OpenAI / Azure OpenAI)
+# Analyze with OpenAI / Azure OpenAI
 uv tool install --python 3.13 "cisco-aibom[agentic,llm-openai]"
 
-# With agentic enrichment (AWS Bedrock)
+# Analyze with AWS Bedrock
 uv tool install --python 3.13 "cisco-aibom[agentic,llm-aws]"
+
+# Core CLI only (report rendering, cache inspection, KB commands, etc.)
+uv tool install --python 3.13 cisco-aibom
 
 # Everything
 uv tool install --python 3.13 "cisco-aibom[all]"
@@ -84,6 +84,8 @@ uv tool install --python 3.13 "cisco-aibom[all]"
 # Verify
 cisco-aibom --help
 ```
+
+`cisco-aibom analyze` always requires `--llm-model`. If the required agentic or provider extras are missing, the CLI fails fast with the exact `uv tool install ...` hint for the missing runtime.
 
 ### Install from source
 
@@ -148,8 +150,8 @@ All LLM options can be set via environment variables (`AIBOM_LLM_MODEL`, `AIBOM_
 | Command | Description |
 |---------|-------------|
 | `analyze` | Scan source code, container images, or repos and produce an AI BOM. |
-| `report` | Render a previously generated JSON report with Rich formatting. |
-| `watch` | Poll directories for changes and re-scan with delta reporting. |
+| `report` | Render or upload a previously generated JSON report. |
+| `watch` | Poll directories for changes and re-scan with delta reporting (deterministic pipeline only). |
 | `diff run` | Compare two AIBOM JSON reports side-by-side. |
 | `benchmark run` | Measure precision/recall/F1 against ground-truth YAML. |
 | `kb download` | Download the latest knowledge base. |
@@ -158,7 +160,8 @@ All LLM options can be set via environment variables (`AIBOM_LLM_MODEL`, `AIBOM_
 | `kb verify` | Verify KB integrity (SHA-256 checksum). |
 | `kb request` | Request a KB build for a specific SDK version. |
 | `cache clear` | Remove cached scan results and agentic cache. |
-| `cache list` | List cached scan entries. |
+| `cache list` | List cached entries by cache type. |
+| `cache get` | Inspect a specific cache entry. |
 | `plugin list` | List discovered plugins (entry points, MCP servers). |
 
 See [docs/CLI_REFERENCE.md](https://github.com/cisco-ai-defense/aibom/blob/main/docs/CLI_REFERENCE.md) for complete option details.
@@ -171,7 +174,7 @@ See [docs/CLI_REFERENCE.md](https://github.com/cisco-ai-defense/aibom/blob/main/
 
 ## Agentic Enrichment
 
-The `--llm-model` option (or `AIBOM_LLM_MODEL` env var) is required. The LLM agent acts as the final classifier for every scanner candidate (requires `cisco-aibom[agentic]`):
+The `--llm-model` option (or `AIBOM_LLM_MODEL` env var) is required. The LLM agent acts as the final classifier for every scanner candidate and requires the `agentic` extra plus any provider-specific integration extra (for example `llm-openai` or `llm-aws`):
 
 - Confirms or removes every scanner candidate (no unverified findings)
 - Classifies and enriches components with concrete identifiers
@@ -205,10 +208,34 @@ All LLM options can also be set via environment variables or a `.env` file. See 
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--agentic-batch-size` | `15` | Max components per LLM invocation. |
+| `--agentic-batch-size` | `5` | Max components per LLM invocation. |
 | `--agentic-concurrency` | `1` | Max parallel LLM batches. |
 | `--agentic-timeout` | `120` | Wall-clock seconds per batch before timeout. |
 | `--agentic-fast-model` | — | Cheaper model for simple confirmations (model lookups, dependency checks). |
+| `--progress` | `auto` | Show live per-stage and per-scanner progress in interactive terminals. |
+| `--include-code-snippets` | `off` | Include raw code snippets inside per-finding decision annotations. |
+
+### Report and cache utilities
+
+```bash
+# Render a saved report
+cisco-aibom report report.json
+
+# Explicit show form
+cisco-aibom report show report.json --raw-json
+
+# Upload an existing JSON report
+cisco-aibom report upload report.json --format json \
+  --post-url https://example.invalid/aibom/reports \
+  --ai-defense-api-key $AI_DEFENSE_API_KEY
+
+# Inspect cache families under the shared cache root
+cisco-aibom cache list --type scan
+cisco-aibom cache list --type agentic
+cisco-aibom cache get scan 0123456789ab
+```
+
+All cache families now default under `~/.aibom/cache`, including deterministic scan cache, agentic cache, org cache, model cache, and package metadata cache.
 
 ## Container Scanning
 
@@ -216,10 +243,13 @@ The CLI auto-detects container image references and extracts application source 
 
 ```bash
 # Auto-detect extraction method
-cisco-aibom analyze my-app:latest -o json -O report.json
+cisco-aibom analyze my-app:latest -o json -O report.json \
+  --llm-model gpt-5.4 --llm-api-key $OPENAI_API_KEY
 
 # Force a specific extraction tier
-cisco-aibom analyze my-app:latest -o json -O report.json --container-extraction-tier podman
+cisco-aibom analyze my-app:latest -o json -O report.json \
+  --llm-model gpt-5.4 --llm-api-key $OPENAI_API_KEY \
+  --container-extraction-tier podman
 ```
 
 Supported tiers: `auto`, `syft`, `docker`, `podman`, `nerdctl`, `buildah`, `crane`, `skopeo`, `tarball`.
@@ -230,23 +260,29 @@ See [docs/CONTAINER_SCANNING.md](https://github.com/cisco-ai-defense/aibom/blob/
 
 ```bash
 # Discover and scan all git repos under a directory
-cisco-aibom analyze /path/to/repos --discover-repos -o json -O report.json
+cisco-aibom analyze /path/to/repos --discover-repos -o json -O report.json \
+  --llm-model gpt-5.4 --llm-api-key $OPENAI_API_KEY
 
 # Scan a GitHub org (requires GITHUB_TOKEN)
-cisco-aibom analyze --github-org my-org --platform-token $GITHUB_TOKEN -o json -O report.json
+cisco-aibom analyze --github-org my-org --platform-token $GITHUB_TOKEN -o json -O report.json \
+  --llm-model gpt-5.4 --llm-api-key $OPENAI_API_KEY
 
 # Scan a GitLab group
-cisco-aibom analyze --gitlab-group my-group --platform-token $GITLAB_TOKEN -o json -O report.json
+cisco-aibom analyze --gitlab-group my-group --platform-token $GITLAB_TOKEN -o json -O report.json \
+  --llm-model gpt-5.4 --llm-api-key $OPENAI_API_KEY
 
 # Scan repos from a file (JSON array or newline-delimited)
-cisco-aibom analyze --repos-file repos.txt -o json -O report.json
+cisco-aibom analyze --repos-file repos.txt -o json -O report.json \
+  --llm-model gpt-5.4 --llm-api-key $OPENAI_API_KEY
 
 # Incremental scan (skip repos with unchanged HEAD)
-cisco-aibom analyze /path/to/repos --discover-repos --incremental -o json -O report.json
+cisco-aibom analyze /path/to/repos --discover-repos --skip-unchanged -o json -O report.json \
+  --llm-model gpt-5.4 --llm-api-key $OPENAI_API_KEY
 
 # Limit and filter
 cisco-aibom analyze --github-org my-org --platform-token $GITHUB_TOKEN \
-  --max-repos 50 --repo-filter "ml-" --parallel-repos 4 -o json -O report.json
+  --max-repos 50 --repo-filter "ml-" --parallel-repos 4 -o json -O report.json \
+  --llm-model gpt-5.4 --llm-api-key $OPENAI_API_KEY
 ```
 
 ## Output Formats
@@ -327,7 +363,8 @@ rules:
 ```
 
 ```bash
-cisco-aibom analyze ./my-app -o json -O report.json --policy policy.yaml
+cisco-aibom analyze ./my-app -o json -O report.json \
+  --llm-model gpt-5.4 --llm-api-key $OPENAI_API_KEY --policy policy.yaml
 # Exit code 1 if policy fails
 ```
 
@@ -404,7 +441,9 @@ docker build -t cisco-aibom .
 docker build -f Dockerfile.agentic -t cisco-aibom-agentic .
 
 # Run
-docker run --rm -v /path/to/project:/workspace cisco-aibom analyze /workspace -o json -O /workspace/report.json
+docker run --rm -v /path/to/project:/workspace cisco-aibom-agentic \
+  analyze /workspace -o json -O /workspace/report.json \
+  --llm-model gpt-5.4 --llm-api-key $OPENAI_API_KEY
 ```
 
 ## Testing

--- a/aibom/docs/TECHNICAL_OVERVIEW.md
+++ b/aibom/docs/TECHNICAL_OVERVIEW.md
@@ -25,9 +25,9 @@
 5. **Scan Pipeline Stage 1: Scan** — Run all registered scanners against the source files. Each scanner produces components and relationships. File I/O uses async caching for performance.
 6. **Scan Pipeline Stage 2: Cross-Ref** — Build env-var and package indexes. Resolve env-var references (`os.getenv("MODEL_NAME")`) to concrete values by correlating across files, `.env`, docker-compose, Helm, and Terraform.
 7. **Scan Pipeline Stage 3: Agentic** — Classify all candidates into simple/complex tiers. Run locality-aware batched LLM classification. The agent confirms, rejects, reclassifies, or enriches each candidate using tools (`read_file_lines`, `search_package_info`). Apply structured output (enrichments, new components, removals, risk findings). Cache results by content hash.
-8. **Scan Pipeline Stage 4: Assemble** — Apply `--strict` filtering (drop `needs_agentic` items), collect counts and timing, build the final `PipelineResult`.
-9. **Reporting** — Route `PipelineResult` to the selected reporter. Convert container temp paths to container-style paths. Build per-source summaries and run metadata.
-10. **Post-Processing** — Optionally POST the JSON report with retries, run policy checks, display compliance advisories, render Rich console summary.
+8. **Scan Pipeline Stage 4: Assemble** — Apply `--strict` filtering (drop `needs_agentic` items), collect counts and timing, build the final `PipelineResult`, and ensure final findings carry decision annotations.
+9. **Reporting** — Route `PipelineResult` to the selected reporter. Convert container temp paths to container-style paths. Build per-source summaries, schema version metadata, and run metadata.
+10. **Post-Processing** — Optionally POST the JSON report with retries or upload an already-generated JSON report, run policy checks, display compliance advisories, render Rich console summary.
 
 ## 3. Scanner Architecture
 
@@ -68,6 +68,7 @@ Each scanner receives a `ScanContext` with paths, config, and shared state. Scan
 | `scan_pipeline.py` | Four-stage pipeline orchestrator (Scan → Cross-Ref → Agentic → Assemble). |
 | `scanners/__init__.py` | Scanner registry and `run_scanners()` dispatcher. |
 | `scanners/base.py` | `BaseScanner` abstract class with `__init_subclass__` auto-registration. |
+| `cache_paths.py` | Shared cache-root resolution for `scan`, `agentic`, `org`, `model`, and `packages` caches. |
 | `cross_ref.py` | Env-var and package index builder, component resolver, external repo dep detection. |
 | `cst_parser.py` | LibCST-based Python parser for assignments, decorators, annotations, imports, class definitions, and inline annotations. |
 | `scanners/multi_language_scanner.py` | Tree-sitter-based parser for JS/TS, Java, Go, Rust, Ruby, C#, PHP. |
@@ -78,6 +79,7 @@ Each scanner receives a `ScanContext` with paths, config, and shared state. Scan
 | `agentic/tools.py` | LangChain tools for file reading, import analysis, code search, package registry queries (PyPI/npm/Go), and repo triage (directory tree, file snippets). |
 | `agentic/middleware.py` | Structured output parser — extracts enrichments, new components, removals, risk findings from LLM JSON responses. |
 | `agentic/prompts.py` | System prompts for the agentic enrichment agent. |
+| `finding_annotations.py` | Applies default per-finding justification and evidence metadata, with optional code snippet hydration. |
 | `llm_factory.py` | Centralized `build_chat_model()` — provider resolution, parameter mapping for OpenAI/Azure/Bedrock/Ollama/etc. |
 | `llm_client.py` | Lightweight LLM client for semantic parsing (model name extraction). |
 | `scanners/container_extractor.py` | Tiered container source extraction (Docker/Podman/nerdctl/Buildah/Skopeo/Crane/tarball). |
@@ -157,10 +159,10 @@ Reporters use a registry pattern. Custom reporters can be added via the `aibom.r
 The agentic layer is the mandatory final classifier. Scanners generate candidates; the agent is the single source of truth.
 
 1. **Candidate triage** — All candidates are split into "simple" (registry-confirmable: known model IDs, manifest dependencies) and "complex" (ambiguous type, missing model name, multi-file reasoning needed).
-2. **Locality-aware batching** — Candidates are grouped by parent directory, then split into batches of configurable size (default 15). This provides coherent code context per batch.
+2. **Locality-aware batching** — Candidates are grouped by parent directory, then split into batches of configurable size (CLI default `5`). This provides coherent code context per batch.
 3. **Agent tools** — The agent uses `read_file_lines` (inspect source), `search_package_info` (query PyPI/npm/Go registries for dependency metadata), and code context to make decisions.
 4. **Structured output** — Each batch returns JSON with `enriched_components`, `new_components`, `remove_components`, and `risk_findings`. The agent must explicitly confirm or remove every candidate.
-5. **Content-hash caching** — Each component's cache key is derived from its file path, line number, name, type, and surrounding code content. Unchanged components reuse cached LLM results.
+5. **Content-hash caching** — Each component's cache key is derived from its file path, line number, name, type, and surrounding code content. Unchanged components reuse cached LLM results from the shared cache root.
 6. **Circuit breaker** — After N consecutive batch failures, remaining batches are skipped to prevent runaway costs.
 7. **Timeout** — Per-batch wall-clock timeout with graceful degradation.
 

--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-aibom"
-version = "1.0.0rc1"
+version = "1.0.0rc2"
 description = "A tool to generate an AI BOM from source code."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -1363,7 +1363,10 @@ def run_agentic_enrichment(
     if cache_dir is None and resolved_cache_dir is not None:
         fallback_dirs = [p for p in cache_read_dirs("agentic") if p != resolved_cache_dir]
     cache = _AgenticResultCache(resolved_cache_dir, fallback_dirs=fallback_dirs)
-    middleware = AIBOMScannerMiddleware(include_code_snippets=include_code_snippets)
+    middleware = AIBOMScannerMiddleware(
+        include_code_snippets=include_code_snippets,
+        allowed_roots=scan_paths,
+    )
     memo = _DecisionMemo()
 
     all_enriched: list[AIComponent] = []

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -27,11 +27,13 @@ import asyncio
 import json
 import logging
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field, ValidationError
 
+from ..cache_paths import cache_read_dirs, ensure_cache_dir
 from ..models import (
     AIComponent,
     AIComponentType,
@@ -52,9 +54,24 @@ _IID_DESC = (
 )
 
 
+class _EvidenceLocation(BaseModel):
+    file_path: str = ""
+    start_line: int = 0
+    end_line: int = 0
+    role: str = ""
+
+
+class _DecisionAnnotation(BaseModel):
+    decision: str = ""
+    justification: str = ""
+    evidence_kinds: list[str] = Field(default_factory=list)
+    evidence_locations: list[_EvidenceLocation] = Field(default_factory=list)
+
+
 class _EnrichedComponent(BaseModel):
     instance_id: str = Field(default="", description=_IID_DESC)
     updates: dict[str, Any] = Field(default_factory=dict)
+    decision_annotation: _DecisionAnnotation | None = None
 
 
 class _NewComponent(BaseModel):
@@ -65,6 +82,7 @@ class _NewComponent(BaseModel):
     framework: str = ""
     model_name: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    decision_annotation: _DecisionAnnotation | None = None
 
 
 class _RemoveComponent(BaseModel):
@@ -82,6 +100,7 @@ class _Relationship(BaseModel):
     source_name: str = ""
     target_name: str = ""
     relationship_type: str = ""
+    decision_annotation: _DecisionAnnotation | None = None
 
 
 class _RiskFinding(BaseModel):
@@ -90,6 +109,7 @@ class _RiskFinding(BaseModel):
     file_path: str = ""
     line_number: int = 0
     severity: str = "info"
+    decision_annotation: _DecisionAnnotation | None = None
 
 
 class AgentResponse(BaseModel):
@@ -344,12 +364,28 @@ def _component_cache_key(c: AIComponent) -> str:
 
 
 _TIER_CACHE_VERSION = 1
+_BATCH_CACHE_VERSION = 1
+_CROSS_REPO_CACHE_VERSION = 1
+
+
+@dataclass
+class _BatchArtifact:
+    inputs: list[AIComponent]
+    new: list[AIComponent]
+    rels: list[ComponentRelationship]
+    flags: list[RiskFlag]
 
 
 def _tier_cache_key(components: list[AIComponent]) -> str:
     """Derive a cache key for the exact inputs to one tier run."""
     raw = "|".join(_component_cache_key(c) for c in components)
     return f"tier_{_hashlib.sha256(raw.encode()).hexdigest()[:24]}"
+
+
+def _batch_cache_key(components: list[AIComponent]) -> str:
+    """Derive a cache key for one executed batch."""
+    raw = "|".join(_component_cache_key(c) for c in components)
+    return f"batch_{_hashlib.sha256(raw.encode()).hexdigest()[:24]}"
 
 
 def _build_tier_cache_payload(
@@ -379,6 +415,103 @@ def _load_tier_cache_payload(
         [AIComponent.model_validate(item) for item in data.get("tier_new", [])],
         [ComponentRelationship.model_validate(item) for item in data.get("tier_rels", [])],
         [RiskFlag.model_validate(item) for item in data.get("tier_flags", [])],
+    )
+
+
+def _build_batch_cache_payload(
+    new: list[AIComponent],
+    rels: list[ComponentRelationship],
+    flags: list[RiskFlag],
+) -> dict[str, Any]:
+    """Serialize batch-scope findings for mixed cache-hit replay."""
+    return {
+        "_batch_cache_version": _BATCH_CACHE_VERSION,
+        "batch_new": [c.model_dump(mode="json") for c in new],
+        "batch_rels": [r.model_dump(mode="json") for r in rels],
+        "batch_flags": [f.model_dump(mode="json") for f in flags],
+    }
+
+
+def _load_batch_cache_payload(
+    data: dict[str, Any] | None,
+) -> tuple[list[AIComponent], list[ComponentRelationship], list[RiskFlag]] | None:
+    """Deserialize cached batch findings, returning None for non-batch entries."""
+    if not data or data.get("_batch_cache_version") != _BATCH_CACHE_VERSION:
+        return None
+    return (
+        [AIComponent.model_validate(item) for item in data.get("batch_new", [])],
+        [ComponentRelationship.model_validate(item) for item in data.get("batch_rels", [])],
+        [RiskFlag.model_validate(item) for item in data.get("batch_flags", [])],
+    )
+
+
+def _normalized_cross_repo_results(
+    per_repo_results: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    normalized: dict[str, dict[str, Any]] = {}
+    for source in sorted(per_repo_results):
+        data = per_repo_results[source]
+        components: list[dict[str, Any]] = []
+        for component in data.get("components", []):
+            if hasattr(component, "model_dump"):
+                item = component.model_dump(mode="json")
+            else:
+                item = dict(component)
+            components.append(item)
+        components.sort(
+            key=lambda item: (
+                str(item.get("instance_id", "")),
+                str(item.get("name", "")),
+                str(item.get("file_path", "")),
+                int(item.get("line_number", 0) or 0),
+            )
+        )
+        normalized[source] = {
+            "components": components,
+            "_unresolved_env_vars": sorted(
+                str(v) for v in data.get("_unresolved_env_vars", [])
+            ),
+        }
+    return normalized
+
+
+def _cross_repo_cache_key(
+    model_string: str,
+    per_repo_results: dict[str, dict[str, Any]],
+) -> str:
+    raw = json.dumps(
+        {
+            "model_string": model_string,
+            "per_repo_results": _normalized_cross_repo_results(per_repo_results),
+        },
+        sort_keys=True,
+        default=str,
+    )
+    return f"xrepo_{_hashlib.sha256(raw.encode()).hexdigest()[:24]}"
+
+
+def _build_cross_repo_cache_payload(
+    rels: list[ComponentRelationship],
+    flags: list[RiskFlag],
+) -> dict[str, Any]:
+    return {
+        "_cross_repo_cache_version": _CROSS_REPO_CACHE_VERSION,
+        "cross_repo_rels": [r.model_dump(mode="json") for r in rels],
+        "cross_repo_flags": [f.model_dump(mode="json") for f in flags],
+    }
+
+
+def _load_cross_repo_cache_payload(
+    data: dict[str, Any] | None,
+) -> tuple[list[ComponentRelationship], list[RiskFlag]] | None:
+    if not data or data.get("_cross_repo_cache_version") != _CROSS_REPO_CACHE_VERSION:
+        return None
+    return (
+        [
+            ComponentRelationship.model_validate(item)
+            for item in data.get("cross_repo_rels", [])
+        ],
+        [RiskFlag.model_validate(item) for item in data.get("cross_repo_flags", [])],
     )
 
 
@@ -416,20 +549,28 @@ class _AgenticResultCache:
     re-runs skips the LLM entirely.
     """
 
-    def __init__(self, cache_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        cache_dir: Path | None = None,
+        fallback_dirs: list[Path] | None = None,
+    ) -> None:
         self._mem: dict[str, dict[str, Any]] = {}
         self._disk_dir = cache_dir
+        self._fallback_dirs = fallback_dirs or []
         if cache_dir:
             cache_dir.mkdir(parents=True, exist_ok=True)
             self._load_disk()
+        for fallback_dir in self._fallback_dirs:
+            self._load_disk(fallback_dir)
 
-    def _load_disk(self) -> None:
-        if not self._disk_dir:
+    def _load_disk(self, disk_dir: Path | None = None) -> None:
+        target_dir = disk_dir or self._disk_dir
+        if not target_dir:
             return
-        for p in self._disk_dir.glob("*.json"):
+        for p in target_dir.glob("*.json"):
             try:
                 data = json.loads(p.read_text(encoding="utf-8"))
-                self._mem[p.stem] = data
+                self._mem.setdefault(p.stem, data)
             except (json.JSONDecodeError, OSError):
                 continue
 
@@ -470,17 +611,29 @@ class _AgenticResultCache:
         all_new: list[AIComponent] = []
         all_rels: list[ComponentRelationship] = []
         all_flags: list[RiskFlag] = []
+        seen_batch_keys: set[str] = set()
         for c in components:
             key = _component_cache_key(c)
             data = self.get(key)
             if data:
-                new, rels, flags = middleware.extract_findings_from_dict(data)
                 cached_component = _load_cached_component_snapshot(data)
                 if cached_component is not None:
-                    enriched.append(cached_component)
+                    enriched.append(middleware.hydrate_component(cached_component))
                 else:
                     enriched_batch = middleware.apply_enrichments_from_dict([c], data)
                     enriched.extend(enriched_batch)
+
+                batch_key = data.get("batch_artifact_key")
+                batch_payload = None
+                if isinstance(batch_key, str) and batch_key and batch_key not in seen_batch_keys:
+                    seen_batch_keys.add(batch_key)
+                    batch_payload = _load_batch_cache_payload(self.get(batch_key))
+
+                if batch_payload is not None:
+                    new, rels, flags = batch_payload
+                else:
+                    new, rels, flags = middleware.extract_findings_from_dict(data)
+
                 all_new.extend(new)
                 all_rels.extend(rels)
                 all_flags.extend(flags)
@@ -781,7 +934,13 @@ async def _run_batches_parallel(
     *,
     timeout_s: int = _DEFAULT_AGENTIC_TIMEOUT_S,
     max_consecutive_failures: int = _DEFAULT_MAX_CONSECUTIVE_FAILURES,
-) -> tuple[list[AIComponent], list[AIComponent], list[ComponentRelationship], list[RiskFlag]]:
+) -> tuple[
+    list[AIComponent],
+    list[AIComponent],
+    list[ComponentRelationship],
+    list[RiskFlag],
+    list[_BatchArtifact],
+]:
     """Run locality-aware batches with a concurrency-limited semaphore.
 
     Up to *max_concurrent* batches are in-flight simultaneously.  A shared
@@ -795,6 +954,7 @@ async def _run_batches_parallel(
 
     _BatchResult = tuple[
         int,  # idx (1-based)
+        list[AIComponent],  # input batch
         list[AIComponent],
         list[AIComponent],
         list[ComponentRelationship],
@@ -804,10 +964,10 @@ async def _run_batches_parallel(
 
     async def _guarded(idx: int, batch: list[AIComponent]) -> _BatchResult:
         if tripped.is_set():
-            return idx, _circuit_breaker_skipped_batch(batch), [], [], [], True
+            return idx, batch, _circuit_breaker_skipped_batch(batch), [], [], [], True
         async with sem:
             if tripped.is_set():
-                return idx, _circuit_breaker_skipped_batch(batch), [], [], [], True
+                return idx, batch, _circuit_breaker_skipped_batch(batch), [], [], [], True
             try:
                 enriched, new, rels, flags, failed = await _run_batch_async(
                     agent, middleware, batch,
@@ -816,10 +976,10 @@ async def _run_batches_parallel(
                     all_components=all_components,
                     timeout_s=timeout_s,
                 )
-                return idx, enriched, new, rels, flags, failed
+                return idx, batch, enriched, new, rels, flags, failed
             except Exception as exc:
                 _LOGGER.warning("Parallel batch %d raised: %s", idx, exc)
-                return idx, list(batch), [], [], [], True
+                return idx, batch, list(batch), [], [], [], True
 
     tasks = [
         asyncio.create_task(_guarded(idx, batch))
@@ -831,7 +991,7 @@ async def _run_batches_parallel(
     for coro in asyncio.as_completed(tasks):
         r = await coro
         results.append(r)
-        _, _, _, _, _, failed = r
+        _, _, _, _, _, _, failed = r
         if failed:
             consecutive_failures += 1
         else:
@@ -850,21 +1010,21 @@ async def _run_batches_parallel(
     all_new: list[AIComponent] = []
     all_rels: list[ComponentRelationship] = []
     all_flags: list[RiskFlag] = []
-    for _, enriched, new, rels, flags, _ in results:
+    artifacts: list[_BatchArtifact] = []
+    for _, batch, enriched, new, rels, flags, _ in results:
         all_enriched.extend(enriched)
         all_new.extend(new)
         all_rels.extend(rels)
         all_flags.extend(flags)
+        artifacts.append(_BatchArtifact(batch, new, rels, flags))
 
-    return all_enriched, all_new, all_rels, all_flags
+    return all_enriched, all_new, all_rels, all_flags, artifacts
 
 
 def _default_agentic_cache_dir() -> Path | None:
     """Return the default on-disk cache directory, or None if unavailable."""
     try:
-        d = Path.home() / ".cache" / "cisco-aibom" / "agentic"
-        d.mkdir(parents=True, exist_ok=True)
-        return d
+        return ensure_cache_dir("agentic")
     except OSError:
         return None
 
@@ -941,7 +1101,7 @@ def _run_tier(
     )
 
     if max_concurrent > 1 and len(batches) > 1:
-        enriched, new, rels, flags = asyncio.run(
+        enriched, new, rels, flags, batch_artifacts = asyncio.run(
             _run_batches_parallel(
                 agent, middleware, batches,
                 relationships, scan_paths,
@@ -956,6 +1116,7 @@ def _run_tier(
         new: list[AIComponent] = []
         rels: list[ComponentRelationship] = []
         flags: list[RiskFlag] = []
+        batch_artifacts: list[_BatchArtifact] = []
         consecutive_failures = 0
         for idx, batch in enumerate(batches, 1):
             if consecutive_failures >= max_consecutive_failures:
@@ -978,6 +1139,7 @@ def _run_tier(
             new.extend(n)
             rels.extend(r)
             flags.extend(f)
+            batch_artifacts.append(_BatchArtifact(batch, n, r, f))
             if batch_failed:
                 consecutive_failures += 1
             else:
@@ -1031,6 +1193,7 @@ def _run_tier(
             retry_new.extend(n)
             retry_rels.extend(r)
             retry_flags.extend(f)
+            batch_artifacts.append(_BatchArtifact(batch, n, r, f))
             if batch_failed:
                 retry_consecutive += 1
             else:
@@ -1049,20 +1212,38 @@ def _run_tier(
         flags.extend(retry_flags)
 
     if cache:
+        artifact_key_by_instance_id: dict[str, str] = {}
+        for artifact in batch_artifacts:
+            if not (artifact.new or artifact.rels or artifact.flags):
+                continue
+            batch_key = _batch_cache_key(artifact.inputs)
+            cache.put(
+                batch_key,
+                _build_batch_cache_payload(
+                    artifact.new, artifact.rels, artifact.flags
+                ),
+            )
+            for c_in in artifact.inputs:
+                artifact_key_by_instance_id[c_in.instance_id] = batch_key
+
         enriched_by_id = {c.instance_id: c for c in enriched}
         all_batch_components = [c for batch in batches for c in batch]
         for c_before in all_batch_components:
             key = _component_cache_key(c_before)
             c_after = enriched_by_id.get(c_before.instance_id)
             if c_after is None:
-                cache.put(key, {
+                entry: dict[str, Any] = {
                     "enriched_components": [],
                     "new_components": [],
                     "remove_components": [{"instance_id": c_before.instance_id, "reason": "cached_removal"}],
                     "reclassify_components": [],
                     "new_relationships": [],
                     "risk_findings": [],
-                })
+                }
+                batch_key = artifact_key_by_instance_id.get(c_before.instance_id)
+                if batch_key:
+                    entry["batch_artifact_key"] = batch_key
+                cache.put(key, entry)
             else:
                 entry: dict[str, Any] = {
                     "cached_component": c_after.model_dump(mode="json"),
@@ -1073,6 +1254,9 @@ def _run_tier(
                     "new_relationships": [],
                     "risk_findings": [],
                 }
+                batch_key = artifact_key_by_instance_id.get(c_before.instance_id)
+                if batch_key:
+                    entry["batch_artifact_key"] = batch_key
                 cache.put(key, entry)
 
     tier_enriched.extend(enriched)
@@ -1122,6 +1306,7 @@ def run_agentic_enrichment(
     timeout_s: int = _DEFAULT_AGENTIC_TIMEOUT_S,
     max_consecutive_failures: int = _DEFAULT_MAX_CONSECUTIVE_FAILURES,
     cache_dir: Path | None = None,
+    include_code_snippets: bool = False,
 ) -> tuple[list[AIComponent], list[ComponentRelationship], list[RiskFlag]]:
     """Run the full agentic enrichment pipeline.
 
@@ -1173,8 +1358,12 @@ def run_agentic_enrichment(
         max_concurrent,
     )
 
-    cache = _AgenticResultCache(cache_dir if cache_dir is not None else _default_agentic_cache_dir())
-    middleware = AIBOMScannerMiddleware()
+    resolved_cache_dir = cache_dir if cache_dir is not None else _default_agentic_cache_dir()
+    fallback_dirs: list[Path] = []
+    if cache_dir is None and resolved_cache_dir is not None:
+        fallback_dirs = [p for p in cache_read_dirs("agentic") if p != resolved_cache_dir]
+    cache = _AgenticResultCache(resolved_cache_dir, fallback_dirs=fallback_dirs)
+    middleware = AIBOMScannerMiddleware(include_code_snippets=include_code_snippets)
     memo = _DecisionMemo()
 
     all_enriched: list[AIComponent] = []
@@ -1511,6 +1700,7 @@ def run_cross_repo_coordination(
     model_string: str,
     per_repo_results: dict[str, dict[str, Any]],
     llm_config: dict[str, Any] | None = None,
+    cache_dir: Path | None = None,
 ) -> tuple[list[ComponentRelationship], list[RiskFlag]]:
     """Coordinate findings across multiple repos using an LLM.
 
@@ -1524,6 +1714,18 @@ def run_cross_repo_coordination(
     """
     if len(per_repo_results) < 2:
         return [], []
+
+    cache = _AgenticResultCache(
+        cache_dir if cache_dir is not None else _default_agentic_cache_dir()
+    )
+    cache_key = _cross_repo_cache_key(model_string, per_repo_results)
+    cached = _load_cross_repo_cache_payload(cache.get(cache_key))
+    if cached is not None:
+        _LOGGER.info(
+            "Cross-repo coordination cache hit across %d repos",
+            len(per_repo_results),
+        )
+        return cached
 
     scan_paths = list(per_repo_results.keys())
 
@@ -1661,6 +1863,7 @@ def run_cross_repo_coordination(
         "Cross-repo coordination: %d relationships, %d risk flags",
         len(rels), len(flags),
     )
+    cache.put(cache_key, _build_cross_repo_cache_payload(rels, flags))
     return rels, flags
 
 

--- a/aibom/src/aibom/agentic/middleware.py
+++ b/aibom/src/aibom/agentic/middleware.py
@@ -59,8 +59,14 @@ class AIBOMScannerMiddleware:
     that can be merged into the deterministic scan results.
     """
 
-    def __init__(self, *, include_code_snippets: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        include_code_snippets: bool = False,
+        allowed_roots: list[str] | None = None,
+    ) -> None:
         self.include_code_snippets = include_code_snippets
+        self.allowed_roots = allowed_roots or []
 
     def extract_findings(
         self, agent_output: str
@@ -386,8 +392,8 @@ class AIBOMScannerMiddleware:
             return annotation
         return annotation.model_copy(update={"code_snippet": snippet})
 
-    @staticmethod
     def _read_code_snippet(
+        self,
         file_path: str,
         start_line: int,
         end_line: int,
@@ -396,6 +402,16 @@ class AIBOMScannerMiddleware:
     ) -> CodeSnippet | None:
         if not file_path or start_line <= 0:
             return None
+        if self.allowed_roots:
+            try:
+                resolved = Path(file_path).resolve()
+            except OSError:
+                return None
+            if not any(
+                resolved == Path(r).resolve() or Path(r).resolve() in resolved.parents
+                for r in self.allowed_roots
+            ):
+                return None
         path = Path(file_path)
         try:
             lines = path.read_text(encoding="utf-8").splitlines(keepends=True)

--- a/aibom/src/aibom/agentic/middleware.py
+++ b/aibom/src/aibom/agentic/middleware.py
@@ -26,13 +26,17 @@ from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
 from typing import Any
 
 from ..models import (
     AIComponent,
     AIComponentType,
+    CodeSnippet,
     ComponentRelationship,
     DetectionSource,
+    DecisionAnnotation,
+    EvidenceLocation,
     RelationshipType,
     RiskFlag,
     Severity,
@@ -54,6 +58,9 @@ class AIBOMScannerMiddleware:
     message content to obtain components, relationships, and risk flags
     that can be merged into the deterministic scan results.
     """
+
+    def __init__(self, *, include_code_snippets: bool = False) -> None:
+        self.include_code_snippets = include_code_snippets
 
     def extract_findings(
         self, agent_output: str
@@ -84,6 +91,17 @@ class AIBOMScannerMiddleware:
         if data is None:
             return list(existing)
         return self.apply_enrichments_from_dict(existing, data)
+
+    def hydrate_component(self, component: AIComponent) -> AIComponent:
+        """Optionally attach a code snippet to an existing component annotation."""
+        if not self.include_code_snippets or component.decision_annotation is None:
+            return component
+        annotation = self._hydrate_code_snippet(
+            component.decision_annotation,
+            fallback_file_path=component.file_path,
+            fallback_line_number=component.line_number,
+        )
+        return component.model_copy(update={"decision_annotation": annotation})
 
     def apply_enrichments_from_dict(
         self,
@@ -123,10 +141,18 @@ class AIBOMScannerMiddleware:
                 )
 
         updates_by_id: dict[str, dict[str, Any]] = {}
+        annotations_by_id: dict[str, DecisionAnnotation] = {}
         for item in data.get("enriched_components", []):
             iid = item.get("instance_id", "")
             if iid:
                 updates_by_id[iid] = item.get("updates", {})
+                annotation = self._decision_annotation_from_item(
+                    item,
+                    fallback_file_path=item.get("file_path", ""),
+                    fallback_line_number=item.get("line_number", 0),
+                )
+                if annotation is not None:
+                    annotations_by_id[iid] = annotation
 
         existing_ids = {c.instance_id for c in existing}
         unmatched_remove_ids = remove_ids - existing_ids
@@ -170,6 +196,7 @@ class AIBOMScannerMiddleware:
                     )
 
             upd = updates_by_id.get(comp.instance_id)
+            annotation = annotations_by_id.get(comp.instance_id)
             if upd is not None:
                 merged_meta = dict(comp.metadata)
                 merged_meta.update(upd.pop("metadata", {}))
@@ -182,10 +209,14 @@ class AIBOMScannerMiddleware:
                 comp = comp.model_copy(update={
                     **upd,
                     "metadata": merged_meta,
+                    "decision_annotation": annotation,
                     "needs_agentic": False,
                 })
             elif comp.needs_agentic:
-                comp = comp.model_copy(update={"needs_agentic": False})
+                update: dict[str, Any] = {"needs_agentic": False}
+                if annotation is not None:
+                    update["decision_annotation"] = annotation
+                comp = comp.model_copy(update=update)
 
             result.append(comp)
 
@@ -211,8 +242,7 @@ class AIBOMScannerMiddleware:
             )
             return None
 
-    @staticmethod
-    def _extract_new_components(data: dict[str, Any]) -> list[AIComponent]:
+    def _extract_new_components(self, data: dict[str, Any]) -> list[AIComponent]:
         components: list[AIComponent] = []
         for item in data.get("new_components", []):
             try:
@@ -228,6 +258,11 @@ class AIBOMScannerMiddleware:
                     framework=item.get("framework", ""),
                     model_name=item.get("model_name"),
                     detection_source=DetectionSource.AGENTIC,
+                    decision_annotation=self._decision_annotation_from_item(
+                        item,
+                        fallback_file_path=item.get("file_path", ""),
+                        fallback_line_number=item.get("line_number", 0),
+                    ),
                     metadata=item.get("metadata", {}),
                 )
             )
@@ -242,8 +277,7 @@ class AIBOMScannerMiddleware:
         """
         return []
 
-    @staticmethod
-    def _extract_relationships(data: dict[str, Any]) -> list[ComponentRelationship]:
+    def _extract_relationships(self, data: dict[str, Any]) -> list[ComponentRelationship]:
         relationships: list[ComponentRelationship] = []
         for item in data.get("new_relationships", []):
             try:
@@ -257,12 +291,12 @@ class AIBOMScannerMiddleware:
                     source_name=item.get("source_name", ""),
                     target_name=item.get("target_name", ""),
                     relationship_type=rel_type,
+                    decision_annotation=self._decision_annotation_from_item(item),
                 )
             )
         return relationships
 
-    @staticmethod
-    def _extract_risk_flags(data: dict[str, Any]) -> list[RiskFlag]:
+    def _extract_risk_flags(self, data: dict[str, Any]) -> list[RiskFlag]:
         from ..risk import RISK_WEIGHTS
 
         flags: list[RiskFlag] = []
@@ -284,6 +318,99 @@ class AIBOMScannerMiddleware:
                     description=item.get("description", ""),
                     file_path=item.get("file_path", ""),
                     line_number=item.get("line_number", 0),
+                    decision_annotation=self._decision_annotation_from_item(
+                        item,
+                        fallback_file_path=item.get("file_path", ""),
+                        fallback_line_number=item.get("line_number", 0),
+                    ),
                 )
             )
         return flags
+
+    def _decision_annotation_from_item(
+        self,
+        item: dict[str, Any],
+        *,
+        fallback_file_path: str = "",
+        fallback_line_number: int = 0,
+    ) -> DecisionAnnotation | None:
+        raw = item.get("decision_annotation")
+        if not raw:
+            return None
+        try:
+            annotation = DecisionAnnotation.model_validate(raw)
+        except ValueError:
+            _LOGGER.warning("Invalid decision_annotation in agent output: %s", raw)
+            return None
+        if not self.include_code_snippets:
+            return annotation
+        return self._hydrate_code_snippet(
+            annotation,
+            fallback_file_path=fallback_file_path,
+            fallback_line_number=fallback_line_number,
+        )
+
+    def _hydrate_code_snippet(
+        self,
+        annotation: DecisionAnnotation,
+        *,
+        fallback_file_path: str = "",
+        fallback_line_number: int = 0,
+    ) -> DecisionAnnotation:
+        if annotation.code_snippet is not None:
+            return annotation
+
+        location = next(
+            (
+                loc for loc in annotation.evidence_locations
+                if loc.file_path and loc.start_line > 0
+            ),
+            None,
+        )
+        if location is None and fallback_file_path and fallback_line_number > 0:
+            location = EvidenceLocation(
+                file_path=fallback_file_path,
+                start_line=fallback_line_number,
+                end_line=fallback_line_number,
+                role="primary",
+            )
+        if location is None:
+            return annotation
+
+        snippet = self._read_code_snippet(
+            location.file_path,
+            location.start_line,
+            location.end_line or location.start_line,
+        )
+        if snippet is None:
+            return annotation
+        return annotation.model_copy(update={"code_snippet": snippet})
+
+    @staticmethod
+    def _read_code_snippet(
+        file_path: str,
+        start_line: int,
+        end_line: int,
+        *,
+        max_lines: int = 30,
+    ) -> CodeSnippet | None:
+        if not file_path or start_line <= 0:
+            return None
+        path = Path(file_path)
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+        except OSError:
+            return None
+        if not lines or start_line > len(lines):
+            return None
+
+        bounded_end = max(start_line, end_line)
+        excerpt_end = min(bounded_end, start_line + max_lines - 1, len(lines))
+        excerpt = "".join(lines[start_line - 1:excerpt_end])
+        return CodeSnippet(
+            file_path=file_path,
+            start_line=start_line,
+            end_line=excerpt_end,
+            text=excerpt,
+            truncated=bounded_end > excerpt_end,
+        )

--- a/aibom/src/aibom/agentic/prompts.py
+++ b/aibom/src/aibom/agentic/prompts.py
@@ -69,6 +69,9 @@ You receive two lists:
    - Decide: is this a genuine AI component, or a false positive?
    - Verify the `type` is correct — reclassify if the code does something
      different from what the scanner inferred
+   - If confirmed: include an `enriched_components` entry for that exact
+     `instance_id`, even when there are no field updates beyond the
+     `decision_annotation`
    - If confirmed: enrich with concrete identifiers you find in the context
    - If false positive: `remove_components` with reason
    - If wrong type: `reclassify_components` with correct type and reason
@@ -81,6 +84,18 @@ You receive two lists:
    `search_package_info` to fetch registry metadata. Decide if the package
    is genuinely AI/ML related based on its summary, keywords, and
    classifiers. Remove non-AI packages.
+   - REMOVE lockfile or manifest dependencies that are generic infra, DB,
+     telemetry, auth, test, or utility packages even when they appear inside
+     an AI-heavy service. Examples: `requests`, `lodash`,
+     `github.com/google/uuid`.
+   - If `search_package_info` is inconclusive or the package metadata does not
+     clearly show AI/ML semantics, REMOVE the dependency.
+   - REMOVE dependency names that are only version tokens such as
+     `0.18.0`, `3.9.3`, or `0.59b0`. These are malformed detections, not
+     package identifiers.
+   - If the code_context shows a dependency declaration line with both a
+     package key and a quoted version value (for example
+     `fuzzywuzzy = "0.18.0"`), prefer the package identifier from the file context and NEVER keep the version string as the dependency name.
 
 3. **KB match verification**: Components with an `agentic_hint` starting
    with "KB catalog matched" were detected by name-matching against a
@@ -113,11 +128,98 @@ You receive two lists:
 
 7. **Relationship discovery**: Using both lists, identify relationships
    (agent uses model, chain uses tool, service calls embedding, etc.).
+   - Treat replayed/cache-restored findings the same way you would treat
+     fresh reasoning: if the code context still supports a cross-component
+     relationship or risk finding, PRESERVE it.
+   - If replayed or partial-cache results contain relationships or risk
+     findings that conflict with the current code context, reject only the
+     spurious extras. Do NOT silently drop validated cross-component links
+     just because they came from replayed results.
 
 8. **Gap analysis**: If the code_context reveals AI assets NOT present in
    either list, add them to `new_components`.
 
 9. **Output your JSON** — then STOP. Do not continue searching.
+
+## Decision annotation requirements
+
+- Every kept finding in the final output must include a `decision_annotation`.
+- Use concise factual explanation, not chain-of-thought.
+- For kept components:
+  - include `decision_annotation` on every item in `enriched_components`
+- For new components:
+  - include `decision_annotation` on every item in `new_components`
+- For relationships:
+  - include `decision_annotation` on every item in `new_relationships`
+- For risk findings:
+  - include `decision_annotation` on every item in `risk_findings`
+- `decision_annotation` format:
+  - `decision`: one of `confirmed`, `added`, `derived`, `flagged`
+  - `justification`: 1-2 concise sentences explaining why the finding belongs
+    in the final AIBOM
+  - `evidence_kinds`: short list such as `code_context`, `registry_lookup`,
+    `env_resolution`, `tool_result`, `relationship_context`,
+    `cross_repo_context`, or `cache_replay`
+  - `evidence_locations`: list of supporting locations with
+    `file_path`, `start_line`, `end_line`, and `role`
+- Do NOT include raw code text inside `decision_annotation`. Only point to
+  evidence locations. The caller decides whether raw snippets are exposed.
+
+## Decision rule — remove vs reclassify
+
+- Use `remove_components` when the row is not an AI asset at all.
+- Use `reclassify_components` when the row is AI-relevant but typed
+  incorrectly.
+- Do NOT leave a wrong type in `enriched_components` without a matching
+  `reclassify_components` entry.
+
+## Few-shot examples
+
+- **Non-AI dependency**: `requests`, `lodash`, or
+  `github.com/google/uuid` in a manifest/lockfile are generic packages, not
+  AI dependencies, unless package metadata proves otherwise. REMOVE them.
+- **Prompt plumbing**: `load_prompt`, `question`, `all_messages`, `dialog`,
+  and `prompt_data` are helper functions or transient payloads, not prompt
+  assets. REMOVE them unless the code context proves they are named prompt
+  templates or instruction content.
+- **Generic helper kwargs are not prompt assets**: local calls such as
+  `render_prompt(prompt=...)` or `RequestBuilder.create(messages=payload)` are
+  helper/plumbing code, not prompt components. REMOVE them unless the
+  enclosing call clearly resolves to a real AI client or agent framework call.
+- **Non-AI secrets**: `LD_API_KEY`, telemetry DSNs, and generic AWS test
+  keys are not AI secrets. REMOVE them unless the secret authenticates to an
+  AI provider or AI service.
+- **Metric constants are not guardrails**: `GUARDRAIL_INPUT_TOKEN_COUNT` and
+  `PROMPT_TOKEN_COUNT` are counters/metrics, not guardrail implementations.
+  REMOVE them.
+- **Vector DB files are not model artifacts**: `data_level0.bin`,
+  `link_lists.bin`, `header.bin`, and `length.bin` under Chroma/HNSW
+  persistence directories are storage/index files, not model bundles.
+  REMOVE them.
+- **Test-only agent rows**: `FakeAgentRouter`, `TestAgentLoop`, and similar
+  test-only symbols under `tests/` are not production agent assets. REMOVE
+  them unless the same asset also appears in production code.
+- **Wrong endpoint type**: `WEAVIATE_ENDPOINT`, `PINECONE_URL`, and
+  `CHROMA_HOST` typed as `llm_endpoint` are AI-relevant but misclassified.
+  Use `reclassify_components` to `vector_store`, not `remove_components`.
+- **Explicit backend selection beats provider-name hints**: if sibling config
+  sets `VECTOR_DB_TYPE: "chroma"` or another backend selector, do not blindly
+  keep `WEAVIATE_ENDPOINT` or similar provider-named rows as authoritative.
+  Treat the row as ambiguous and keep it only when surrounding config clearly
+  proves that endpoint is the active vector store.
+- **KB method matches are usually operations, not assets**: rows such as
+  `create_store_adapter` or `build_index_client` that came from a KB method
+  match are helper operations. REMOVE them unless the code context shows a
+  concrete store/client instance, endpoint, or persisted asset identifier.
+- **Config env vars are not models**: `CODEX_TIMEOUT`, `RETRY_COUNT`,
+  `BATCH_SIZE`, and `REQUEST_LIMIT` are infrastructure settings, not model
+  assets. REMOVE them unless the resolved value is itself a model or endpoint
+  identifier.
+- **Deployment IDs may need normalization, not invention**: values such as
+  `prod-chat-gpt4o` or `embed-prod-westus` may be real deployment aliases or
+  provider-side resource IDs. Keep the observed identifier unless code
+  context or tool results prove a more canonical mapping. Do not invent a
+  canonical public model name without supporting evidence.
 
 ## Valid asset types
 
@@ -201,6 +303,12 @@ Apply these checks when processing each component by type:
 - **Embedding pipeline ETL**: Classes that copy embedding files between
   environments or path templates for embedding storage are infrastructure.
   Only classes that GENERATE or INVOKE embeddings count.
+- **Embedding helper/template false positives**: Storage paths, file
+  templates, copy jobs, and helper functions are not embedding assets.
+  S3 key templates, archive-path builders, and copy-to-bucket activities
+  should be REMOVED unless the code context proves they instantiate or call
+  a real embedding implementation. A class name alone is not enough to
+  confirm an embedding.
 - **Non-AI endpoints**: URLs for observability (OTEL), network management,
   security orchestration, identity/auth, or any service that is not an AI
   inference provider.
@@ -230,6 +338,19 @@ Return a SINGLE JSON object:
       "updates": {
         "model_name": "<resolved value>",
         "metadata": {"license": "...", "deprecated": false, "model_card_url": "..."}
+      },
+      "decision_annotation": {
+        "decision": "confirmed",
+        "justification": "Why this finding belongs in the final AIBOM.",
+        "evidence_kinds": ["code_context"],
+        "evidence_locations": [
+          {
+            "file_path": "/absolute/path/to/file.py",
+            "start_line": 42,
+            "end_line": 47,
+            "role": "primary"
+          }
+        ]
       }
     }
   ],
@@ -241,7 +362,20 @@ Return a SINGLE JSON object:
       "line_number": 0,
       "framework": "...",
       "model_name": "...",
-      "metadata": {}
+      "metadata": {},
+      "decision_annotation": {
+        "decision": "added",
+        "justification": "Why this missing component should be added.",
+        "evidence_kinds": ["code_context"],
+        "evidence_locations": [
+          {
+            "file_path": "/absolute/path/to/file.py",
+            "start_line": 12,
+            "end_line": 18,
+            "role": "primary"
+          }
+        ]
+      }
     }
   ],
   "remove_components": [
@@ -261,7 +395,20 @@ Return a SINGLE JSON object:
     {
       "source_name": "...",
       "target_name": "...",
-      "relationship_type": "USES_MODEL|USES_TOOL|..."
+      "relationship_type": "USES_MODEL|USES_TOOL|...",
+      "decision_annotation": {
+        "decision": "derived",
+        "justification": "Why this relationship exists in the final AIBOM.",
+        "evidence_kinds": ["relationship_context"],
+        "evidence_locations": [
+          {
+            "file_path": "/absolute/path/to/file.py",
+            "start_line": 55,
+            "end_line": 60,
+            "role": "source"
+          }
+        ]
+      }
     }
   ],
   "risk_findings": [
@@ -270,7 +417,20 @@ Return a SINGLE JSON object:
       "description": "...",
       "file_path": "...",
       "line_number": 0,
-      "severity": "critical|high|medium|low|info"
+      "severity": "critical|high|medium|low|info",
+      "decision_annotation": {
+        "decision": "flagged",
+        "justification": "Why this risk finding should be kept.",
+        "evidence_kinds": ["code_context"],
+        "evidence_locations": [
+          {
+            "file_path": "/absolute/path/to/file.py",
+            "start_line": 88,
+            "end_line": 88,
+            "role": "trigger"
+          }
+        ]
+      }
     }
   ]
 }
@@ -283,13 +443,13 @@ Return a SINGLE JSON object:
 2. Prefer concrete values. If you cannot resolve a reference, say so.
 3. When using search_codebase or resolve_env_var, ONLY pass paths from the
    `scan_paths` field in the input. NEVER search outside those directories.
-5. instance_id values in remove_components, reclassify_components, and
+4. instance_id values in remove_components, reclassify_components, and
    enriched_components MUST be copied VERBATIM from the input. They contain
    underscores, full absolute paths, and line numbers (e.g.
    `MyClass_/Users/dev/project/src/file.py_42`). Do NOT shorten, use colons,
    use relative paths, or drop the line number — mismatched IDs cause silent
    data loss.
-4. After you have finished using tools and are ready to respond:
+5. After you have finished using tools and are ready to respond:
    - Your FINAL message MUST be **valid JSON and nothing else**.
    - Do NOT write any explanation, analysis, summary, or commentary.
    - Do NOT wrap the JSON in markdown fences (no ```json blocks).

--- a/aibom/src/aibom/agentic/tools.py
+++ b/aibom/src/aibom/agentic/tools.py
@@ -31,6 +31,8 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
+from ..cache_paths import cache_read_dirs, ensure_cache_dir
+
 _LOGGER = logging.getLogger(__name__)
 
 import contextvars
@@ -471,9 +473,6 @@ def search_codebase_impl(
 # search_package_info — query package registries for AI relevance
 # ---------------------------------------------------------------------------
 
-_PKG_CACHE_DIR = Path.home() / ".cache" / "cisco-aibom" / "packages"
-
-
 class SearchPackageInfoArgs(BaseModel):
     package_name: str = Field(description="Package name (e.g. 'openai', 'langchain', 'chromadb')")
     ecosystem: str = Field(
@@ -483,21 +482,22 @@ class SearchPackageInfoArgs(BaseModel):
 
 
 def _read_pkg_cache(name: str, ecosystem: str) -> dict[str, Any] | None:
-    cache_file = _PKG_CACHE_DIR / ecosystem / f"{name}.json"
-    if cache_file.exists():
-        try:
-            data = json.loads(cache_file.read_text())
-            age_days = (time.time() - cache_file.stat().st_mtime) / 86400
-            if age_days < 7:
-                data["is_cached"] = True
-                return data
-        except (json.JSONDecodeError, OSError):
-            pass
+    for cache_root in cache_read_dirs("packages"):
+        cache_file = cache_root / ecosystem / f"{name}.json"
+        if cache_file.exists():
+            try:
+                data = json.loads(cache_file.read_text())
+                age_days = (time.time() - cache_file.stat().st_mtime) / 86400
+                if age_days < 7:
+                    data["is_cached"] = True
+                    return data
+            except (json.JSONDecodeError, OSError):
+                pass
     return None
 
 
 def _write_pkg_cache(name: str, ecosystem: str, data: dict[str, Any]) -> None:
-    cache_file = _PKG_CACHE_DIR / ecosystem / f"{name}.json"
+    cache_file = ensure_cache_dir("packages") / ecosystem / f"{name}.json"
     try:
         cache_file.parent.mkdir(parents=True, exist_ok=True)
         cache_file.write_text(json.dumps(data))

--- a/aibom/src/aibom/cache_inspector.py
+++ b/aibom/src/aibom/cache_inspector.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .cache_paths import CacheType, cache_dir, cache_read_dirs, resolve_cache_root
+from .incremental import OrgCache, _repo_bucket_key
+
+
+def _unique_files(directories: list[Path], pattern: str) -> list[Path]:
+    files: list[Path] = []
+    seen: set[str] = set()
+    for directory in directories:
+        if not directory.exists():
+            continue
+        for path in sorted(directory.glob(pattern)):
+            key = str(path.resolve())
+            if key in seen:
+                continue
+            seen.add(key)
+            files.append(path)
+    return files
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _format_size_bytes(size_bytes: int) -> str:
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    return f"{round(size_bytes / 1024, 1)} KB"
+
+
+def _agentic_subtype(payload: dict[str, Any]) -> str:
+    if "_tier_cache_version" in payload:
+        return "tier"
+    if "_batch_cache_version" in payload:
+        return "batch"
+    if "_cross_repo_cache_version" in payload:
+        return "cross_repo"
+    if "cached_component" in payload:
+        return "component"
+    return "unknown"
+
+
+def _scan_entries(cache_root: Path) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for path in _unique_files(cache_read_dirs("scan", cache_root), "*.json"):
+        payload = _load_json(path)
+        if not payload:
+            continue
+        components = payload.get("components", [])
+        relationships = payload.get("relationships", [])
+        flags = payload.get("_agentic_risk_flags", [])
+        entries.append(
+            {
+                "id": payload.get("_cache_key", path.stem),
+                "path": path,
+                "cached_at": payload.get("_cached_at", "unknown"),
+                "subtype": "scan",
+                "size": _format_size_bytes(path.stat().st_size),
+                "detail": (
+                    f"{len(components)} comps, {len(relationships)} rels, "
+                    f"{len(flags)} flags"
+                ),
+                "payload": payload,
+            }
+        )
+    return entries
+
+
+def _agentic_entries(cache_root: Path) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for path in _unique_files(cache_read_dirs("agentic", cache_root), "*.json"):
+        payload = _load_json(path)
+        if not payload:
+            continue
+        subtype = _agentic_subtype(payload)
+        detail = "cached component snapshot"
+        if subtype == "tier":
+            detail = (
+                f"{len(payload.get('tier_enriched', []))} enriched, "
+                f"{len(payload.get('tier_new', []))} new, "
+                f"{len(payload.get('tier_rels', []))} rels, "
+                f"{len(payload.get('tier_flags', []))} flags"
+            )
+        elif subtype == "batch":
+            detail = (
+                f"{len(payload.get('batch_new', []))} new, "
+                f"{len(payload.get('batch_rels', []))} rels, "
+                f"{len(payload.get('batch_flags', []))} flags"
+            )
+        elif subtype == "cross_repo":
+            detail = (
+                f"{len(payload.get('cross_repo_rels', []))} rels, "
+                f"{len(payload.get('cross_repo_flags', []))} flags"
+            )
+        entries.append(
+            {
+                "id": path.stem,
+                "path": path,
+                "cached_at": payload.get("_cached_at", "unknown"),
+                "subtype": subtype,
+                "size": _format_size_bytes(path.stat().st_size),
+                "detail": detail,
+                "payload": payload,
+            }
+        )
+    return entries
+
+
+def _org_entries(cache_root: Path) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    base_dirs = cache_read_dirs("org", cache_root)
+    repo_dirs = _unique_files(base_dirs, "*")
+    for repo_dir in repo_dirs:
+        if not repo_dir.is_dir():
+            continue
+        for path in sorted(repo_dir.glob("*.json")):
+            payload = _load_json(path)
+            if not payload:
+                continue
+            sources = payload.get("sources", [])
+            repo_path = ""
+            if isinstance(sources, list) and sources:
+                repo_path = str(sources[0].get("path", ""))
+            component_count = sum(
+                len(source.get("components", []))
+                for source in sources
+                if isinstance(source, dict)
+            )
+            entries.append(
+                {
+                    "id": f"{repo_path}@{path.stem}" if repo_path else path.stem,
+                    "path": path,
+                    "cached_at": "unknown",
+                    "subtype": "org",
+                    "size": _format_size_bytes(path.stat().st_size),
+                    "detail": f"{len(sources)} sources, {component_count} comps",
+                    "repo_path": repo_path,
+                    "sha": path.stem,
+                    "payload": payload,
+                }
+            )
+    return entries
+
+
+def _model_entries(cache_root: Path) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for path in _unique_files(cache_read_dirs("model", cache_root), "*.json"):
+        payload = _load_json(path)
+        if not payload:
+            continue
+        models = payload.get("models", {})
+        entries.append(
+            {
+                "id": path.name,
+                "path": path,
+                "cached_at": payload.get("_ts", "unknown"),
+                "subtype": "model",
+                "size": _format_size_bytes(path.stat().st_size),
+                "detail": f"{len(models)} models",
+                "payload": payload,
+            }
+        )
+    return entries
+
+
+def _package_entries(cache_root: Path) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for base_dir in cache_read_dirs("packages", cache_root):
+        if not base_dir.exists():
+            continue
+        for ecosystem_dir in sorted(base_dir.iterdir()):
+            if not ecosystem_dir.is_dir():
+                continue
+            for path in sorted(ecosystem_dir.glob("*.json")):
+                payload = _load_json(path)
+                if not payload:
+                    continue
+                entry_id = f"{ecosystem_dir.name}/{path.stem}"
+                entries.append(
+                    {
+                        "id": entry_id,
+                        "path": path,
+                        "cached_at": "unknown",
+                        "subtype": ecosystem_dir.name,
+                        "size": _format_size_bytes(path.stat().st_size),
+                        "detail": payload.get("summary", "") or payload.get("name", ""),
+                        "payload": payload,
+                    }
+                )
+    return entries
+
+
+def list_cache_entries(cache_type: CacheType, cache_root: Path | None = None) -> list[dict[str, Any]]:
+    root = resolve_cache_root(cache_root)
+    if cache_type == "scan":
+        return _scan_entries(root)
+    if cache_type == "agentic":
+        return _agentic_entries(root)
+    if cache_type == "org":
+        return _org_entries(root)
+    if cache_type == "model":
+        return _model_entries(root)
+    if cache_type == "packages":
+        return _package_entries(root)
+    raise ValueError(f"Unsupported cache type: {cache_type}")
+
+
+def _resolve_prefix(entries: list[dict[str, Any]], entry_ref: str) -> dict[str, Any]:
+    exact = [entry for entry in entries if entry["id"] == entry_ref]
+    if exact:
+        return exact[0]
+    matches = [entry for entry in entries if str(entry["id"]).startswith(entry_ref)]
+    if not matches:
+        raise FileNotFoundError(f"No cache entry matches '{entry_ref}'")
+    if len(matches) > 1:
+        raise ValueError(f"Ambiguous cache entry reference '{entry_ref}'")
+    return matches[0]
+
+
+def get_cache_entry(
+    cache_type: CacheType,
+    entry_ref: str,
+    *,
+    cache_root: Path | None = None,
+    sha: str | None = None,
+    model_id: str | None = None,
+) -> dict[str, Any]:
+    root = resolve_cache_root(cache_root)
+
+    if cache_type in {"scan", "agentic", "model", "packages"}:
+        entry = _resolve_prefix(list_cache_entries(cache_type, root), entry_ref)
+        payload = entry["payload"]
+        if cache_type == "model" and model_id:
+            models = payload.get("models", {})
+            if model_id not in models:
+                raise FileNotFoundError(
+                    f"Model id '{model_id}' not present in {entry['id']}"
+                )
+            entry = {
+                **entry,
+                "detail": f"{model_id}: {models[model_id]}",
+                "payload": {model_id: models[model_id]},
+            }
+        return entry
+
+    if cache_type == "org":
+        repo_path = str(Path(entry_ref).expanduser())
+        resolved_sha = sha or OrgCache._get_head_sha(repo_path)
+        if not resolved_sha:
+            raise FileNotFoundError(
+                "Could not resolve a commit SHA for the requested org cache entry"
+            )
+        candidate_dirs = cache_read_dirs("org", root)
+        for base_dir in candidate_dirs:
+            path = base_dir / _repo_bucket_key(repo_path) / f"{resolved_sha}.json"
+            payload = _load_json(path)
+            if payload:
+                sources = payload.get("sources", [])
+                component_count = sum(
+                    len(source.get("components", []))
+                    for source in sources
+                    if isinstance(source, dict)
+                )
+                return {
+                    "id": f"{repo_path}@{resolved_sha}",
+                    "path": path,
+                    "cached_at": "unknown",
+                    "subtype": "org",
+                    "size": _format_size_bytes(path.stat().st_size),
+                    "detail": f"{len(sources)} sources, {component_count} comps",
+                    "repo_path": repo_path,
+                    "sha": resolved_sha,
+                    "payload": payload,
+                }
+        raise FileNotFoundError(
+            f"No org cache entry matches '{repo_path}' at sha '{resolved_sha}'"
+        )
+
+    raise ValueError(f"Unsupported cache type: {cache_type}")

--- a/aibom/src/aibom/cache_paths.py
+++ b/aibom/src/aibom/cache_paths.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from platformdirs import user_cache_dir
+
+CacheType = Literal["scan", "agentic", "org", "model", "packages"]
+
+_CACHE_TYPES: tuple[CacheType, ...] = ("scan", "agentic", "org", "model", "packages")
+
+
+def default_cache_root() -> Path:
+    return Path.home() / ".aibom" / "cache"
+
+
+def resolve_cache_root(root: Path | None = None) -> Path:
+    return (root or default_cache_root()).expanduser()
+
+
+def cache_dir(cache_type: CacheType, root: Path | None = None) -> Path:
+    return resolve_cache_root(root) / cache_type
+
+
+def cache_read_dirs(cache_type: CacheType, root: Path | None = None) -> list[Path]:
+    base_root = resolve_cache_root(root)
+    primary = cache_dir(cache_type, base_root)
+    dirs: list[Path] = [primary]
+
+    if cache_type == "scan":
+        legacy = base_root
+        if legacy != primary:
+            dirs.append(legacy)
+        return dirs
+
+    if root is not None:
+        return dirs
+
+    legacy_map = {
+        "agentic": Path.home() / ".cache" / "cisco-aibom" / "agentic",
+        "org": Path.home() / ".cache" / "cisco-aibom" / "org-cache",
+        "model": Path(user_cache_dir("aibom")) / "model_cache",
+        "packages": Path.home() / ".cache" / "cisco-aibom" / "packages",
+    }
+    legacy = legacy_map.get(cache_type)
+    if legacy and legacy != primary:
+        dirs.append(legacy)
+    return dirs
+
+
+def ensure_cache_dir(cache_type: CacheType, root: Path | None = None) -> Path:
+    directory = cache_dir(cache_type, root)
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def cache_types() -> tuple[CacheType, ...]:
+    return _CACHE_TYPES

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -29,10 +29,16 @@ from typing import Any, Dict, List, Optional
 import typer
 from rich import box
 from rich.console import Console
-
-_LOGGER = logging.getLogger(__name__)
+from rich.markup import escape
 from rich.panel import Panel
-from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
 from rich.syntax import Syntax
 from rich.table import Table
 from rich.tree import Tree
@@ -40,6 +46,13 @@ from rich.tree import Tree
 from .report_sender import post_report_with_retries
 from .utils.version import resolve_package_version
 from .scanners.container_extractor import extract_source_from_image, is_container_image, VALID_TIERS, validate_tier
+from .cache_paths import (
+    cache_dir as resolve_cache_type_dir,
+    cache_read_dirs,
+    cache_types,
+    resolve_cache_root,
+)
+from .llm_factory import ensure_llm_runtime_available
 from .custom_catalog import (
     CustomCatalogConfig,
     load_custom_catalog,
@@ -48,6 +61,8 @@ from .api_handler import start_api_server
 from .reporters import get_reporter, reporter_registry
 from .models.enums import Severity as SeverityEnum
 from .kb.manager import KBManager, KBError
+
+_LOGGER = logging.getLogger(__name__)
 
 console = Console()
 
@@ -122,8 +137,6 @@ def _utcnow_iso() -> str:
 
 
 def _print_timing_table(console: "rich.console.Console", result: "PipelineResult") -> None:  # type: ignore[name-defined]
-    from rich.table import Table
-
     from .scanners import scanner_timings
 
     table = Table(title="Pipeline Timing", show_footer=True)
@@ -152,6 +165,108 @@ def _print_timing_table(console: "rich.console.Console", result: "PipelineResult
             sc_table.add_row(name, f"{elapsed:.2f}s", f"{pct:.1f}%", style=table_style)
 
         console.print(sc_table)
+
+
+def _should_render_progress(progress_enabled: Optional[bool]) -> bool:
+    """Choose whether to show live progress for the current terminal."""
+    if progress_enabled is not None:
+        return progress_enabled
+    return console.is_terminal and not os.environ.get("CI")
+
+
+def _run_pipeline_with_progress(source: str, pipeline: "ScanPipeline", progress_enabled: Optional[bool]) -> "PipelineResult":  # type: ignore[name-defined]
+    """Run a scan pipeline with either a Rich progress display or a spinner."""
+    if not _should_render_progress(progress_enabled):
+        with console.status(f"[cyan]Scanning {source}"):
+            return pipeline.run()
+
+    stage_labels = {
+        "scan": "Stage 1/4: deterministic scanners",
+        "cross_ref": "Stage 2/4: cross-reference resolution",
+        "agentic": "Stage 3/4: agentic enrichment",
+        "assemble": "Stage 4/4: final assembly",
+    }
+
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TaskProgressColumn(),
+        TimeElapsedColumn(),
+        console=console,
+        transient=True,
+    ) as progress_ui:
+        stage_task = progress_ui.add_task(f"{source}: preparing scan", total=4)
+        cache_task = progress_ui.add_task(
+            f"{source}: file cache prep",
+            total=1,
+            completed=0,
+            visible=False,
+        )
+        scanner_task = progress_ui.add_task(
+            f"{source}: deterministic scanners",
+            total=1,
+            completed=0,
+            visible=False,
+        )
+
+        def _on_progress(event: dict[str, Any]) -> None:
+            event_name = str(event.get("event", ""))
+            if event_name == "stage_started":
+                stage = str(event.get("stage", ""))
+                progress_ui.update(
+                    stage_task,
+                    description=f"{source}: {stage_labels.get(stage, stage)}",
+                )
+                return
+            if event_name == "stage_completed":
+                progress_ui.advance(stage_task, 1)
+                return
+            if event_name == "file_cache_prep_started":
+                total = max(int(event.get("files_total", 0) or 0), 1)
+                progress_ui.update(
+                    cache_task,
+                    total=total,
+                    completed=0,
+                    visible=True,
+                    description=f"{source}: file cache prep",
+                )
+                return
+            if event_name == "file_cache_prep_completed":
+                total = max(int(event.get("files_total", 0) or 0), 1)
+                warmed = min(int(event.get("files_warmed", 0) or 0), total)
+                progress_ui.update(
+                    cache_task,
+                    total=total,
+                    completed=warmed,
+                    visible=True,
+                    description=f"{source}: file cache prep",
+                )
+                return
+            if event_name == "scanners_discovered":
+                total = max(int(event.get("total", 0) or 0), 1)
+                progress_ui.update(
+                    scanner_task,
+                    total=total,
+                    completed=0,
+                    visible=True,
+                    description=f"{source}: deterministic scanners",
+                )
+                return
+            if event_name == "scanner_completed":
+                total = max(int(event.get("total", 0) or 0), 1)
+                completed = min(int(event.get("completed", 0) or 0), total)
+                scanner = str(event.get("scanner", "scanner"))
+                progress_ui.update(
+                    scanner_task,
+                    total=total,
+                    completed=completed,
+                    visible=True,
+                    description=f"{source}: scanner {completed}/{total} ({scanner})",
+                )
+
+        pipeline.progress_callback = _on_progress
+        return pipeline.run()
 
 
 def _record_analysis_error(
@@ -208,6 +323,7 @@ def _scan_cache_settings(
     agentic_concurrency: int,
     agentic_fast_model: Optional[str],
     agentic_timeout: int,
+    include_code_snippets: bool,
     container_tier: str,
     custom_catalog: Optional[Path],
 ) -> Dict[str, Any]:
@@ -229,6 +345,7 @@ def _scan_cache_settings(
         "agentic_concurrency": agentic_concurrency,
         "agentic_fast_model": agentic_fast_model,
         "agentic_timeout": agentic_timeout,
+        "include_code_snippets": include_code_snippets,
         "container_tier": container_tier,
         "custom_catalog": _file_cache_fingerprint(custom_catalog),
     }
@@ -405,11 +522,13 @@ def _map_source_kind(kind: Optional[str]) -> str:
 
 def _build_submission_payload(
     report: Dict[str, Any],
-    source_outcomes: Dict[str, Dict[str, Any]],
+    source_outcomes: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Wrap the generated report in the API submission envelope."""
     analysis = report.get("aibom_analysis", {})
     metadata = analysis.get("metadata", {})
+    if not source_outcomes:
+        source_outcomes = _source_outcomes_from_report(report)
 
     source_kinds = {
         _map_source_kind(info.get("source_kind"))
@@ -444,6 +563,61 @@ def _build_submission_payload(
         "sources": sources_payload,
         "report": report,
     }
+
+
+def _source_outcomes_from_report(report: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Reconstruct per-source submission metadata from an on-disk JSON report."""
+    analysis = report.get("aibom_analysis", {})
+    sources = analysis.get("sources", {})
+    outcomes: Dict[str, Dict[str, Any]] = {}
+    for source_key, entry in sources.items():
+        if not isinstance(entry, dict):
+            continue
+        summary = entry.get("summary", {}) if isinstance(entry.get("summary"), dict) else {}
+        source_path = str(entry.get("source_path") or source_key)
+        outcomes[source_path] = {
+            "source_name": str(entry.get("source_name") or source_key),
+            "source_path": source_path,
+            "source_kind": summary.get("source_kind"),
+            "status": summary.get("status"),
+            "last_generated_at": summary.get("last_generated_at"),
+            "assets_discovered": summary.get("assets_discovered"),
+        }
+    return outcomes
+
+
+def _load_report_json_dict(report_file: Path) -> Dict[str, Any]:
+    """Read a report file and ensure it is valid JSON object content."""
+    try:
+        data = json.loads(report_file.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"Failed to read report: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Failed to parse JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("Report JSON must contain an object at the top level")
+    return data
+
+
+def _canonicalize_report_for_upload(report_file: Path) -> tuple[Dict[str, Any], bool]:
+    """Validate a report file and rebuild the canonical upload payload shape."""
+    from pydantic import ValidationError
+
+    from .diff import load_scan_result_json
+    from .reporters.json_reporter import _aibom_payload
+
+    raw_report = _load_report_json_dict(report_file)
+    analysis = raw_report.get("aibom_analysis")
+    if not isinstance(analysis, dict):
+        raise ValueError("Report does not contain an 'aibom_analysis' key")
+
+    legacy_schema = not bool(analysis.get("metadata", {}).get("report_schema_version"))
+    try:
+        scan_result = load_scan_result_json(report_file)
+    except ValidationError as exc:
+        raise ValueError(f"Invalid report structure: {exc}") from exc
+
+    return _aibom_payload(scan_result), legacy_schema
 
 
 def _render_json_report_console(report: Dict[str, Any]) -> None:
@@ -481,21 +655,119 @@ def _render_json_report_console(report: Dict[str, Any]) -> None:
         _render_relationship_table(source_data.get("relationships", []))
 
 
-@app.command("report")
-def report_command(
-    report_file: Path = typer.Argument(..., exists=True, readable=True, dir_okay=False, help="Path to a JSON report file."),
-    raw: bool = typer.Option(False, "--raw-json", help="Display the raw JSON using syntax highlighting before the summary."),
-) -> None:
-    """Render a previously generated JSON report using Rich components."""
-    try:
-        data = json.loads(report_file.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        console.print(f"[red]Failed to parse JSON:[/] {exc}")
-        raise typer.Exit(code=1)
-
+def _show_report_impl(report_file: Path, *, raw: bool = False) -> None:
+    data = _load_report_json_dict(report_file)
     if raw:
         console.print(Syntax(json.dumps(data, indent=2), "json", theme="monokai"))
     _render_json_report_console(data)
+
+
+@app.command("report")
+def report_command(
+    action_or_file: str = typer.Argument(
+        ...,
+        help="Either a report file path, or one of: show, upload.",
+    ),
+    report_file: Optional[Path] = typer.Argument(
+        None,
+        readable=True,
+        dir_okay=False,
+        resolve_path=True,
+        help="Path to the JSON report file when using 'show' or 'upload'.",
+    ),
+    raw: bool = typer.Option(False, "--raw-json", help="Display the raw JSON using syntax highlighting before the summary."),
+    report_format: str = typer.Option(
+        "json",
+        "--format",
+        help="Upload format. Only 'json' is currently supported.",
+    ),
+    post_url: Optional[str] = typer.Option(
+        None,
+        "--post-url",
+        help="HTTP endpoint to POST the JSON report to (can also be set via AIBOM_POST_URL).",
+        envvar="AIBOM_POST_URL",
+    ),
+    ai_defense_api_key: Optional[str] = typer.Option(
+        None,
+        "--ai-defense-api-key",
+        help="API key sent when POSTing the report.",
+        envvar="AI_DEFENSE_API_KEY",
+    ),
+    post_timeout: float = typer.Option(
+        30.0,
+        "--post-timeout",
+        help="Timeout (seconds) for posting the JSON report.",
+        envvar="AIBOM_POST_TIMEOUT",
+    ),
+    post_verify_tls: bool = typer.Option(
+        True,
+        "--post-verify-tls/--no-post-verify-tls",
+        help="Verify TLS certificates when POSTing the report.",
+        envvar="AIBOM_POST_VERIFY_TLS",
+    ),
+) -> None:
+    """Show or upload a previously generated JSON report."""
+    action = action_or_file.lower()
+    if action in {"show", "upload"}:
+        target_report = report_file
+        if target_report is None:
+            console.print(f"[red]Missing report file for 'report {action}'.[/]")
+            raise typer.Exit(code=1)
+    else:
+        if report_file is not None:
+            console.print(
+                "[red]Unexpected extra argument.[/] "
+                "Use 'cisco-aibom report <report.json>' or "
+                "'cisco-aibom report show|upload <report.json>'."
+            )
+            raise typer.Exit(code=1)
+        action = "show"
+        target_report = Path(action_or_file).expanduser()
+
+    if not target_report.exists() or not target_report.is_file():
+        console.print(f"[red]Report file not found:[/] {target_report}")
+        raise typer.Exit(code=1)
+
+    if action == "show":
+        try:
+            _show_report_impl(target_report, raw=raw)
+        except ValueError as exc:
+            console.print(f"[red]{exc}[/]")
+            raise typer.Exit(code=1)
+        return
+
+    if report_format.lower() != "json":
+        console.print(
+            f"[red]Unsupported report upload format:[/] {report_format}. "
+            "Only 'json' is currently supported."
+        )
+        raise typer.Exit(code=1)
+    if not post_url:
+        console.print("[red]--post-url is required for 'report upload'.[/]")
+        raise typer.Exit(code=1)
+
+    try:
+        canonical_report, legacy_schema = _canonicalize_report_for_upload(target_report)
+        if legacy_schema:
+            console.print(
+                "[yellow]Warning:[/] Report uses a deprecated schema without "
+                "`report_schema_version`; synthesizing the current schema for upload."
+            )
+        submission_payload = _build_submission_payload(canonical_report)
+        post_report_with_retries(
+            post_url,
+            submission_payload,
+            api_key=ai_defense_api_key,
+            verify_tls=post_verify_tls,
+            timeout_seconds=post_timeout,
+        )
+        console.print(f"[green]Report uploaded to {post_url}[/]")
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/]")
+        raise typer.Exit(code=1)
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"[red]Failed to POST report:[/] {exc}")
+        raise typer.Exit(code=1)
 
 
 @app.command("analyze")
@@ -642,6 +914,14 @@ def analyze(
         "--timing",
         help="Print a per-stage and per-scanner timing breakdown after analysis.",
     ),
+    progress: Optional[bool] = typer.Option(
+        None,
+        "--progress/--no-progress",
+        help=(
+            "Show live per-stage and per-scanner progress during analysis. "
+            "Defaults to auto when attached to an interactive terminal."
+        ),
+    ),
     agentic_scope: str = typer.Option(
         "all",
         "--agentic-scope",
@@ -675,6 +955,14 @@ def analyze(
         "--agentic-timeout",
         help="Wall-clock timeout (seconds) per agentic LLM batch (default 120).",
     ),
+    include_code_snippets: bool = typer.Option(
+        False,
+        "--include-code-snippets/--no-code-snippets",
+        help=(
+            "Include raw code snippets in per-finding decision annotations. "
+            "Disabled by default to limit report size and source exposure."
+        ),
+    ),
     container_tier: str = typer.Option(
         "auto",
         "--container-extraction-tier",
@@ -688,7 +976,8 @@ def analyze(
         None,
         "--cache-dir",
         help=(
-            "Directory for caching scan results keyed by repo@commit_sha. "
+            "Cache root directory. Scan results are stored under <cache-dir>/scan "
+            "and agentic cache under <cache-dir>/agentic. "
             "Repeated scans of the same codebase at the same revision are instant. "
             "Use 'cisco-aibom cache clear' to purge."
         ),
@@ -775,8 +1064,9 @@ def analyze(
         "--skip-unchanged",
         help=(
             "Skip scanning git repos whose HEAD has not changed since "
-            "the last cached scan.  Cache is stored under "
-            "~/.cache/cisco-aibom/org-cache/."
+            "the last cached scan. Cache is written under "
+            "~/.aibom/cache/org by default and still reads legacy org-cache "
+            "locations for compatibility."
         ),
     ),
     compliance: Optional[str] = typer.Option(
@@ -830,6 +1120,17 @@ def analyze(
             "api_base": llm_api_base,
             "api_version": llm_api_version,
         }
+        try:
+            ensure_llm_runtime_available(
+                llm_model,
+                provider=llm_provider,
+            )
+        except ImportError as exc:
+            console.print(
+                f"[bold red]Error:[/] {escape(str(exc))}",
+                highlight=False,
+            )
+            raise typer.Exit(code=1)
     else:
         console.print(
             "[bold red]Error:[/] --llm-model (or AIBOM_LLM_MODEL env var) is required.\n"
@@ -967,6 +1268,9 @@ def analyze(
     explicit_config: Optional[CustomCatalogConfig] = None
     if custom_catalog:
         explicit_config = load_custom_catalog(Path(custom_catalog))
+    cache_root = resolve_cache_root(cache_dir)
+    scan_cache_dir = resolve_cache_type_dir("scan", cache_root)
+    scan_cache_read_dirs = [p for p in cache_read_dirs("scan", cache_root) if p != scan_cache_dir]
     scan_cache_settings = _scan_cache_settings(
         strict=strict,
         min_severity=severity_filter,
@@ -976,10 +1280,11 @@ def analyze(
         agentic_concurrency=agentic_concurrency,
         agentic_fast_model=agentic_fast_model,
         agentic_timeout=agentic_timeout,
+        include_code_snippets=include_code_snippets,
         container_tier=container_tier,
         custom_catalog=custom_catalog,
     )
-    agentic_cache_dir = cache_dir / "agentic" if cache_dir else None
+    agentic_cache_dir = resolve_cache_type_dir("agentic", cache_root)
 
     clone_managers: list[Any] = []
 
@@ -1080,7 +1385,7 @@ def analyze(
             if cached_sr is not None:
                 console.print(
                     f"[green]Org cache hit[/] for {source} "
-                    f"(~/.cache/cisco-aibom/org-cache)"
+                    f"(~/.aibom/cache/org)"
                 )
                 merged_components: list = []
                 merged_rels: list = []
@@ -1103,11 +1408,15 @@ def analyze(
                 continue
 
         _scan_cache_hit = False
-        if cache_dir:
+        if scan_cache_dir:
             from .scan_cache import cache_key, load_cached, save_cached
 
             _ck = cache_key([scan_path], scan_cache_settings)
-            cached = load_cached(cache_dir, _ck)
+            cached = load_cached(
+                scan_cache_dir,
+                _ck,
+                search_dirs=scan_cache_read_dirs,
+            )
             if cached:
                 _scan_cache_hit = True
                 console.print(f"[green]Cache hit[/] for {source} ({_ck[:12]}…)")
@@ -1130,9 +1439,9 @@ def analyze(
             agentic_fast_model=agentic_fast_model,
             agentic_timeout=agentic_timeout,
             agentic_cache_dir=agentic_cache_dir,
+            include_code_snippets=include_code_snippets,
         )
-        with console.status(f"[cyan]Scanning {source}"):
-            result = pipeline.run()
+        result = _run_pipeline_with_progress(source, pipeline, progress)
 
         if llm_config and result.agentic_risk_flags:
             console.print(
@@ -1177,7 +1486,7 @@ def analyze(
         }
         all_analysis_outputs[source] = output_data
 
-        if cache_dir and not _scan_cache_hit:
+        if scan_cache_dir and not _scan_cache_hit:
             from .scan_cache import cache_key, save_cached
 
             _ck = cache_key([scan_path], scan_cache_settings)
@@ -1191,7 +1500,7 @@ def analyze(
                 ],
                 "_agentic_candidate_count": result.agentic_candidate_count,
             }
-            save_cached(cache_dir, _ck, _serializable)
+            save_cached(scan_cache_dir, _ck, _serializable)
 
         if skip_unchanged and not is_container and (path_to_analyze / ".git").exists():
             from .incremental import OrgCache
@@ -1280,6 +1589,7 @@ def analyze(
         ScanResult,
         SourceResult,
     )
+    from .finding_annotations import annotate_findings
     from .models.scan import RiskFlag
     from .risk import RiskScorer
 
@@ -1294,11 +1604,18 @@ def analyze(
                 V2Relationship.model_validate(r) if isinstance(r, dict) else r
                 for r in output["relationships"]
             ]
+            comps, rels, _ = annotate_findings(
+                comps,
+                rels,
+                [],
+                include_code_snippets=include_code_snippets,
+            )
             v2_sources.append(SourceResult(
                 path=source_path,
                 components=comps,
                 relationships=rels,
             ))
+    run_metadata["source_outcomes"] = source_outcomes
     scan_result = ScanResult(
         metadata=run_metadata,
         sources=v2_sources,
@@ -1315,6 +1632,14 @@ def analyze(
                     scan_result.risk.add_flag(rf)
                 elif isinstance(rf, dict):
                     scan_result.risk.add_flag(RiskFlag.model_validate(rf))
+
+    _, _, annotated_risk_flags = annotate_findings(
+        [],
+        [],
+        scan_result.risk.flags,
+        include_code_snippets=include_code_snippets,
+    )
+    scan_result.risk.flags = annotated_risk_flags
 
     if compliance:
         from .compliance import ComplianceFramework, evaluate_compliance, parse_compliance_cli_value
@@ -1590,16 +1915,16 @@ app.add_typer(kb_app, name="kb")
 # cisco-aibom cache  — manage scan result cache
 # ---------------------------------------------------------------------------
 
-cache_app = typer.Typer(help="Manage the scan result cache.", no_args_is_help=True)
+cache_app = typer.Typer(help="Manage AIBOM cache entries.", no_args_is_help=True)
 app.add_typer(cache_app, name="cache")
 
 
 @cache_app.command("clear")
 def cache_clear(
     cache_dir: Path = typer.Option(
-        Path.home() / ".aibom" / "cache",
+        resolve_cache_root(),
         "--cache-dir",
-        help="Directory where cached scan results are stored.",
+        help="Cache root directory.",
     ),
     include_agentic: bool = typer.Option(
         True,
@@ -1612,44 +1937,173 @@ def cache_clear(
 
     from .scan_cache import clear_cache as _clear
 
-    removed = _clear(cache_dir)
-    console.print(f"[green]Removed {removed} cached scan result(s) from {cache_dir}[/]")
+    cache_root = resolve_cache_root(cache_dir)
+    removed = 0
+    seen_dirs: set[str] = set()
+    for directory in cache_read_dirs("scan", cache_root):
+        key = str(directory)
+        if key in seen_dirs:
+            continue
+        seen_dirs.add(key)
+        removed += _clear(directory)
+    console.print(
+        f"[green]Removed {removed} cached scan result(s) from {cache_root}[/]"
+    )
 
     if include_agentic:
-        agentic_dir = Path.home() / ".cache" / "cisco-aibom" / "agentic"
-        if agentic_dir.exists():
-            count = sum(1 for _ in agentic_dir.glob("*.json"))
-            shutil.rmtree(agentic_dir)
-            console.print(f"[green]Removed {count} agentic cache file(s) from {agentic_dir}[/]")
+        count = 0
+        for agentic_dir in cache_read_dirs("agentic", cache_root):
+            if agentic_dir.exists():
+                count += sum(1 for _ in agentic_dir.glob("*.json"))
+                shutil.rmtree(agentic_dir)
+        if count:
+            console.print(
+                f"[green]Removed {count} agentic cache file(s) from {cache_root}[/]"
+            )
         else:
             console.print("[dim]No agentic cache to clear.[/]")
 
 
 @cache_app.command("list")
 def cache_list(
+    cache_type: str = typer.Option(
+        "scan",
+        "--type",
+        help="Cache family: scan, agentic, org, model, packages.",
+    ),
     cache_dir: Path = typer.Option(
-        Path.home() / ".aibom" / "cache",
+        resolve_cache_root(),
         "--cache-dir",
-        help="Directory where cached scan results are stored.",
+        help="Cache root directory.",
     ),
 ) -> None:
-    """List all cached scan results."""
+    """List cached entries for one cache family."""
     from rich.table import Table
 
-    from .scan_cache import cache_info
+    from .cache_inspector import list_cache_entries
 
-    entries = cache_info(cache_dir)
+    if cache_type not in cache_types():
+        console.print(
+            f"[red]Unsupported cache type:[/] {cache_type}. "
+            f"Use one of: {', '.join(cache_types())}."
+        )
+        raise typer.Exit(code=1)
+
+    entries = list_cache_entries(cache_type, cache_dir)
     if not entries:
-        console.print("[dim]No cached scan results found.[/]")
+        console.print(f"[dim]No cached {cache_type} entries found.[/]")
         return
 
-    table = Table(title=f"Scan Cache ({cache_dir})")
-    table.add_column("Key")
+    table = Table(title=f"{cache_type.title()} Cache ({resolve_cache_root(cache_dir)})")
+    table.add_column("Entry", no_wrap=True)
+    table.add_column("Subtype")
     table.add_column("Cached At")
     table.add_column("Size", justify="right")
+    table.add_column("Detail")
     for e in entries:
-        table.add_row(e["key"][:16] + "…", e["cached_at"], f"{e['size_kb']} KB")
+        table.add_row(
+            str(e["id"]),
+            str(e.get("subtype", "")),
+            str(e.get("cached_at", "unknown")),
+            str(e.get("size", "")),
+            str(e.get("detail", "")),
+        )
     console.print(table)
+
+
+@cache_app.command("get")
+def cache_get(
+    cache_type: str = typer.Argument(..., help="Cache family to inspect."),
+    entry_ref: str = typer.Argument(..., help="Entry id, prefix, or logical reference."),
+    cache_dir: Path = typer.Option(
+        resolve_cache_root(),
+        "--cache-dir",
+        help="Cache root directory.",
+    ),
+    sha: Optional[str] = typer.Option(
+        None,
+        "--sha",
+        help="Commit SHA for org cache lookups.",
+    ),
+    model_id: Optional[str] = typer.Option(
+        None,
+        "--model-id",
+        help="Optional model id filter for model cache lookups.",
+    ),
+    raw_json: bool = typer.Option(
+        False,
+        "--raw-json",
+        help="Print the raw cache payload instead of a summary.",
+    ),
+) -> None:
+    """Inspect a specific cache entry by type."""
+    from .cache_inspector import get_cache_entry
+
+    if cache_type not in cache_types():
+        console.print(
+            f"[red]Unsupported cache type:[/] {cache_type}. "
+            f"Use one of: {', '.join(cache_types())}."
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        entry = get_cache_entry(
+            cache_type,
+            entry_ref,
+            cache_root=cache_dir,
+            sha=sha,
+            model_id=model_id,
+        )
+    except FileNotFoundError as exc:
+        console.print(f"[red]{exc}[/]")
+        raise typer.Exit(code=1)
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/]")
+        raise typer.Exit(code=1)
+
+    if raw_json:
+        console.print(Syntax(json.dumps(entry["payload"], indent=2), "json", theme="monokai"))
+        return
+
+    summary = Table(title=f"{cache_type.title()} Cache Entry", box=box.SIMPLE_HEAVY)
+    summary.add_column("Field")
+    summary.add_column("Value")
+    summary.add_row("Entry", str(entry["id"]))
+    summary.add_row("Subtype", str(entry.get("subtype", "")))
+    summary.add_row("Path", str(entry.get("path", "")))
+    summary.add_row("Cached At", str(entry.get("cached_at", "unknown")))
+    summary.add_row("Size", str(entry.get("size", "")))
+    summary.add_row("Detail", str(entry.get("detail", "")))
+    if entry.get("repo_path"):
+        summary.add_row("Repo Path", str(entry["repo_path"]))
+    if entry.get("sha"):
+        summary.add_row("SHA", str(entry["sha"]))
+    console.print(summary)
+    if entry.get("repo_path"):
+        console.print(f"[cyan]Repo Path:[/] {entry['repo_path']}", soft_wrap=True)
+    if entry.get("sha"):
+        console.print(f"[cyan]SHA:[/] {entry['sha']}", soft_wrap=True)
+
+    payload = entry["payload"]
+    if cache_type == "scan":
+        component_names = [
+            str(item.get("name"))
+            for item in payload.get("components", [])
+            if isinstance(item, dict) and item.get("name")
+        ]
+        if component_names:
+            console.print(
+                f"[cyan]Components:[/] {', '.join(component_names[:10])}"
+            )
+    elif cache_type == "model":
+        models = payload.get("models", payload)
+        if isinstance(models, dict) and models:
+            console.print(
+                f"[cyan]Models:[/] {', '.join(list(models.keys())[:10])}"
+            )
+    elif cache_type == "packages":
+        if payload.get("summary"):
+            console.print(f"[cyan]Summary:[/] {payload['summary']}")
 
 
 # ---------------------------------------------------------------------------

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -1609,6 +1609,7 @@ def analyze(
                 rels,
                 [],
                 include_code_snippets=include_code_snippets,
+                allowed_roots=[source_path],
             )
             v2_sources.append(SourceResult(
                 path=source_path,
@@ -1638,6 +1639,7 @@ def analyze(
         [],
         scan_result.risk.flags,
         include_code_snippets=include_code_snippets,
+        allowed_roots=list(all_analysis_outputs.keys()),
     )
     scan_result.risk.flags = annotated_risk_flags
 

--- a/aibom/src/aibom/diff.py
+++ b/aibom/src/aibom/diff.py
@@ -124,9 +124,22 @@ def load_scan_result_json(path: Path | str) -> ScanResult:
     data = json.loads(raw)
     if "aibom_analysis" in data:
         data = data["aibom_analysis"]
+    metadata = dict(data.get("metadata", {}))
     sources_raw: dict[str, Any] = data.get("sources", {})
     sources: list[SourceResult] = []
+    source_details: dict[str, Any] = {}
     for path_s, src in sources_raw.items():
+        source_path = str(src.get("source_path") or path_s)
+        summary = src.get("summary", {}) if isinstance(src, dict) else {}
+        source_details[source_path] = {
+            "source_key": path_s,
+            "source_name": src.get("source_name") or path_s,
+            "source_path": source_path,
+            "source_kind": summary.get("source_kind"),
+            "status": summary.get("status"),
+            "last_generated_at": summary.get("last_generated_at"),
+            "assets_discovered": summary.get("assets_discovered"),
+        }
         raw_comps = src.get("components", [])
         flat: list[AIComponent] = []
         if isinstance(raw_comps, dict):
@@ -137,11 +150,13 @@ def load_scan_result_json(path: Path | str) -> ScanResult:
             for item in raw_comps:
                 flat.append(AIComponent.model_validate(item))
         rels = [ComponentRelationship.model_validate(r) for r in src.get("relationships", [])]
-        sources.append(SourceResult(path=path_s, components=flat, relationships=rels))
+        sources.append(SourceResult(path=source_path, components=flat, relationships=rels))
     risk_data = data.get("risk", {})
     risk = RiskScore.model_validate(risk_data) if risk_data else RiskScore()
+    if source_details:
+        metadata["_report_source_details"] = source_details
     return ScanResult(
-        metadata=data.get("metadata", {}),
+        metadata=metadata,
         sources=sources,
         risk=risk,
         errors=list(data.get("errors", [])),

--- a/aibom/src/aibom/finding_annotations.py
+++ b/aibom/src/aibom/finding_annotations.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .models import (
+    AIComponent,
+    CodeSnippet,
+    ComponentRelationship,
+    DecisionAnnotation,
+    EvidenceLocation,
+)
+from .models.scan import RiskFlag
+
+
+def _evidence_location(
+    file_path: str,
+    line_number: int,
+    *,
+    role: str,
+) -> EvidenceLocation | None:
+    if not file_path:
+        return None
+    start_line = max(line_number or 1, 1)
+    end_line = start_line
+    return EvidenceLocation(
+        file_path=file_path,
+        start_line=start_line,
+        end_line=end_line,
+        role=role,
+    )
+
+
+def _read_code_snippet(location: EvidenceLocation | None) -> CodeSnippet | None:
+    if location is None or not location.file_path:
+        return None
+    try:
+        lines = Path(location.file_path).read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+
+    start_line = max(location.start_line, 1)
+    end_line = max(location.end_line, start_line)
+    if start_line > len(lines):
+        return None
+
+    excerpt_end = min(end_line, start_line + 4, len(lines))
+    excerpt = lines[start_line - 1:excerpt_end]
+    if not excerpt:
+        return None
+
+    return CodeSnippet(
+        file_path=location.file_path,
+        start_line=start_line,
+        end_line=start_line + len(excerpt) - 1,
+        text="\n".join(excerpt) + "\n",
+        truncated=excerpt_end < end_line or excerpt_end < len(lines),
+    )
+
+
+def _hydrate_annotation(
+    annotation: DecisionAnnotation,
+    *,
+    include_code_snippets: bool,
+    snippet_location: EvidenceLocation | None,
+) -> DecisionAnnotation:
+    if not include_code_snippets or annotation.code_snippet is not None:
+        return annotation
+    snippet = _read_code_snippet(snippet_location)
+    if snippet is None:
+        return annotation
+    return annotation.model_copy(update={"code_snippet": snippet})
+
+
+def _component_annotation(
+    component: AIComponent,
+    *,
+    include_code_snippets: bool,
+) -> DecisionAnnotation:
+    primary_location = _evidence_location(
+        component.file_path,
+        component.line_number,
+        role="primary",
+    )
+    if component.decision_annotation is not None:
+        return _hydrate_annotation(
+            component.decision_annotation,
+            include_code_snippets=include_code_snippets,
+            snippet_location=primary_location,
+        )
+
+    evidence_locations = [primary_location] if primary_location is not None else []
+    annotation = DecisionAnnotation(
+        decision="confirmed",
+        justification=(
+            f"Kept in the final AIBOM because the scan identified "
+            f"{component.component_type.value.replace('_', ' ')} '{component.name}'."
+        ),
+        evidence_kinds=["code_context"] if evidence_locations else ["scan_result"],
+        evidence_locations=evidence_locations,
+    )
+    return _hydrate_annotation(
+        annotation,
+        include_code_snippets=include_code_snippets,
+        snippet_location=primary_location,
+    )
+
+
+def _relationship_annotation(
+    relationship: ComponentRelationship,
+    *,
+    component_by_id: dict[str, AIComponent],
+    include_code_snippets: bool,
+) -> DecisionAnnotation:
+    source = component_by_id.get(relationship.source_instance_id)
+    target = component_by_id.get(relationship.target_instance_id)
+    evidence_locations = [
+        location
+        for location in [
+            _evidence_location(
+                source.file_path if source else "",
+                source.line_number if source else 0,
+                role="source",
+            ),
+            _evidence_location(
+                target.file_path if target else "",
+                target.line_number if target else 0,
+                role="target",
+            ),
+        ]
+        if location is not None
+    ]
+    primary_location = evidence_locations[0] if evidence_locations else None
+    if relationship.decision_annotation is not None:
+        return _hydrate_annotation(
+            relationship.decision_annotation,
+            include_code_snippets=include_code_snippets,
+            snippet_location=primary_location,
+        )
+
+    source_label = relationship.source_name or relationship.source_instance_id or "source"
+    target_label = relationship.target_name or relationship.target_instance_id or "target"
+    annotation = DecisionAnnotation(
+        decision="derived",
+        justification=(
+            f"Kept in the final AIBOM because the scan linked "
+            f"{source_label} to {target_label} via "
+            f"{relationship.relationship_type.value.replace('_', ' ').lower()}."
+        ),
+        evidence_kinds=["relationship_context"],
+        evidence_locations=evidence_locations,
+    )
+    return _hydrate_annotation(
+        annotation,
+        include_code_snippets=include_code_snippets,
+        snippet_location=primary_location,
+    )
+
+
+def _risk_annotation(
+    flag: RiskFlag,
+    *,
+    include_code_snippets: bool,
+) -> DecisionAnnotation:
+    primary_location = _evidence_location(
+        flag.file_path,
+        flag.line_number,
+        role="primary",
+    )
+    if flag.decision_annotation is not None:
+        return _hydrate_annotation(
+            flag.decision_annotation,
+            include_code_snippets=include_code_snippets,
+            snippet_location=primary_location,
+        )
+
+    evidence_locations = [primary_location] if primary_location is not None else []
+    annotation = DecisionAnnotation(
+        decision="flagged",
+        justification=flag.description or f"Flagged because the {flag.flag} rule matched.",
+        evidence_kinds=["code_context"] if evidence_locations else ["risk_rule"],
+        evidence_locations=evidence_locations,
+    )
+    return _hydrate_annotation(
+        annotation,
+        include_code_snippets=include_code_snippets,
+        snippet_location=primary_location,
+    )
+
+
+def annotate_findings(
+    components: list[AIComponent],
+    relationships: list[ComponentRelationship],
+    risk_flags: list[RiskFlag],
+    *,
+    include_code_snippets: bool = False,
+) -> tuple[list[AIComponent], list[ComponentRelationship], list[RiskFlag]]:
+    """Ensure every final finding carries a decision annotation."""
+    annotated_components = [
+        component.model_copy(
+            update={
+                "decision_annotation": _component_annotation(
+                    component,
+                    include_code_snippets=include_code_snippets,
+                )
+            }
+        )
+        for component in components
+    ]
+    component_by_id = {component.instance_id: component for component in annotated_components}
+    annotated_relationships = [
+        relationship.model_copy(
+            update={
+                "decision_annotation": _relationship_annotation(
+                    relationship,
+                    component_by_id=component_by_id,
+                    include_code_snippets=include_code_snippets,
+                )
+            }
+        )
+        for relationship in relationships
+    ]
+    annotated_risk_flags = [
+        flag.model_copy(
+            update={
+                "decision_annotation": _risk_annotation(
+                    flag,
+                    include_code_snippets=include_code_snippets,
+                )
+            }
+        )
+        for flag in risk_flags
+    ]
+    return annotated_components, annotated_relationships, annotated_risk_flags

--- a/aibom/src/aibom/finding_annotations.py
+++ b/aibom/src/aibom/finding_annotations.py
@@ -30,8 +30,28 @@ def _evidence_location(
     )
 
 
-def _read_code_snippet(location: EvidenceLocation | None) -> CodeSnippet | None:
+def _is_within_roots(file_path: str, allowed_roots: list[str]) -> bool:
+    """Return True only if *file_path* resolves inside one of *allowed_roots*."""
+    if not allowed_roots:
+        return False
+    try:
+        resolved = Path(file_path).resolve()
+    except OSError:
+        return False
+    return any(
+        resolved == Path(root).resolve() or Path(root).resolve() in resolved.parents
+        for root in allowed_roots
+    )
+
+
+def _read_code_snippet(
+    location: EvidenceLocation | None,
+    *,
+    allowed_roots: list[str] | None = None,
+) -> CodeSnippet | None:
     if location is None or not location.file_path:
+        return None
+    if allowed_roots is not None and not _is_within_roots(location.file_path, allowed_roots):
         return None
     try:
         lines = Path(location.file_path).read_text(encoding="utf-8").splitlines()
@@ -62,10 +82,11 @@ def _hydrate_annotation(
     *,
     include_code_snippets: bool,
     snippet_location: EvidenceLocation | None,
+    allowed_roots: list[str] | None = None,
 ) -> DecisionAnnotation:
     if not include_code_snippets or annotation.code_snippet is not None:
         return annotation
-    snippet = _read_code_snippet(snippet_location)
+    snippet = _read_code_snippet(snippet_location, allowed_roots=allowed_roots)
     if snippet is None:
         return annotation
     return annotation.model_copy(update={"code_snippet": snippet})
@@ -75,6 +96,7 @@ def _component_annotation(
     component: AIComponent,
     *,
     include_code_snippets: bool,
+    allowed_roots: list[str] | None = None,
 ) -> DecisionAnnotation:
     primary_location = _evidence_location(
         component.file_path,
@@ -86,6 +108,7 @@ def _component_annotation(
             component.decision_annotation,
             include_code_snippets=include_code_snippets,
             snippet_location=primary_location,
+            allowed_roots=allowed_roots,
         )
 
     evidence_locations = [primary_location] if primary_location is not None else []
@@ -102,6 +125,7 @@ def _component_annotation(
         annotation,
         include_code_snippets=include_code_snippets,
         snippet_location=primary_location,
+        allowed_roots=allowed_roots,
     )
 
 
@@ -110,6 +134,7 @@ def _relationship_annotation(
     *,
     component_by_id: dict[str, AIComponent],
     include_code_snippets: bool,
+    allowed_roots: list[str] | None = None,
 ) -> DecisionAnnotation:
     source = component_by_id.get(relationship.source_instance_id)
     target = component_by_id.get(relationship.target_instance_id)
@@ -135,6 +160,7 @@ def _relationship_annotation(
             relationship.decision_annotation,
             include_code_snippets=include_code_snippets,
             snippet_location=primary_location,
+            allowed_roots=allowed_roots,
         )
 
     source_label = relationship.source_name or relationship.source_instance_id or "source"
@@ -153,6 +179,7 @@ def _relationship_annotation(
         annotation,
         include_code_snippets=include_code_snippets,
         snippet_location=primary_location,
+        allowed_roots=allowed_roots,
     )
 
 
@@ -160,6 +187,7 @@ def _risk_annotation(
     flag: RiskFlag,
     *,
     include_code_snippets: bool,
+    allowed_roots: list[str] | None = None,
 ) -> DecisionAnnotation:
     primary_location = _evidence_location(
         flag.file_path,
@@ -171,6 +199,7 @@ def _risk_annotation(
             flag.decision_annotation,
             include_code_snippets=include_code_snippets,
             snippet_location=primary_location,
+            allowed_roots=allowed_roots,
         )
 
     evidence_locations = [primary_location] if primary_location is not None else []
@@ -184,6 +213,7 @@ def _risk_annotation(
         annotation,
         include_code_snippets=include_code_snippets,
         snippet_location=primary_location,
+        allowed_roots=allowed_roots,
     )
 
 
@@ -193,6 +223,7 @@ def annotate_findings(
     risk_flags: list[RiskFlag],
     *,
     include_code_snippets: bool = False,
+    allowed_roots: list[str] | None = None,
 ) -> tuple[list[AIComponent], list[ComponentRelationship], list[RiskFlag]]:
     """Ensure every final finding carries a decision annotation."""
     annotated_components = [
@@ -201,6 +232,7 @@ def annotate_findings(
                 "decision_annotation": _component_annotation(
                     component,
                     include_code_snippets=include_code_snippets,
+                    allowed_roots=allowed_roots,
                 )
             }
         )
@@ -214,6 +246,7 @@ def annotate_findings(
                     relationship,
                     component_by_id=component_by_id,
                     include_code_snippets=include_code_snippets,
+                    allowed_roots=allowed_roots,
                 )
             }
         )
@@ -225,6 +258,7 @@ def annotate_findings(
                 "decision_annotation": _risk_annotation(
                     flag,
                     include_code_snippets=include_code_snippets,
+                    allowed_roots=allowed_roots,
                 )
             }
         )

--- a/aibom/src/aibom/incremental.py
+++ b/aibom/src/aibom/incremental.py
@@ -84,7 +84,7 @@ class OrgCache:
                 raw = json.loads(cache_file.read_text(encoding="utf-8"))
                 return ScanResult.model_validate(raw)
             except (json.JSONDecodeError, OSError, ValueError):
-                return None
+                continue
         return None
 
     def store(self, repo_path: str, result: ScanResult) -> None:

--- a/aibom/src/aibom/incremental.py
+++ b/aibom/src/aibom/incremental.py
@@ -23,6 +23,7 @@ import subprocess
 from pathlib import Path
 from typing import Callable, Optional
 
+from .cache_paths import cache_read_dirs, ensure_cache_dir
 from .models import ScanResult
 
 
@@ -40,12 +41,18 @@ def _repo_bucket_key(repo_path: str) -> str:
 
 class OrgCache:
     def __init__(self, base_dir: Optional[Path] = None) -> None:
-        self.base_dir = base_dir or (Path.home() / ".cache" / "cisco-aibom" / "org-cache")
-        self.base_dir.mkdir(parents=True, exist_ok=True)
+        if base_dir is None:
+            read_dirs = cache_read_dirs("org")
+            self.base_dir = ensure_cache_dir("org")
+            self.fallback_dirs = [p for p in read_dirs if p != self.base_dir]
+        else:
+            self.base_dir = base_dir
+            self.base_dir.mkdir(parents=True, exist_ok=True)
+            self.fallback_dirs = []
 
-    def _repo_dir(self, repo_path: str) -> Path:
+    def _repo_dir(self, repo_path: str, base_dir: Optional[Path] = None) -> Path:
         key = _repo_bucket_key(repo_path)
-        return self.base_dir / key
+        return (base_dir or self.base_dir) / key
 
     @staticmethod
     def _get_head_sha(repo_path: str) -> Optional[str]:
@@ -68,14 +75,17 @@ class OrgCache:
         sha = self._get_head_sha(repo_path)
         if not sha:
             return None
-        cache_file = self._repo_dir(repo_path) / f"{sha}.json"
-        if not cache_file.is_file():
-            return None
-        try:
-            raw = json.loads(cache_file.read_text(encoding="utf-8"))
-            return ScanResult.model_validate(raw)
-        except (json.JSONDecodeError, OSError, ValueError):
-            return None
+        candidate_dirs = [self.base_dir, *self.fallback_dirs]
+        for base_dir in candidate_dirs:
+            cache_file = self._repo_dir(repo_path, base_dir) / f"{sha}.json"
+            if not cache_file.is_file():
+                continue
+            try:
+                raw = json.loads(cache_file.read_text(encoding="utf-8"))
+                return ScanResult.model_validate(raw)
+            except (json.JSONDecodeError, OSError, ValueError):
+                return None
+        return None
 
     def store(self, repo_path: str, result: ScanResult) -> None:
         sha = self._get_head_sha(repo_path)

--- a/aibom/src/aibom/llm_factory.py
+++ b/aibom/src/aibom/llm_factory.py
@@ -21,6 +21,7 @@ Every code path that needs a ``BaseChatModel`` should call
 """
 from __future__ import annotations
 
+import importlib
 import logging
 from typing import Any
 
@@ -30,6 +31,53 @@ try:
     from langchain.chat_models import init_chat_model
 except ImportError:
     init_chat_model = None  # agentic extras not installed
+
+_PROVIDER_IMPORT_HINTS: dict[str, tuple[str, str]] = {
+    "openai": ("langchain_openai", 'cisco-aibom[agentic,llm-openai]'),
+    "azure_openai": ("langchain_openai", 'cisco-aibom[agentic,llm-openai]'),
+    "bedrock": ("langchain_aws", 'cisco-aibom[agentic,llm-aws]'),
+}
+
+
+def resolve_provider(model_string: str, provider: str | None = None) -> str | None:
+    """Resolve the effective model provider from explicit or legacy syntax."""
+    if provider:
+        return provider
+    if "/" in model_string:
+        resolved_provider, _, _ = model_string.partition("/")
+        return resolved_provider or None
+    return None
+
+
+def ensure_llm_runtime_available(
+    model_string: str,
+    *,
+    provider: str | None = None,
+) -> str | None:
+    """Fail fast when the required agentic or provider extras are missing."""
+    if init_chat_model is None:
+        raise ImportError(
+            "LLM-assisted analysis requires the agentic extras. "
+            'Install with: uv tool install "cisco-aibom[agentic]"'
+        )
+
+    resolved_provider = resolve_provider(model_string, provider)
+    if not resolved_provider:
+        return None
+
+    provider_hint = _PROVIDER_IMPORT_HINTS.get(resolved_provider)
+    if not provider_hint:
+        return resolved_provider
+
+    module_name, install_target = provider_hint
+    try:
+        importlib.import_module(module_name)
+    except ImportError as exc:
+        raise ImportError(
+            f"LLM provider '{resolved_provider}' requires additional runtime support. "
+            f'Install with: uv tool install "{install_target}"'
+        ) from exc
+    return resolved_provider
 
 
 def build_chat_model(
@@ -71,19 +119,18 @@ def build_chat_model(
     rate_limiter:
         Optional ``langchain_core.rate_limiters.BaseRateLimiter``.
     """
-    if init_chat_model is None:
-        raise ImportError(
-            "langchain is required for LLM features. "
-            "Install with: uv pip install 'cisco-aibom[agentic]'"
-        )
+    resolved_provider = ensure_llm_runtime_available(
+        model_string,
+        provider=provider,
+    )
 
     init_kwargs: dict[str, Any] = {}
 
     model_id = model_string
-    resolved_provider = provider
-
-    if not resolved_provider and "/" in model_string:
-        resolved_provider, _, model_id = model_string.partition("/")
+    if "/" in model_string:
+        inferred_provider, _, legacy_model_id = model_string.partition("/")
+        if not provider or provider == inferred_provider:
+            model_id = legacy_model_id
 
     if resolved_provider:
         init_kwargs["model_provider"] = resolved_provider

--- a/aibom/src/aibom/manifest.json
+++ b/aibom/src/aibom/manifest.json
@@ -1,8 +1,8 @@
 {
-  "analyzer_version": "1.0.0rc1",
-  "schema_version": "1.0.0rc1",
+  "analyzer_version": "1.0.0rc2",
+  "schema_version": "1.0.0rc2",
   "duckdb_sha256": "b1165384a646094aa6a4762d676f285c1c68b6d7f9367c90a129b529904a3268",
-  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.0rc1.duckdb",
+  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.0rc2.duckdb",
   "upload_mode": "direct",
   "max_direct_upload_mb": 25,
   "log_level": "INFO"

--- a/aibom/src/aibom/models/__init__.py
+++ b/aibom/src/aibom/models/__init__.py
@@ -22,7 +22,10 @@ from .enums import (
 )
 from .scan import (
     AIComponent,
+    CodeSnippet,
     ComponentRelationship,
+    DecisionAnnotation,
+    EvidenceLocation,
     RiskFlag,
     RiskScore,
     ScanContext,
@@ -33,8 +36,11 @@ from .scan import (
 __all__ = [
     "AIComponent",
     "AIComponentType",
+    "CodeSnippet",
     "ComponentRelationship",
+    "DecisionAnnotation",
     "DetectionSource",
+    "EvidenceLocation",
     "RelationshipType",
     "RiskFlag",
     "RiskScore",

--- a/aibom/src/aibom/models/scan.py
+++ b/aibom/src/aibom/models/scan.py
@@ -24,6 +24,35 @@ from pydantic import BaseModel, Field
 from .enums import AIComponentType, DetectionSource, RelationshipType, Severity
 
 
+class EvidenceLocation(BaseModel):
+    """A structured source reference supporting a finding decision."""
+
+    file_path: str = ""
+    start_line: int = 0
+    end_line: int = 0
+    role: str = ""
+
+
+class CodeSnippet(BaseModel):
+    """Optional source excerpt attached to a finding decision."""
+
+    file_path: str = ""
+    start_line: int = 0
+    end_line: int = 0
+    text: str = ""
+    truncated: bool = False
+
+
+class DecisionAnnotation(BaseModel):
+    """Human-readable explanation and evidence for a final finding."""
+
+    decision: str = ""
+    justification: str = ""
+    evidence_kinds: list[str] = Field(default_factory=list)
+    evidence_locations: list[EvidenceLocation] = Field(default_factory=list)
+    code_snippet: CodeSnippet | None = None
+
+
 class AIComponent(BaseModel):
     """A detected AI asset in source code, configuration, or infrastructure."""
 
@@ -55,6 +84,7 @@ class AIComponent(BaseModel):
     kb_label: Optional[str] = None
     sdk_version: Optional[str] = None
 
+    decision_annotation: DecisionAnnotation | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
     instance_id: str = ""
 
@@ -74,6 +104,7 @@ class ComponentRelationship(BaseModel):
     target_name: str = ""
     source_type: AIComponentType = AIComponentType.OTHER
     target_type: AIComponentType = AIComponentType.OTHER
+    decision_annotation: DecisionAnnotation | None = None
 
     def model_post_init(self, __context: Any) -> None:
         if not self.label:
@@ -89,6 +120,7 @@ class RiskFlag(BaseModel):
     description: str
     file_path: str = ""
     line_number: int = 0
+    decision_annotation: DecisionAnnotation | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/aibom/src/aibom/reporters/json_reporter.py
+++ b/aibom/src/aibom/reporters/json_reporter.py
@@ -30,6 +30,7 @@ from .base import BaseReporter
 _LOGGER = logging.getLogger(__name__)
 
 _REMOTE_ORG_REPO_RE = re.compile(r"[/:]([^/]+)/([^/]+?)(?:\.git)?$")
+REPORT_SCHEMA_VERSION = "1"
 
 
 def _friendly_source_name(path: str) -> str:
@@ -72,28 +73,38 @@ def _disambiguate_source_key(source_name: str, seen: dict[str, int]) -> str:
 
 def _aibom_payload(result: ScanResult) -> dict[str, Any]:
     base = result.model_dump(mode="json")
+    raw_metadata = dict(base["metadata"])
+    source_outcomes = raw_metadata.pop("source_outcomes", {})
+    source_details = raw_metadata.pop("_report_source_details", {})
+    raw_metadata.setdefault("report_schema_version", REPORT_SCHEMA_VERSION)
     sources_out: dict[str, dict[str, Any]] = {}
     seen_source_names: dict[str, int] = {}
     for src in result.sources:
         comps = _components_by_type(src.components)
         total_components = sum(len(v) for v in comps.values())
-        source_name = _friendly_source_name(src.path)
+        detail = source_outcomes.get(src.path) or source_details.get(src.path) or {}
+        source_name = detail.get("source_name") or _friendly_source_name(src.path)
         source_key = _disambiguate_source_key(source_name, seen_source_names)
+        source_path = detail.get("source_path") or src.path
+        source_kind = detail.get("source_kind") or "local-path"
         sources_out[source_key] = {
             "source_name": source_name,
-            "source_path": src.path,
+            "source_path": source_path,
             "components": comps,
             "relationships": [r.model_dump(mode="json") for r in src.relationships],
             "summary": {
-                "status": "completed",
-                "source_kind": "local-path",
-                "assets_discovered": total_components,
-                "last_generated_at": base["metadata"].get("completed_at"),
+                "status": detail.get("status") or "completed",
+                "source_kind": source_kind,
+                "assets_discovered": detail.get("assets_discovered") or total_components,
+                "last_generated_at": (
+                    detail.get("last_generated_at")
+                    or raw_metadata.get("completed_at")
+                ),
             },
         }
     return {
         "aibom_analysis": {
-            "metadata": base["metadata"],
+            "metadata": raw_metadata,
             "sources": sources_out,
             "summary": result.summary,
             "risk": base["risk"],

--- a/aibom/src/aibom/scan_cache.py
+++ b/aibom/src/aibom/scan_cache.py
@@ -135,13 +135,13 @@ def load_cached(
         try:
             data = json.loads(p.read_text(encoding="utf-8"))
             if data.get("_cache_version") != _CACHE_VERSION:
-                _LOGGER.debug("Cache version mismatch for %s", key)
-                return None
+                _LOGGER.debug("Cache version mismatch for %s in %s", key, directory)
+                continue
             _LOGGER.info("Cache hit: %s (cached %s)", key[:12], data.get("_cached_at", "?"))
             return data
         except (json.JSONDecodeError, OSError) as exc:
-            _LOGGER.debug("Cache load error for %s: %s", key, exc)
-            return None
+            _LOGGER.debug("Cache load error for %s in %s: %s", key, directory, exc)
+            continue
     return None
 
 

--- a/aibom/src/aibom/scan_cache.py
+++ b/aibom/src/aibom/scan_cache.py
@@ -112,21 +112,37 @@ def _cache_path(cache_dir: Path, key: str) -> Path:
     return cache_dir / f"{key}.json"
 
 
-def load_cached(cache_dir: Path, key: str) -> Optional[dict[str, Any]]:
+def load_cached(
+    cache_dir: Path,
+    key: str,
+    *,
+    search_dirs: list[Path] | None = None,
+) -> Optional[dict[str, Any]]:
     """Load a cached scan result. Returns None on miss or version mismatch."""
-    p = _cache_path(cache_dir, key)
-    if not p.exists():
-        return None
-    try:
-        data = json.loads(p.read_text(encoding="utf-8"))
-        if data.get("_cache_version") != _CACHE_VERSION:
-            _LOGGER.debug("Cache version mismatch for %s", key)
+    dirs = [cache_dir]
+    if search_dirs:
+        dirs.extend(search_dirs)
+
+    seen: set[str] = set()
+    for directory in dirs:
+        resolved = str(directory)
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        p = _cache_path(directory, key)
+        if not p.exists():
+            continue
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+            if data.get("_cache_version") != _CACHE_VERSION:
+                _LOGGER.debug("Cache version mismatch for %s", key)
+                return None
+            _LOGGER.info("Cache hit: %s (cached %s)", key[:12], data.get("_cached_at", "?"))
+            return data
+        except (json.JSONDecodeError, OSError) as exc:
+            _LOGGER.debug("Cache load error for %s: %s", key, exc)
             return None
-        _LOGGER.info("Cache hit: %s (cached %s)", key[:12], data.get("_cached_at", "?"))
-        return data
-    except (json.JSONDecodeError, OSError) as exc:
-        _LOGGER.debug("Cache load error for %s: %s", key, exc)
-        return None
+    return None
 
 
 def save_cached(cache_dir: Path, key: str, data: dict[str, Any]) -> None:
@@ -157,20 +173,32 @@ def clear_cache(cache_dir: Path) -> int:
     return count
 
 
-def cache_info(cache_dir: Path) -> list[dict[str, Any]]:
+def cache_info(
+    cache_dir: Path,
+    *,
+    search_dirs: list[Path] | None = None,
+) -> list[dict[str, Any]]:
     """List all cached entries with metadata."""
-    if not cache_dir.exists():
-        return []
+    dirs = [cache_dir]
+    if search_dirs:
+        dirs.extend(search_dirs)
     entries = []
-    for f in sorted(cache_dir.glob("*.json")):
-        try:
-            data = json.loads(f.read_text(encoding="utf-8"))
-            entries.append({
-                "key": data.get("_cache_key", f.stem),
-                "cached_at": data.get("_cached_at", "unknown"),
-                "size_kb": round(f.stat().st_size / 1024, 1),
-                "path": str(f),
-            })
-        except (json.JSONDecodeError, OSError):
+    seen_files: set[str] = set()
+    for directory in dirs:
+        if not directory.exists():
             continue
+        for f in sorted(directory.glob("*.json")):
+            if str(f) in seen_files:
+                continue
+            seen_files.add(str(f))
+            try:
+                data = json.loads(f.read_text(encoding="utf-8"))
+                entries.append({
+                    "key": data.get("_cache_key", f.stem),
+                    "cached_at": data.get("_cached_at", "unknown"),
+                    "size_kb": round(f.stat().st_size / 1024, 1),
+                    "path": str(f),
+                })
+            except (json.JSONDecodeError, OSError):
+                continue
     return entries

--- a/aibom/src/aibom/scan_pipeline.py
+++ b/aibom/src/aibom/scan_pipeline.py
@@ -29,6 +29,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from collections.abc import Callable
 from typing import Any
 
 from .cross_ref import (
@@ -39,10 +40,12 @@ from .cross_ref import (
     detect_external_repo_deps,
     resolve_components,
 )
+from .llm_factory import ensure_llm_runtime_available
 from .models import ScanContext
 from .models.enums import AIComponentType
 from .models.scan import AIComponent, ComponentRelationship
 from .scanners import run_scanners
+from .scanners.dependency_scanner import discover_ai_package_set, is_known_ai_package
 from .scanners.file_cache import cache_stats, clear_cache
 
 _LOGGER = logging.getLogger(__name__)
@@ -72,12 +75,12 @@ class PipelineResult:
     total_elapsed_s: float = 0.0
 
 
-def _service_dir(file_path: str, scan_paths: list[str] | None = None) -> str:
+def _service_dir(file_path: str) -> str:
     """Extract a logical service/directory key from a file path.
 
     Walks up from the file until it finds a directory that contains a
-    manifest (pyproject.toml, go.mod, package.json, Cargo.toml) or is
-    two levels deep from a scan root.  Falls back to the immediate parent.
+    manifest (pyproject.toml, go.mod, package.json, Cargo.toml). Falls back
+    to the immediate parent.
     """
     from pathlib import Path
 
@@ -291,10 +294,15 @@ _TEST_PATH_SEGMENTS: frozenset[str] = frozenset({
 
 
 def _is_test_file(file_path: str) -> bool:
-    """Return True when the file lives under a test directory."""
+    """Return True when the file is clearly test-only by path or filename."""
     from pathlib import Path
-    parts = Path(file_path).parts
-    return any(seg in _TEST_PATH_SEGMENTS for seg in parts)
+
+    path = Path(file_path)
+    if any(seg in _TEST_PATH_SEGMENTS for seg in path.parts):
+        return True
+
+    stem = path.stem.lower()
+    return stem.startswith("test_") or stem.endswith("_test")
 
 
 def _consolidate_components(
@@ -361,9 +369,81 @@ def _consolidate_components(
     return result
 
 
+def _filter_default_bom_scope_components(
+    components: list["AIComponent"],
+) -> list["AIComponent"]:
+    """Remove components that only occur under test/fixture paths."""
+    return [c for c in components if c.metadata.get("test_only") is not True]
+
+
+def _filter_ai_only_dependency_components(
+    components: list["AIComponent"],
+) -> list["AIComponent"]:
+    """Keep only AI-relevant dependency rows in the default BOM."""
+    filtered: list[AIComponent] = []
+    for comp in components:
+        if comp.component_type != AIComponentType.DEPENDENCY:
+            filtered.append(comp)
+            continue
+        if comp.metadata.get("known_ai_package") is True:
+            filtered.append(comp)
+            continue
+        ecosystem = str(comp.metadata.get("ecosystem", "") or "")
+        if ecosystem and is_known_ai_package(ecosystem, comp.name):
+            meta = dict(comp.metadata)
+            meta["known_ai_package"] = True
+            filtered.append(comp.model_copy(update={"metadata": meta}))
+    return filtered
+
+
+def _filter_relationships_for_components(
+    relationships: list["ComponentRelationship"],
+    components: list["AIComponent"],
+) -> list["ComponentRelationship"]:
+    """Drop relationships that reference excluded components."""
+    component_ids = {c.instance_id for c in components}
+    component_names = {
+        name.strip().lower()
+        for c in components
+        for name in (c.name, c.model_name or "")
+        if name
+    }
+
+    def _endpoint_present(instance_id: str, name: str) -> bool:
+        if instance_id:
+            return instance_id in component_ids
+        if name:
+            return name.strip().lower() in component_names
+        return False
+
+    return [
+        rel for rel in relationships
+        if _endpoint_present(rel.source_instance_id, rel.source_name)
+        and _endpoint_present(rel.target_instance_id, rel.target_name)
+    ]
+
+
+def _filter_risk_flags_for_default_scope(flags: list[Any]) -> list[Any]:
+    """Drop risk flags whose evidence comes only from test/fixture files."""
+    filtered: list[Any] = []
+    for flag in flags:
+        file_path = ""
+        if isinstance(flag, dict):
+            file_path = str(flag.get("file_path", "") or "")
+        else:
+            file_path = str(getattr(flag, "file_path", "") or "")
+        if file_path and _is_test_file(file_path):
+            continue
+        filtered.append(flag)
+    return filtered
+
+
 def _vector_store_technology(c: "AIComponent") -> str | None:
     if c.component_type != AIComponentType.VECTOR_STORE:
         return None
+    meta_tech = c.metadata.get("store_technology")
+    if isinstance(meta_tech, str) and meta_tech.strip():
+        return meta_tech.strip().lower()
     name_l = (c.model_name or c.name or "").lower()
     if "weaviate" in name_l:
         return "weaviate"
@@ -520,6 +600,8 @@ class ScanPipeline:
         agentic_fast_model: str | None = None,
         agentic_timeout: int = 120,
         agentic_cache_dir: str | Path | None = None,
+        include_code_snippets: bool = False,
+        progress_callback: Callable[[dict[str, Any]], None] | None = None,
     ) -> None:
         self.scan_paths = scan_paths
         self.output_format = output_format
@@ -540,6 +622,15 @@ class ScanPipeline:
             if agentic_cache_dir is not None
             else None
         )
+        self.include_code_snippets = include_code_snippets
+        self.progress_callback = progress_callback
+
+    def _emit_progress(self, event: str, **payload: Any) -> None:
+        """Send a best-effort progress event to the CLI."""
+        if not self.progress_callback:
+            return
+        progress_event = {"event": event, **payload}
+        self.progress_callback(progress_event)
 
     def run(self) -> PipelineResult:
         clear_cache()
@@ -563,6 +654,7 @@ class ScanPipeline:
             ctx_kwargs["min_severity"] = self.min_severity
         ctx = ScanContext(**ctx_kwargs)
 
+        self._emit_progress("stage_started", stage="scan", total_stages=4)
         t0 = time.monotonic()
         components, relationships = self._stage_scan(ctx)
         elapsed = time.monotonic() - t0
@@ -572,7 +664,14 @@ class ScanPipeline:
             f"{len(components)} components, {len(relationships)} relationships, "
             f"file cache {fc['hits']} hits / {fc['misses']} misses",
         ))
+        self._emit_progress(
+            "stage_completed",
+            stage="scan",
+            elapsed_s=elapsed,
+            detail=timings[-1].detail,
+        )
 
+        self._emit_progress("stage_started", stage="cross_ref", total_stages=4)
         t0 = time.monotonic()
         components, env_idx, pkg_idx, ext_deps = self._stage_cross_ref(
             components
@@ -583,7 +682,14 @@ class ScanPipeline:
             f"{sum(len(v) for v in env_idx.env.values())} env vars, "
             f"{len(pkg_idx.packages)} packages, {len(ext_deps)} external deps",
         ))
+        self._emit_progress(
+            "stage_completed",
+            stage="cross_ref",
+            elapsed_s=elapsed,
+            detail=timings[-1].detail,
+        )
 
+        self._emit_progress("stage_started", stage="agentic", total_stages=4)
         t0 = time.monotonic()
         components, relationships, agentic_flags = self._stage_agentic(
             components, relationships
@@ -594,13 +700,30 @@ class ScanPipeline:
             "agentic", elapsed,
             "skipped (no --llm-model)" if skipped else f"{len(agentic_flags)} risk flags",
         ))
+        self._emit_progress(
+            "stage_completed",
+            stage="agentic",
+            elapsed_s=elapsed,
+            detail=timings[-1].detail,
+        )
 
+        self._emit_progress("stage_started", stage="assemble", total_stages=4)
         t0 = time.monotonic()
         components, agentic_count = self._stage_assemble(components)
         elapsed = time.monotonic() - t0
         timings.append(StageTiming(
             "assemble", elapsed, f"{len(components)} final, {agentic_count} agentic",
         ))
+        self._emit_progress(
+            "stage_completed",
+            stage="assemble",
+            elapsed_s=elapsed,
+            detail=timings[-1].detail,
+        )
+        relationships = _filter_relationships_for_components(
+            relationships, components
+        )
+        agentic_flags = _filter_risk_flags_for_default_scope(agentic_flags)
 
         total_elapsed = time.monotonic() - pipeline_start
 
@@ -627,8 +750,6 @@ class ScanPipeline:
     ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
         _LOGGER.info("Stage 1/4 — scanning %d path(s)", len(self.scan_paths))
 
-        from .scanners.dependency_scanner import discover_ai_package_set
-
         ai_pkgs = discover_ai_package_set(ctx)
         if ai_pkgs:
             _LOGGER.info(
@@ -648,6 +769,10 @@ class ScanPipeline:
             from .scanners.file_cache import warm_cache_async
 
             all_paths = [e.path for entries in idx.values() for e in entries]
+            self._emit_progress(
+                "file_cache_prep_started",
+                files_total=len(all_paths),
+            )
             try:
                 loop = asyncio.get_running_loop()
             except RuntimeError:
@@ -665,8 +790,16 @@ class ScanPipeline:
                 "Pass 2 prep: pre-cached %d / %d files via async I/O",
                 warmed, len(all_paths),
             )
+            self._emit_progress(
+                "file_cache_prep_completed",
+                files_total=len(all_paths),
+                files_warmed=warmed,
+            )
 
-        return run_scanners(ctx_pass2)
+        return run_scanners(
+            ctx_pass2,
+            progress_callback=self.progress_callback,
+        )
 
     # ------------------------------------------------------------------
     # Stage 2: Cross-reference resolution
@@ -718,13 +851,18 @@ class ScanPipeline:
             len(components),
         )
 
+        ensure_llm_runtime_available(
+            self.llm_config["model"],
+            provider=self.llm_config.get("provider"),
+        )
+
         try:
             from .agentic.agent import run_agentic_enrichment
-        except ImportError:
-            _LOGGER.warning(
-                "Agentic classification requires 'cisco-aibom[agentic]'. Skipping."
-            )
-            return components, relationships, []
+        except ImportError as exc:
+            raise ImportError(
+                "Agentic classification requires the agentic runtime. "
+                'Install with: uv tool install "cisco-aibom[agentic]"'
+            ) from exc
 
         try:
             deduped, fanout = _dedup_for_agentic(components)
@@ -746,6 +884,7 @@ class ScanPipeline:
                 fast_model=self.agentic_fast_model,
                 timeout_s=self.agentic_timeout,
                 cache_dir=self.agentic_cache_dir,
+                include_code_snippets=self.include_code_snippets,
             )
             deduped_ids = {c.instance_id for c in deduped}
             enriched_deduped_ids = {c.instance_id for c in enriched if c.instance_id in deduped_ids}
@@ -763,6 +902,8 @@ class ScanPipeline:
             relationships = relationships + agentic_rels
             return enriched, relationships, agentic_flags
 
+        except ImportError:
+            raise
         except Exception as exc:  # noqa: BLE001
             _LOGGER.warning("Agentic classification failed: %s", exc, exc_info=True)
 
@@ -802,6 +943,24 @@ class ScanPipeline:
             _LOGGER.info(
                 "Tool/vector_store priority dedup: %d → %d (-%d)",
                 before_td, after_td, before_td - after_td,
+            )
+
+        before_scope = len(components)
+        components = _filter_default_bom_scope_components(components)
+        after_scope = len(components)
+        if before_scope != after_scope:
+            _LOGGER.info(
+                "Default BOM scope: %d → %d components (-%d test/fixture-only)",
+                before_scope, after_scope, before_scope - after_scope,
+            )
+
+        before_deps = len(components)
+        components = _filter_ai_only_dependency_components(components)
+        after_deps = len(components)
+        if before_deps != after_deps:
+            _LOGGER.info(
+                "AI-only dependency policy: %d → %d components (-%d non-AI dependencies)",
+                before_deps, after_deps, before_deps - after_deps,
             )
 
         agentic_count = sum(1 for c in components if c.needs_agentic)

--- a/aibom/src/aibom/scanners/base.py
+++ b/aibom/src/aibom/scanners/base.py
@@ -20,6 +20,7 @@ import asyncio
 import logging
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from pathlib import Path
 from typing import Optional
 
@@ -76,17 +77,22 @@ def _load_aibomignore(paths: list[str]) -> Optional[PathSpec]:
 
 async def _async_timed_scan(
     scanner: BaseScanner, ctx: ScanContext,
-) -> tuple[str, float, list[AIComponent], list[ComponentRelationship]]:
+) -> tuple[str, float, list[AIComponent], list[ComponentRelationship], Exception | None]:
     """Run a scanner in a thread (to release the event loop) and time it."""
     t0 = time.monotonic()
-    comps, rels = await asyncio.to_thread(scanner.scan, ctx)
+    try:
+        comps, rels = await asyncio.to_thread(scanner.scan, ctx)
+    except Exception as exc:  # pragma: no cover - exercised via async wrapper
+        elapsed = time.monotonic() - t0
+        return scanner.name, elapsed, [], [], exc
     elapsed = time.monotonic() - t0
-    return scanner.name, elapsed, comps, rels
+    return scanner.name, elapsed, comps, rels, None
 
 
 async def _run_scanners_async(
     context: ScanContext,
     extra_scanners: Optional[list[type[BaseScanner]]] = None,
+    progress_callback: Callable[[dict[str, object]], None] | None = None,
 ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
     """Run all applicable scanners concurrently using asyncio."""
     ignore_spec = _load_aibomignore(context.paths)
@@ -123,17 +129,34 @@ async def _run_scanners_async(
     all_relationships: list[ComponentRelationship] = []
     scanner_timings.clear()
 
-    tasks = [_async_timed_scan(s, context) for s in applicable]
-    results = await asyncio.gather(*tasks, return_exceptions=True)
+    if progress_callback:
+        progress_callback({
+            "event": "scanners_discovered",
+            "total": len(applicable),
+        })
 
-    for i, result in enumerate(results):
-        if isinstance(result, Exception):
-            _LOGGER.exception("Scanner %s failed", applicable[i].name, exc_info=result)
+    tasks = [asyncio.create_task(_async_timed_scan(scanner, context)) for scanner in applicable]
+    completed = 0
+
+    for task in asyncio.as_completed(tasks):
+        name, elapsed, comps, rels, error = await task
+        if error is not None:
+            _LOGGER.exception("Scanner %s failed", name, exc_info=error)
             continue
-        name, elapsed, comps, rels = result
         scanner_timings[name] = elapsed
         all_components.extend(comps)
         all_relationships.extend(rels)
+        completed += 1
+        if progress_callback:
+            progress_callback({
+                "event": "scanner_completed",
+                "scanner": name,
+                "completed": completed,
+                "total": len(applicable),
+                "elapsed_s": elapsed,
+                "component_count": len(comps),
+                "relationship_count": len(rels),
+            })
 
     all_components = _merge_model_duplicates(all_components)
     return all_components, all_relationships
@@ -143,6 +166,7 @@ def run_scanners(
     context: ScanContext,
     workers: int = 4,
     extra_scanners: Optional[list[type[BaseScanner]]] = None,
+    progress_callback: Callable[[dict[str, object]], None] | None = None,
 ) -> tuple[list[AIComponent], list[ComponentRelationship]]:
     """Instantiate and run all registered scanners concurrently via asyncio.
 
@@ -159,10 +183,23 @@ def run_scanners(
     if loop and loop.is_running():
         import concurrent.futures
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            future = pool.submit(asyncio.run, _run_scanners_async(context, extra_scanners))
+            future = pool.submit(
+                asyncio.run,
+                _run_scanners_async(
+                    context,
+                    extra_scanners,
+                    progress_callback=progress_callback,
+                ),
+            )
             return future.result()
 
-    return asyncio.run(_run_scanners_async(context, extra_scanners))
+    return asyncio.run(
+        _run_scanners_async(
+            context,
+            extra_scanners,
+            progress_callback=progress_callback,
+        )
+    )
 
 
 _MERGE_LINE_PROXIMITY = 5

--- a/aibom/src/aibom/scanners/config_scanner.py
+++ b/aibom/src/aibom/scanners/config_scanner.py
@@ -82,6 +82,62 @@ def _is_model_name(value: str) -> bool:
         return False
     return True
 
+
+_KEY_TOKEN_SPLIT_RE = re.compile(r"[._-]+")
+
+_VECTOR_STORE_HINTS: frozenset[str] = frozenset({
+    "vector", "vectorstore", "vectorstores", "weaviate", "pinecone",
+    "qdrant", "chroma", "chromadb", "milvus", "pgvector", "faiss",
+})
+
+_EMBEDDING_HINTS: frozenset[str] = frozenset({
+    "embedding", "embeddings", "embed", "embedder",
+})
+
+_MODEL_ENDPOINT_HINTS: frozenset[str] = frozenset({
+    "sagemaker", "inference", "serving", "vllm",
+})
+
+
+def _key_tokens(value: str) -> set[str]:
+    return {tok for tok in _KEY_TOKEN_SPLIT_RE.split(value.lower()) if tok}
+
+
+def _model_registry_entry(value: str) -> Optional[dict[str, Any]]:
+    stripped = value.strip()
+    if not stripped:
+        return None
+    from .model_detector import _registry_lookup
+    return _registry_lookup(stripped)
+
+
+def _is_embedding_model_value(value: str) -> bool:
+    reg = _model_registry_entry(value)
+    if reg is not None and str(reg.get("family", "")).lower() == "embedding":
+        return True
+    return value.strip().lower().startswith("text-embedding")
+
+
+def _env_model_component_type(key: str, value: str) -> AIComponentType:
+    if _is_embedding_model_value(value):
+        return AIComponentType.EMBEDDING
+    if _key_tokens(key) & _EMBEDDING_HINTS:
+        return AIComponentType.EMBEDDING
+    return AIComponentType.MODEL
+
+
+def _env_endpoint_component_type(key: str, value: str) -> AIComponentType:
+    lower_key = key.lower()
+    lower_value = value.lower()
+    tokens = _key_tokens(key)
+    if any(hint in lower_key or hint in lower_value for hint in _VECTOR_STORE_HINTS):
+        return AIComponentType.VECTOR_STORE
+    if tokens & _EMBEDDING_HINTS:
+        return AIComponentType.MODEL_ENDPOINT
+    if tokens & _MODEL_ENDPOINT_HINTS:
+        return AIComponentType.MODEL_ENDPOINT
+    return AIComponentType.LLM_ENDPOINT
+
 _FROM_RE = re.compile(r"^\s*FROM\s+(--platform=\S+\s+)?(\S+)", re.IGNORECASE)
 _ENV_RE = re.compile(
     r"^\s*ENV\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+?)\s*$",
@@ -541,10 +597,7 @@ def _parse_env(
             or ku.endswith("_BASE_URL")
         )
         if is_endpoint_key and is_url:
-            is_custom_served = any(
-                tok in ku for tok in ("SAGEMAKER", "INFERENCE", "SERVING")
-            )
-            ctype = AIComponentType.MODEL_ENDPOINT if is_custom_served else AIComponentType.LLM_ENDPOINT
+            ctype = _env_endpoint_component_type(key, value)
             prov = _provider_from_env_key(key)
             out.append(
                 AIComponent(
@@ -586,13 +639,15 @@ def _parse_env(
             )
             continue
 
-        if "MODEL" in ku or "LLM" in ku:
+        if any(tok in ku for tok in ("MODEL", "LLM", "EMBEDDING", "ENGINE")):
             if _looks_like_model_name(value):
                 v = value.strip().strip("\"'")
+                ctype = _env_model_component_type(key, v)
+                name = f"env_embedding_{key}" if ctype == AIComponentType.EMBEDDING else f"env_model_{key}"
                 out.append(
                     AIComponent(
-                        name=f"env_model_{key}",
-                        component_type=AIComponentType.MODEL,
+                        name=name,
+                        component_type=ctype,
                         file_path=str(path.resolve()),
                         line_number=i,
                         detection_source=DetectionSource.CONFIG_FILE,
@@ -693,12 +748,14 @@ def _parse_dockerfile(
             ek = em.group(1)
             ev = em.group(2).strip().strip("\"'")
             ku = ek.upper()
-            if "MODEL" in ku or "LLM" in ku:
+            if any(tok in ku for tok in ("MODEL", "LLM", "EMBEDDING", "ENGINE")):
                 if _looks_like_model_name(ev):
+                    ctype = _env_model_component_type(ek, ev)
+                    name = f"dockerfile_env_{ek}"
                     out.append(
                         AIComponent(
-                            name=f"dockerfile_env_{ek}",
-                            component_type=AIComponentType.MODEL,
+                            name=name,
+                            component_type=ctype,
                             file_path=str(path.resolve()),
                             line_number=i,
                             detection_source=DetectionSource.CONFIG_FILE,

--- a/aibom/src/aibom/scanners/dependency_scanner.py
+++ b/aibom/src/aibom/scanners/dependency_scanner.py
@@ -95,6 +95,10 @@ KNOWN_AI_PACKAGES: dict[str, set[str]] = {
         "semantic-kernel",
         "promptflow",
         "deepeval",
+        "google-genai",
+        "guardrails",
+        "llmetry",
+        "openai-agents",
         # Observability
         "traceloop-sdk",
         "openllmetry",
@@ -105,8 +109,18 @@ KNOWN_AI_PACKAGES: dict[str, set[str]] = {
         "opik",
         "helicone",
         "tracia",
+        "opentelemetry-instrumentation-anthropic",
+        "opentelemetry-instrumentation-chromadb",
+        "opentelemetry-instrumentation-crewai",
+        "opentelemetry-instrumentation-google-generativeai",
+        "opentelemetry-instrumentation-llamaindex",
+        "opentelemetry-instrumentation-mistralai",
         "opentelemetry-instrumentation-openai",
+        "opentelemetry-instrumentation-openai-v2",
+        "opentelemetry-instrumentation-vertexai",
+        "opentelemetry-instrumentation-weaviate",
         "opentelemetry-instrumentation-langchain",
+        "opentelemetry-semantic-conventions-ai",
         # Guardrails
         "nemoguardrails",
         "guardrails-ai",
@@ -173,6 +187,7 @@ _REQUIREMENT_NAME = re.compile(r"^([a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?)")
 _PIPFILE_PKG = re.compile(r"^([a-zA-Z0-9_.-]+)\s*=")
 _TOML_STRING_DEP = re.compile(r"""["']([^"']+)["']""")
 _POETRY_DEP_KEY = re.compile(r"^([a-zA-Z0-9_.-]+)\s*=")
+_PURE_VERSION_TOKEN = re.compile(r"^[vV]?\d+(?:\.\d+)+(?:[a-zA-Z0-9._-]*)?$")
 _LOCK_PACKAGE = re.compile(r"^\[\[package\]\]\s*$")
 _LOCK_NAME = re.compile(r'^name\s*=\s*["\']([^"\']+)["\']')
 _LOCK_VERSION = re.compile(r'^version\s*=\s*["\']([^"\']+)["\']')
@@ -244,6 +259,8 @@ def _parse_pep508_name_version(spec: str) -> tuple[str, str, bool, Optional[str]
     if not m:
         return "", "", False, None
     name = m.group(1)
+    if _PURE_VERSION_TOKEN.fullmatch(name):
+        return "", "", False, None
     if not ver_part:
         return name, "*", False, None
     if sep_used in ("==", "==="):
@@ -325,7 +342,7 @@ def _parse_pipfile(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
 def _parse_pyproject_toml(text: str) -> list[tuple[str, str, int, Optional[str], str]]:
     out: list[tuple[str, str, int, Optional[str], str]] = []
     lower = text.lower()
-    for marker in ("[project.dependencies]", "[tool.poetry.dependencies]"):
+    for marker in ("[project.dependencies]",):
         pos = lower.find(marker.lower())
         if pos < 0:
             continue
@@ -350,6 +367,37 @@ def _parse_pyproject_toml(text: str) -> list[tuple[str, str, int, Optional[str],
                             "pypi",
                         ),
                     )
+    poetry_re = re.compile(r"^\[(tool\.poetry(?:\.group\.[^.]+)?\.dependencies)\]\s*$", re.MULTILINE | re.IGNORECASE)
+    for m in poetry_re.finditer(text):
+        start = m.end()
+        rest = text[start:]
+        endm = re.search(r"^\[", rest, re.MULTILINE)
+        block = rest[: endm.start()] if endm else rest
+        line_base = text[:start].count("\n")
+        for i, line in enumerate(block.splitlines(), start=1):
+            ls = line.strip()
+            if not ls or ls.startswith("#"):
+                continue
+            key_match = _POETRY_DEP_KEY.match(ls)
+            if not key_match:
+                continue
+            name = key_match.group(1)
+            if name == "python" or _PURE_VERSION_TOKEN.fullmatch(name):
+                continue
+            rest = ls[key_match.end() :].strip()
+            ver_m = re.search(r'version\s*=\s*["\']([^"\']+)["\']', rest)
+            quoted = re.search(r'["\']([^"\']+)["\']', rest)
+            raw_spec = ver_m.group(1) if ver_m else (quoted.group(1) if quoted else "*")
+            pinned, ver = _pypi_spec_pinned(raw_spec)
+            out.append(
+                (
+                    name,
+                    raw_spec,
+                    line_base + i,
+                    ver if pinned else None,
+                    "pypi",
+                ),
+            )
     opt_re = re.compile(
         r"^\[project\.optional-dependencies\.([^\]]+)\]\s*$",
         re.MULTILINE | re.IGNORECASE,
@@ -876,6 +924,11 @@ def _is_known_ai(ecosystem: str, name: str) -> bool:
     return name in pkgs
 
 
+def is_known_ai_package(ecosystem: str, name: str) -> bool:
+    """Public helper for enforcing the AI-only dependency policy."""
+    return _is_known_ai(ecosystem, name)
+
+
 def _display_name(ecosystem: str, name: str) -> str:
     if ecosystem == "pypi":
         return _normalize_pypi_name(name)
@@ -969,6 +1022,8 @@ class DependencyScanner(BaseScanner):
             if key not in _MANIFEST_PARSERS and not key.endswith(".csproj"):
                 continue
             for name, raw_spec, line_no, pinned_ver, ecosystem in _parse_manifest(path):
+                if not _is_known_ai(ecosystem, name):
+                    continue
                 disp = _display_name(ecosystem, name)
                 dedup_key = disp.lower()
                 if dedup_key in seen:
@@ -977,12 +1032,11 @@ class DependencyScanner(BaseScanner):
                         prev.sdk_version = pinned_ver
                         prev.metadata["version_spec"] = raw_spec
                     continue
-                known_ai = _is_known_ai(ecosystem, name)
                 meta: dict[str, Any] = {
                     "ecosystem": ecosystem,
                     "version_spec": raw_spec,
                     "manifest": path.name,
-                    "known_ai_package": known_ai,
+                    "known_ai_package": True,
                 }
                 comp = AIComponent(
                     name=disp,

--- a/aibom/src/aibom/scanners/deployment_detector.py
+++ b/aibom/src/aibom/scanners/deployment_detector.py
@@ -142,6 +142,37 @@ _MODEL_ENDPOINT_ENV_KEYS: frozenset[str] = frozenset({
     "AWS_SAGEMAKER_ENDPOINT", "INFERENCE_URL",
 })
 
+_KEY_TOKEN_SPLIT_RE = re.compile(r"[._-]+")
+
+_VECTOR_STORE_HINTS: frozenset[str] = frozenset({
+    "vector", "vectorstore", "vectorstores", "weaviate", "pinecone",
+    "qdrant", "chroma", "chromadb", "milvus", "pgvector", "faiss",
+})
+
+_VECTOR_STORE_TECH_ALIASES: tuple[tuple[str, str], ...] = (
+    ("weaviate", "weaviate"),
+    ("pinecone", "pinecone"),
+    ("qdrant", "qdrant"),
+    ("chromadb", "chromadb"),
+    ("chroma", "chromadb"),
+    ("milvus", "milvus"),
+    ("pgvector", "pgvector"),
+    ("faiss", "faiss"),
+    ("redis", "redis"),
+)
+
+_EMBEDDING_HINTS: frozenset[str] = frozenset({
+    "embedding", "embeddings", "embed", "embedder",
+})
+
+_MODEL_ENDPOINT_HINTS: frozenset[str] = frozenset({
+    "sagemaker", "inference", "serving", "vllm",
+})
+
+_MODEL_ENDPOINT_SELECTOR_HINTS: frozenset[str] = frozenset({
+    "engine", "deployment",
+})
+
 _SECRET_ENV_NAMES: frozenset[str] = frozenset({
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
@@ -166,16 +197,144 @@ _AI_ENV_NAMES: frozenset[str] = (
     })
 )
 
+def _key_tokens(value: str) -> set[str]:
+    return {tok for tok in _KEY_TOKEN_SPLIT_RE.split(value.lower()) if tok}
+
+
+def _model_registry_entry(value: str) -> Optional[dict[str, Any]]:
+    stripped = value.strip()
+    if not stripped:
+        return None
+    from .model_detector import _registry_lookup
+    return _registry_lookup(stripped)
+
+
+def _is_embedding_model_value(value: str) -> bool:
+    reg = _model_registry_entry(value)
+    if reg is not None and str(reg.get("family", "")).lower() == "embedding":
+        return True
+    return value.strip().lower().startswith("text-embedding")
+
+
+def _model_component_type_for_value(key_path: str, value: str) -> AIComponentType:
+    if _is_embedding_model_value(value):
+        return AIComponentType.EMBEDDING
+    if _key_tokens(key_path) & _EMBEDDING_HINTS:
+        return AIComponentType.EMBEDDING
+    return AIComponentType.MODEL
+
+
+def _normalized_vector_store_technology(value: str) -> str | None:
+    lower = value.lower()
+    for hint, technology in _VECTOR_STORE_TECH_ALIASES:
+        if hint in lower:
+            return technology
+    return None
+
+
+def _explicit_vector_backend(
+    sibling_values: Optional[dict[str, Any]],
+) -> tuple[str | None, str | None]:
+    if sibling_values is None:
+        return None, None
+
+    for sibling_key, sibling_val in sibling_values.items():
+        if not isinstance(sibling_key, str) or not isinstance(sibling_val, str):
+            continue
+
+        technology = _normalized_vector_store_technology(sibling_val)
+        if technology is None:
+            continue
+
+        tokens = _key_tokens(sibling_key)
+        if (
+            "backend" in tokens
+            or "provider" in tokens
+            or ("type" in tokens and tokens & {"vector", "db", "store"})
+        ):
+            return sibling_key, technology
+
+    return None, None
+
+
+def _has_model_endpoint_selector(
+    sibling_values: Optional[dict[str, Any]],
+) -> bool:
+    if sibling_values is None:
+        return False
+
+    for sibling_key, sibling_val in sibling_values.items():
+        if not isinstance(sibling_key, str) or not isinstance(sibling_val, str):
+            continue
+
+        stripped = sibling_val.strip()
+        if not stripped or stripped.startswith(("http://", "https://")):
+            continue
+
+        tokens = _key_tokens(sibling_key)
+        if tokens & _MODEL_ENDPOINT_SELECTOR_HINTS:
+            return True
+        if "model" in tokens and tokens & {"id", "name"}:
+            return True
+
+    return False
+
+
+def _endpoint_component_details(
+    key_path: str,
+    value: str,
+    sibling_values: Optional[dict[str, Any]] = None,
+) -> tuple[AIComponentType, str | None, bool, str | None]:
+    hinted_technology = _normalized_vector_store_technology(f"{key_path} {value}")
+    selector_key, explicit_backend = _explicit_vector_backend(sibling_values)
+
+    if explicit_backend is not None:
+        return (
+            AIComponentType.VECTOR_STORE,
+            explicit_backend,
+            bool(hinted_technology and hinted_technology != explicit_backend),
+            selector_key,
+        )
+
+    if hinted_technology is not None:
+        return AIComponentType.VECTOR_STORE, hinted_technology, False, None
+
+    if _has_model_endpoint_selector(sibling_values):
+        return AIComponentType.MODEL_ENDPOINT, None, False, None
+
+    tokens = _key_tokens(key_path)
+    if sibling_values is not None:
+        parent_path = key_path.rsplit(".", 1)[0]
+        for sibling_key, sibling_val in sibling_values.items():
+            if not isinstance(sibling_key, str) or not isinstance(sibling_val, str):
+                continue
+            sibling_path = f"{parent_path}.{sibling_key}" if parent_path else sibling_key
+            if _model_component_type_for_value(sibling_path, sibling_val) == AIComponentType.EMBEDDING:
+                return AIComponentType.MODEL_ENDPOINT, None, False, None
+
+    if tokens & _EMBEDDING_HINTS:
+        return AIComponentType.MODEL_ENDPOINT, None, False, None
+    if tokens & _MODEL_ENDPOINT_HINTS:
+        return AIComponentType.MODEL_ENDPOINT, None, False, None
+    return AIComponentType.LLM_ENDPOINT, None, False, None
+
+
+def _endpoint_component_type(
+    key_path: str,
+    value: str,
+    sibling_values: Optional[dict[str, Any]] = None,
+) -> AIComponentType:
+    return _endpoint_component_details(key_path, value, sibling_values)[0]
+
+
 def _classify_env(key: str, value: str) -> AIComponentType:
     """Resolve component type for a K8s/Helm env var."""
     if key in _SECRET_ENV_NAMES:
         return AIComponentType.SECRET
     is_url = value.strip().startswith(("http://", "https://"))
-    if key in _LLM_ENDPOINT_ENV_KEYS and is_url:
-        return AIComponentType.LLM_ENDPOINT
-    if key in _MODEL_ENDPOINT_ENV_KEYS and is_url:
-        return AIComponentType.MODEL_ENDPOINT
-    return AIComponentType.MODEL
+    if (key in _LLM_ENDPOINT_ENV_KEYS or key in _MODEL_ENDPOINT_ENV_KEYS) and is_url:
+        return _endpoint_component_type(key, value)
+    return _model_component_type_for_value(key, value)
 
 
 _HELM_ENDPOINT_KEY_RE = re.compile(
@@ -515,7 +674,9 @@ def _parse_k8s_yaml(
                             comp_type,
                             fp,
                             ln,
-                            model_name=ev.strip() if comp_type == AIComponentType.MODEL else None,
+                            model_name=ev.strip()
+                            if comp_type in (AIComponentType.MODEL, AIComponentType.EMBEDDING)
+                            else None,
                             metadata={"config_key": ek},
                         )
                     )
@@ -590,7 +751,9 @@ def _parse_k8s_yaml(
                         comp_type,
                         fp,
                         ln,
-                        model_name=val.strip() or None if comp_type == AIComponentType.MODEL else None,
+                        model_name=val.strip() or None
+                        if comp_type in (AIComponentType.MODEL, AIComponentType.EMBEDDING)
+                        else None,
                         metadata={"env": ename},
                     )
                 )
@@ -648,10 +811,11 @@ def _walk_helm_values(
                         )
                     )
                 elif _is_known_model(stripped):
+                    comp_type = _model_component_type_for_value(sub, stripped)
                     out.append(
                         _emit(
                             stripped[:120],
-                            AIComponentType.MODEL,
+                            comp_type,
                             file_path,
                             ln,
                             model_name=stripped,
@@ -663,28 +827,59 @@ def _walk_helm_values(
                     _helm_key_is_ai_endpoint(lk)
                     and stripped.startswith(("http://", "https://"))
                 ):
+                    (
+                        comp_type,
+                        store_technology,
+                        conflicting_backend,
+                        selector_key,
+                    ) = _endpoint_component_details(sub, stripped, obj)
+                    needs_agentic = (
+                        comp_type == AIComponentType.LLM_ENDPOINT
+                        or conflicting_backend
+                    )
+                    confidence = 0.5 if needs_agentic else 0.95
+                    if conflicting_backend:
+                        selector_label = selector_key or "backend selector"
+                        hint = (
+                            "Explicit backend selection beats provider-name "
+                            f"hints: sibling key '{selector_label}' selects "
+                            f"'{store_technology}', but endpoint key '{k}' "
+                            "still looks provider-specific. Treat the row as "
+                            "ambiguous and keep it only if surrounding config "
+                            "proves this endpoint is active."
+                        )
+                    elif needs_agentic:
+                        hint = (
+                            f"Helm key '{k}' ends with an endpoint suffix "
+                            f"and value is a URL. Confirm whether this is "
+                            f"an AI/LLM endpoint or an unrelated service."
+                        )
+                    else:
+                        hint = ""
+                    metadata = {"helm_key": sub, "endpoint_url": stripped}
+                    if store_technology is not None:
+                        metadata["store_technology"] = store_technology
+                    if selector_key is not None:
+                        metadata["backend_selector_key"] = selector_key
                     out.append(
                         _emit(
                             f"env:{k}",
-                            AIComponentType.LLM_ENDPOINT,
+                            comp_type,
                             file_path,
                             ln,
-                            metadata={"helm_key": sub, "endpoint_url": stripped},
-                            confidence=0.5,
-                            needs_agentic=True,
-                            agentic_hint=(
-                                f"Helm key '{k}' ends with an endpoint suffix "
-                                f"and value is a URL. Confirm whether this is "
-                                f"an AI/LLM endpoint or an unrelated service."
-                            ),
+                            metadata=metadata,
+                            confidence=confidence,
+                            needs_agentic=needs_agentic,
+                            agentic_hint=hint,
                         )
                     )
                 elif _helm_key_suggests_model(sub) and stripped and len(stripped) < 120:
                     hint = _azure_deployment_hint(sub, stripped)
+                    comp_type = _model_component_type_for_value(sub, stripped)
                     out.append(
                         _emit(
                             stripped[:120],
-                            AIComponentType.MODEL,
+                            comp_type,
                             file_path,
                             ln,
                             model_name=stripped,

--- a/aibom/src/aibom/scanners/env_var_resolver.py
+++ b/aibom/src/aibom/scanners/env_var_resolver.py
@@ -140,6 +140,25 @@ _INFRA_ENV_PREFIXES: tuple[str, ...] = (
     "SPLUNK_", "SENTRY_", "MY_NODE_", "CLUSTER_", "POD_",
 )
 
+_KEY_TOKEN_SPLIT_RE = re.compile(r"[._-]+")
+
+_VECTOR_STORE_HINTS: frozenset[str] = frozenset({
+    "vector", "vectorstore", "vectorstores", "weaviate", "pinecone",
+    "qdrant", "chroma", "chromadb", "milvus", "pgvector", "faiss",
+})
+
+_EMBEDDING_HINTS: frozenset[str] = frozenset({
+    "embedding", "embeddings", "embed", "embedder",
+})
+
+_MODEL_ENDPOINT_HINTS: frozenset[str] = frozenset({
+    "sagemaker", "inference", "serving", "vllm",
+})
+
+
+def _key_tokens(value: str) -> set[str]:
+    return {tok for tok in _KEY_TOKEN_SPLIT_RE.split(value.lower()) if tok}
+
 # ---------------------------------------------------------------------------
 # Vault / Secret-manager patterns  (Fix 3: generalized secret fetch)
 #
@@ -293,13 +312,20 @@ def _classify_assignment(text: str, env_match_start: int) -> str | None:
 
 
 def _env_context_to_component_type(ctx: str, env_name: str = "") -> AIComponentType:
+    tokens = _key_tokens(env_name)
     if ctx in ("model_kwarg", "model_assignment"):
+        if tokens & _EMBEDDING_HINTS:
+            return AIComponentType.EMBEDDING
         return AIComponentType.MODEL
     if ctx in ("api_key_kwarg", "api_key_envname"):
         return AIComponentType.SECRET
     if ctx == "endpoint_kwarg":
-        eu = env_name.upper()
-        if any(tok in eu for tok in ("SAGEMAKER", "INFERENCE", "SERVING")):
+        lower_name = env_name.lower()
+        if any(hint in lower_name for hint in _VECTOR_STORE_HINTS):
+            return AIComponentType.VECTOR_STORE
+        if tokens & _EMBEDDING_HINTS:
+            return AIComponentType.MODEL_ENDPOINT
+        if tokens & _MODEL_ENDPOINT_HINTS:
             return AIComponentType.MODEL_ENDPOINT
         return AIComponentType.LLM_ENDPOINT
     return AIComponentType.MODEL

--- a/aibom/src/aibom/scanners/kb_enrichment_scanner.py
+++ b/aibom/src/aibom/scanners/kb_enrichment_scanner.py
@@ -284,10 +284,59 @@ _AMBIGUOUS_NAME_TYPES: frozenset[AIComponentType] = frozenset({
     AIComponentType.GUARDRAIL,
 })
 
+_EMBEDDING_IMPORT_SIGNALS: frozenset[str] = frozenset({
+    "embedding",
+    "embedder",
+    "embedders",
+    "openai",
+    "langchain",
+    "haystack",
+    "llama_index",
+    "sentence_transformers",
+    "transformers",
+    "chromadb",
+})
+
+_EMBEDDING_CALL_SIGNALS: frozenset[str] = frozenset({
+    "model=",
+    "model_name=",
+    "deployment=",
+    "deployment_name=",
+    "api_key=",
+    "client=",
+    "embedding_function=",
+})
+
 
 def _is_data_class_name(name: str) -> bool:
     """Return True when the class name looks like a data/schema class."""
     return any(name.endswith(s) for s in _NON_AI_CLASS_SUFFIXES)
+
+
+def _is_class_like_name(name: str) -> bool:
+    return bool(name) and name[0].isupper() and not name.isupper()
+
+
+def _has_embedding_type_name(name: str) -> bool:
+    lower = name.lower()
+    return (
+        lower.endswith("embedding")
+        or lower.endswith("embeddings")
+        or lower.endswith("embedder")
+    )
+
+
+def _has_embedding_import_evidence(text: str) -> bool:
+    lower = text.lower()
+    return any(signal in lower for signal in _EMBEDDING_IMPORT_SIGNALS)
+
+
+def _has_embedding_call_evidence(line: str, source: str) -> bool:
+    lower_line = line.lower()
+    return (
+        any(signal in lower_line for signal in _EMBEDDING_CALL_SIGNALS)
+        or _has_embedding_import_evidence(source)
+    )
 
 
 def _infer_type_from_name(name: str) -> tuple[AIComponentType, bool]:
@@ -730,6 +779,13 @@ def _emit_suggestive_candidates(
             continue
         seen_lines.add(i)
         inferred_type, _name_ambiguous = _infer_type_from_name(class_name)
+        if inferred_type == AIComponentType.MODEL:
+            continue
+        if inferred_type == AIComponentType.EMBEDDING and not (
+            _has_embedding_type_name(class_name)
+            and _has_embedding_call_evidence(stripped, source)
+        ):
+            continue
         candidates.append(
             AIComponent(
                 name=class_name,
@@ -849,6 +905,12 @@ def _detect_import_based_assets(
                 if not cleaned or cleaned in ("from", "import", "as"):
                     continue
                 inferred, name_ambiguous = _infer_type_from_name(cleaned)
+                if inferred == AIComponentType.EMBEDDING and not (
+                    _is_class_like_name(cleaned)
+                    and _has_embedding_type_name(cleaned)
+                    and _has_embedding_import_evidence(imp_lower)
+                ):
+                    continue
                 if inferred != AIComponentType.MODEL:
                     comp_type = inferred
                     matched_name = cleaned
@@ -1091,6 +1153,28 @@ _BARE_CLIENT_HINTS: dict[str, str] = {
 }
 
 
+def _is_confirmed_ai_prompt_call(qn: str) -> bool:
+    """Return True only for prompt kwargs on confirmed AI call chains.
+
+    Generic helpers frequently accept ``prompt=`` or ``messages=`` kwargs, so
+    we require the enclosing call to resolve to a known AI constructor or an AI
+    client method chain before emitting a prompt asset.
+    """
+    if not qn:
+        return False
+
+    short = qn.rsplit(".", 1)[-1] if "." in qn else qn
+    if short == "create_deep_agent":
+        return True
+    if short in _KNOWN_AI_CLIENT_CLASSES:
+        return True
+    if short not in _AI_CLIENT_CALLS:
+        return False
+
+    class_segment = _extract_class_segment(qn)
+    return bool(class_segment and class_segment in _KNOWN_AI_CLIENT_CLASSES)
+
+
 def _detect_model_kwargs(result: "CodeAnalysisResult") -> list[AIComponent]:
     """Extract models, LLM endpoints, and bare clients from AI constructor kwargs via LibCST.
 
@@ -1210,13 +1294,19 @@ def _detect_prompt_kwargs(result: "CodeAnalysisResult") -> list[AIComponent]:
     """
     components: list[AIComponent] = []
     seen: set[tuple[str, int]] = set()
+    variable_map: dict[str, str] = {}
 
-    all_calls = list(result.calls) + [a.call for a in result.assignments]
-    all_lines = [c.line_number for c in result.calls] + [a.line_number for a in result.assignments]
+    for assignment in result.assignments:
+        if assignment.target_qualified_name and assignment.call.qualified_name:
+            variable_map[assignment.target_qualified_name] = assignment.call.qualified_name
 
-    for call_obs, line in zip(all_calls, all_lines):
-        qn = call_obs.qualified_name or ""
-        short = qn.rsplit(".", 1)[-1] if "." in qn else qn
+    all_calls = [(c, c.line_number) for c in result.calls]
+    all_calls += [(a.call, a.line_number) for a in result.assignments]
+
+    for call_obs, line in all_calls:
+        qn = _resolve_chain(call_obs.qualified_name or "", variable_map)
+        if not _is_confirmed_ai_prompt_call(qn):
+            continue
 
         for kwarg_name in _PROMPT_KWARG_NAMES:
             val = call_obs.arguments.get(kwarg_name)
@@ -1261,6 +1351,11 @@ def _detect_prompt_kwargs(result: "CodeAnalysisResult") -> list[AIComponent]:
                     )
                 )
     return components
+
+
+def _kb_entry_describes_method(kb_entry: dict[str, Any]) -> bool:
+    """KB method rows describe operations, not durable AI assets."""
+    return str(kb_entry.get("label") or "").strip().lower() == "method"
 
 
 def _find_python_files(context: ScanContext) -> list[Path]:
@@ -1447,6 +1542,8 @@ def _process_file_with_cache(
         if match.is_confirmed:
             kb_entry = match.entry
             assert kb_entry is not None  # noqa: S101
+            if _kb_entry_describes_method(kb_entry):
+                continue
             concept = kb_entry["concept"].lower()
             comp_type = _CONCEPT_TO_TYPE.get(concept)
             if not comp_type:
@@ -1675,6 +1772,8 @@ def _process_file(
         if match.is_confirmed:
             kb_entry = match.entry
             assert kb_entry is not None  # noqa: S101
+            if _kb_entry_describes_method(kb_entry):
+                continue
             concept = kb_entry["concept"].lower()
             comp_type = _CONCEPT_TO_TYPE.get(concept)
             if not comp_type:

--- a/aibom/src/aibom/scanners/model_detector.py
+++ b/aibom/src/aibom/scanners/model_detector.py
@@ -26,8 +26,8 @@ from urllib.parse import quote_plus
 
 import yaml
 from pathspec import PathSpec
-from platformdirs import user_cache_dir
 
+from ..cache_paths import cache_read_dirs, ensure_cache_dir
 from .file_cache import is_python_source, read_python_source, read_text_cached
 
 from ..models import AIComponent, ComponentRelationship, ScanContext
@@ -39,7 +39,6 @@ _LOGGER = logging.getLogger(__name__)
 _MODEL_CATALOG_URL = "https://models.litellm.ai/model_catalog"
 _HF_API_URL = "https://huggingface.co/api/models"
 _CACHE_TTL_SECONDS = 86400  # 24 hours
-_CACHE_DIR = Path(user_cache_dir("aibom")) / "model_cache"
 
 _HF_SLUG_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
@@ -49,21 +48,23 @@ _HF_SLUG_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
 def _cache_file(name: str) -> Path:
-    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    return _CACHE_DIR / name
+    cache_dir = ensure_cache_dir("model")
+    return cache_dir / name
 
 
 def _load_cached(name: str) -> dict[str, dict[str, Any]] | None:
-    cp = _cache_file(name)
-    if not cp.exists():
-        return None
-    try:
-        data = json.loads(cp.read_text(encoding="utf-8"))
-        if time.time() - data.get("_ts", 0) > _CACHE_TTL_SECONDS:
+    for cache_dir in cache_read_dirs("model"):
+        cp = cache_dir / name
+        if not cp.exists():
+            continue
+        try:
+            data = json.loads(cp.read_text(encoding="utf-8"))
+            if time.time() - data.get("_ts", 0) > _CACHE_TTL_SECONDS:
+                return None
+            return data.get("models", {})
+        except Exception:
             return None
-        return data.get("models", {})
-    except Exception:
-        return None
+    return None
 
 
 def _save_cached(name: str, models: dict[str, dict[str, Any]]) -> None:

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -29,7 +29,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aibom.agentic.agent import _build_context_message, _extract_structured_response
-from aibom.models import AIComponent, AIComponentType, ComponentRelationship
+from aibom.models import (
+    AIComponent,
+    AIComponentType,
+    ComponentRelationship,
+    DecisionAnnotation,
+    EvidenceLocation,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -215,7 +221,7 @@ class TestRunAgenticEnrichment:
                 cache_dir=cache_dir,
             )
 
-        mock_cache_cls.assert_called_once_with(cache_dir)
+        mock_cache_cls.assert_called_once_with(cache_dir, fallback_dirs=[])
         assert comps == []
         assert rels == []
         assert flags == []
@@ -323,6 +329,210 @@ class TestRunAgenticEnrichment:
 
         assert {c.name for c in fresh} == {"existing", "agent-found-model"}
         assert {c.name for c in cached} == {c.name for c in fresh}
+        assert mock_agent.invoke.call_count == 1
+
+    @patch("aibom.agentic.agent._close_model_clients")
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_partial_cached_rerun_replays_batch_findings_once(
+        self, mock_create, _mock_build, _mock_close, tmp_path
+    ):
+        from aibom.agentic.agent import run_agentic_enrichment
+
+        first_msg = MagicMock()
+        first_msg.content = json.dumps({
+            "enriched_components": [],
+            "new_components": [
+                {
+                    "name": "agent-found-model",
+                    "component_type": "model",
+                    "file_path": "new.py",
+                    "line_number": 1,
+                    "framework": "openai",
+                    "model_name": "gpt-5",
+                }
+            ],
+            "new_relationships": [
+                {
+                    "source_name": "existing-a",
+                    "target_name": "existing-b",
+                    "relationship_type": "USES_MODEL",
+                }
+            ],
+            "risk_findings": [
+                {
+                    "flag": "cache_replayed",
+                    "description": "cached finding",
+                    "file_path": "app_a.py",
+                    "line_number": 1,
+                    "severity": "low",
+                }
+            ],
+        })
+        second_msg = MagicMock()
+        second_msg.content = json.dumps({
+            "enriched_components": [],
+            "new_components": [],
+            "new_relationships": [],
+            "risk_findings": [],
+        })
+        mock_agent = MagicMock()
+        mock_agent.invoke.side_effect = [
+            {"messages": [first_msg]},
+            {"messages": [second_msg]},
+        ]
+        mock_create.return_value = mock_agent
+
+        det_comps_first = [
+            AIComponent(
+                name="existing-a",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="app_a.py",
+                line_number=1,
+            ),
+            AIComponent(
+                name="existing-b",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="app_b.py",
+                line_number=1,
+            ),
+        ]
+        det_comps_second = det_comps_first + [
+            AIComponent(
+                name="existing-c",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="app_c.py",
+                line_number=1,
+            )
+        ]
+        cache_dir = tmp_path / "agentic-cache"
+
+        fresh_components, fresh_rels, fresh_flags = run_agentic_enrichment(
+            model_string="test-model",
+            deterministic_components=det_comps_first,
+            deterministic_relationships=[],
+            scan_paths=["/tmp"],
+            cache_dir=cache_dir,
+        )
+        cached_components, cached_rels, cached_flags = run_agentic_enrichment(
+            model_string="test-model",
+            deterministic_components=det_comps_second,
+            deterministic_relationships=[],
+            scan_paths=["/tmp"],
+            cache_dir=cache_dir,
+        )
+
+        assert {c.name for c in fresh_components} == {
+            "existing-a", "existing-b", "agent-found-model",
+        }
+        assert {c.name for c in cached_components} == {
+            "existing-a", "existing-b", "existing-c", "agent-found-model",
+        }
+        assert sum(c.name == "agent-found-model" for c in cached_components) == 1
+        assert len(cached_rels) == 1
+        assert cached_rels[0].source_name == "existing-a"
+        assert cached_rels[0].target_name == "existing-b"
+        assert len(cached_flags) == 1
+        assert cached_flags[0].flag == "cache_replayed"
+        assert len(fresh_rels) == 1
+        assert len(fresh_flags) == 1
+        assert mock_agent.invoke.call_count == 2
+
+    @patch("aibom.agentic.agent._close_model_clients")
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_cross_repo_coordination_rerun_uses_cache(
+        self, mock_create, _mock_build, _mock_close, tmp_path
+    ):
+        from types import SimpleNamespace
+
+        from aibom.agentic.agent import run_cross_repo_coordination
+
+        mock_msg = MagicMock()
+        mock_msg.content = json.dumps({
+            "new_relationships": [
+                {
+                    "source_name": "repo-a-model",
+                    "target_name": "repo-b-endpoint",
+                    "relationship_type": "USES_MODEL",
+                }
+            ],
+            "risk_findings": [
+                {
+                    "flag": "cross_repo_env_var_mismatch",
+                    "description": "backend mismatch",
+                    "severity": "medium",
+                }
+            ],
+        })
+        mock_agent = MagicMock()
+        mock_agent.invoke.return_value = {"messages": [mock_msg]}
+        mock_create.return_value = mock_agent
+
+        per_repo_results = {
+            "/repo-a": {
+                "components": [
+                    AIComponent(
+                        name="repo-a-model",
+                        component_type=AIComponentType.MODEL,
+                        file_path="/repo-a/app.py",
+                        line_number=10,
+                        model_name="gpt-4o-mini",
+                    )
+                ],
+                "_unresolved_env_vars": [],
+            },
+            "/repo-b": {
+                "components": [
+                    AIComponent(
+                        name="repo-b-endpoint",
+                        component_type=AIComponentType.LLM_ENDPOINT,
+                        file_path="/repo-b/values.yaml",
+                        line_number=20,
+                    )
+                ],
+                "_unresolved_env_vars": [],
+            },
+        }
+
+        with (
+            patch(
+                "aibom.agentic.cross_repo.cross_repo_summary_tool",
+                return_value=json.dumps(
+                    {
+                        "shared_env_vars": [],
+                        "shared_packages": [],
+                        "unresolved_env_var_refs": [],
+                    }
+                ),
+            ),
+            patch(
+                "aibom.agentic.cross_repo.build_cross_repo_tools",
+                return_value=[MagicMock()],
+            ),
+            patch(
+                "aibom.cross_ref.build_env_index",
+                return_value=SimpleNamespace(env={}),
+            ),
+        ):
+            fresh_rels, fresh_flags = run_cross_repo_coordination(
+                model_string="test-model",
+                per_repo_results=per_repo_results,
+                cache_dir=tmp_path / "agentic-cache",
+            )
+            cached_rels, cached_flags = run_cross_repo_coordination(
+                model_string="test-model",
+                per_repo_results=per_repo_results,
+                cache_dir=tmp_path / "agentic-cache",
+            )
+
+        assert len(fresh_rels) == 1
+        assert len(cached_rels) == 1
+        assert fresh_rels[0].source_name == cached_rels[0].source_name
+        assert fresh_rels[0].target_name == cached_rels[0].target_name
+        assert len(fresh_flags) == 1
+        assert len(cached_flags) == 1
+        assert fresh_flags[0].flag == cached_flags[0].flag
         assert mock_agent.invoke.call_count == 1
 
     @patch("aibom.agentic.agent._close_model_clients")
@@ -627,6 +837,70 @@ class TestAgenticResultCache:
         assert enriched[0].confidence == 0.97
         assert enriched[0].agentic_hint == ""
         assert enriched[0].needs_agentic is False
+
+    def test_apply_cached_hydrates_component_snippet_when_enabled(self, tmp_path):
+        from aibom.agentic.agent import _AgenticResultCache, _component_cache_key
+        from aibom.agentic.middleware import AIBOMScannerMiddleware
+
+        source = tmp_path / "service.py"
+        source.write_text(
+            "setup()\n"
+            "agent = RouterAgent()\n"
+            "agent.run(task)\n",
+            encoding="utf-8",
+        )
+
+        cache = _AgenticResultCache(tmp_path / "cache")
+        before = AIComponent(
+            name="router_agent",
+            component_type=AIComponentType.AGENT,
+            file_path=str(source),
+            line_number=2,
+        )
+        after = before.model_copy(
+            update={
+                "decision_annotation": DecisionAnnotation(
+                    decision="confirmed",
+                    justification="The code instantiates and runs the agent.",
+                    evidence_kinds=["code_context"],
+                    evidence_locations=[
+                        EvidenceLocation(
+                            file_path=str(source),
+                            start_line=2,
+                            end_line=3,
+                            role="primary",
+                        )
+                    ],
+                ),
+                "needs_agentic": False,
+            }
+        )
+        cache.put(
+            _component_cache_key(before),
+            {
+                "cached_component": after.model_dump(mode="json"),
+                "enriched_components": [],
+                "new_components": [],
+                "remove_components": [],
+                "reclassify_components": [],
+                "new_relationships": [],
+                "risk_findings": [],
+            },
+        )
+
+        enriched, new, rels, flags = cache.apply_cached(
+            [before],
+            AIBOMScannerMiddleware(include_code_snippets=True),
+        )
+
+        assert new == []
+        assert rels == []
+        assert flags == []
+        assert enriched[0].decision_annotation is not None
+        assert enriched[0].decision_annotation.code_snippet is not None
+        assert enriched[0].decision_annotation.code_snippet.text == (
+            "agent = RouterAgent()\nagent.run(task)\n"
+        )
 
 
 class TestRunTier:

--- a/aibom/tests/test_agentic_cli.py
+++ b/aibom/tests/test_agentic_cli.py
@@ -133,6 +133,9 @@ class TestAgenticEnrichmentViaCLI:
         self, monkeypatch, sample_dir, tmp_path
     ):
         out = tmp_path / "report.txt"
+
+        monkeypatch.setattr("aibom.llm_factory.init_chat_model", lambda *a, **k: None)
+
         real_import_module = importlib.import_module
 
         def fake_import_module(name: str, package: str | None = None):

--- a/aibom/tests/test_agentic_cli.py
+++ b/aibom/tests/test_agentic_cli.py
@@ -55,10 +55,12 @@ class TestAgenticEnrichmentViaCLI:
         assert result.exit_code == 1
         assert "llm-model" in result.output.lower() or "AIBOM_LLM_MODEL" in result.output
 
+    @patch("aibom.scan_pipeline.ensure_llm_runtime_available", return_value=None)
+    @patch("aibom.cli.ensure_llm_runtime_available", return_value=None)
     @patch("aibom.agentic.agent._close_model_clients")
     @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
     @patch("aibom.agentic.agent.create_aibom_agent")
-    def test_llm_model_triggers_agentic_enrichment(self, mock_create, _mock_build, _mock_close, sample_dir, tmp_path):
+    def test_llm_model_triggers_agentic_enrichment(self, mock_create, _mock_build, _mock_close, _mock_cli_preflight, _mock_pipeline_preflight, sample_dir, tmp_path):
         out = tmp_path / "report.txt"
         agent_response = json.dumps({
             "enriched_components": [],

--- a/aibom/tests/test_agentic_cli.py
+++ b/aibom/tests/test_agentic_cli.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import json
+import importlib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -98,3 +99,65 @@ class TestAgenticEnrichmentViaCLI:
         clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
         assert "--llm-model" in clean
         assert "agentic" in clean
+
+    def test_missing_agentic_extras_fail_fast_with_install_hint(
+        self, monkeypatch, sample_dir, tmp_path
+    ):
+        out = tmp_path / "report.txt"
+
+        monkeypatch.setattr("aibom.llm_factory.init_chat_model", None)
+
+        result = runner.invoke(
+            app,
+            [
+                "analyze",
+                str(sample_dir),
+                "--output-format",
+                "plaintext",
+                "--output-file",
+                str(out),
+                "--llm-model",
+                "test-model",
+                "--llm-api-base",
+                "http://localhost:11434",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "cisco-aibom[agentic]" in result.output
+        assert "install" in result.output.lower()
+
+    def test_missing_openai_provider_extra_fails_fast_with_install_hint(
+        self, monkeypatch, sample_dir, tmp_path
+    ):
+        out = tmp_path / "report.txt"
+        real_import_module = importlib.import_module
+
+        def fake_import_module(name: str, package: str | None = None):
+            if name == "langchain_openai":
+                raise ImportError("missing langchain_openai")
+            return real_import_module(name, package)
+
+        monkeypatch.setattr("importlib.import_module", fake_import_module)
+
+        result = runner.invoke(
+            app,
+            [
+                "analyze",
+                str(sample_dir),
+                "--output-format",
+                "plaintext",
+                "--output-file",
+                str(out),
+                "--llm-model",
+                "gpt-5.4",
+                "--llm-provider",
+                "openai",
+                "--llm-api-key",
+                "not-a-real-key",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "llm-openai" in result.output
+        assert "cisco-aibom[agentic,llm-openai]" in result.output

--- a/aibom/tests/test_agentic_middleware.py
+++ b/aibom/tests/test_agentic_middleware.py
@@ -112,6 +112,105 @@ class TestExtractFindings:
         comps, rels, flags = mw.extract_findings(output)
         assert comps == [] and rels == [] and flags == []
 
+    def test_extracts_decision_annotations_for_relationships_and_risk_flags(self, mw):
+        output = json.dumps(
+            {
+                "new_components": [],
+                "new_relationships": [
+                    {
+                        "source_name": "planner_agent",
+                        "target_name": "search_tool",
+                        "relationship_type": "USES_TOOL",
+                        "decision_annotation": {
+                            "decision": "derived",
+                            "justification": "The planner calls the search tool in the same workflow.",
+                            "evidence_kinds": ["relationship_context"],
+                            "evidence_locations": [
+                                {
+                                    "file_path": "/repo/app.py",
+                                    "start_line": 12,
+                                    "end_line": 16,
+                                    "role": "source",
+                                }
+                            ],
+                        },
+                    }
+                ],
+                "risk_findings": [
+                    {
+                        "flag": "unpinned_model",
+                        "description": "The configured model identifier is not version-pinned.",
+                        "file_path": "/repo/app.py",
+                        "line_number": 18,
+                        "severity": "medium",
+                        "decision_annotation": {
+                            "decision": "flagged",
+                            "justification": "The model name is generic and lacks an immutable revision.",
+                            "evidence_kinds": ["code_context"],
+                            "evidence_locations": [
+                                {
+                                    "file_path": "/repo/app.py",
+                                    "start_line": 18,
+                                    "end_line": 18,
+                                    "role": "trigger",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        )
+
+        _, rels, flags = mw.extract_findings(output)
+
+        assert rels[0].decision_annotation is not None
+        assert rels[0].decision_annotation.decision == "derived"
+        assert flags[0].decision_annotation is not None
+        assert flags[0].decision_annotation.justification.startswith("The model name")
+
+    def test_extracts_code_snippet_only_when_enabled(self, tmp_path):
+        source = tmp_path / "app.py"
+        source.write_text("line 1\nline 2\nline 3\n", encoding="utf-8")
+
+        output = json.dumps(
+            {
+                "new_components": [
+                    {
+                        "name": "router_agent",
+                        "component_type": "agent",
+                        "file_path": str(source),
+                        "line_number": 2,
+                        "framework": "custom",
+                        "decision_annotation": {
+                            "decision": "added",
+                            "justification": "The code declares and uses a request routing agent.",
+                            "evidence_kinds": ["code_context"],
+                            "evidence_locations": [
+                                {
+                                    "file_path": str(source),
+                                    "start_line": 2,
+                                    "end_line": 3,
+                                    "role": "primary",
+                                }
+                            ],
+                        },
+                    }
+                ]
+            }
+        )
+
+        without_snippets = AIBOMScannerMiddleware(include_code_snippets=False)
+        with_snippets = AIBOMScannerMiddleware(include_code_snippets=True)
+
+        comps_without, _, _ = without_snippets.extract_findings(output)
+        comps_with, _, _ = with_snippets.extract_findings(output)
+
+        assert comps_without[0].decision_annotation is not None
+        assert comps_without[0].decision_annotation.code_snippet is None
+        assert comps_with[0].decision_annotation is not None
+        assert comps_with[0].decision_annotation.code_snippet is not None
+        assert comps_with[0].decision_annotation.code_snippet.text == "line 2\nline 3\n"
+
 
 class TestApplyEnrichments:
     def test_updates_existing_component(self, mw):
@@ -169,6 +268,46 @@ class TestApplyEnrichments:
         result = mw.apply_enrichments(existing, output)
         assert len(result) == 1
         assert result[0].name == "a"
+
+    def test_applies_component_decision_annotation(self, mw):
+        existing = [
+            AIComponent(
+                name="my-model",
+                component_type=AIComponentType.MODEL,
+                file_path="app.py",
+                line_number=10,
+                instance_id="comp1_app.py_10",
+            )
+        ]
+        output = json.dumps(
+            {
+                "enriched_components": [
+                    {
+                        "instance_id": "comp1_app.py_10",
+                        "updates": {},
+                        "decision_annotation": {
+                            "decision": "confirmed",
+                            "justification": "The constructor argument shows this is an active model dependency.",
+                            "evidence_kinds": ["code_context"],
+                            "evidence_locations": [
+                                {
+                                    "file_path": "app.py",
+                                    "start_line": 10,
+                                    "end_line": 10,
+                                    "role": "primary",
+                                }
+                            ],
+                        },
+                    }
+                ]
+            }
+        )
+
+        enriched = mw.apply_enrichments(existing, output)
+
+        assert enriched[0].decision_annotation is not None
+        assert enriched[0].decision_annotation.decision == "confirmed"
+        assert "active model dependency" in enriched[0].decision_annotation.justification
 
 
 class TestRemoveComponents:

--- a/aibom/tests/test_agentic_prompts.py
+++ b/aibom/tests/test_agentic_prompts.py
@@ -1,0 +1,90 @@
+from aibom.agentic.prompts import AIBOM_AGENT_SYSTEM_PROMPT
+
+
+def _normalized_aibom_prompt() -> str:
+    """Single-line lowercase prompt for stable substring checks."""
+    return " ".join(AIBOM_AGENT_SYSTEM_PROMPT.lower().split())
+
+
+class TestAgenticPromptHardening:
+    def test_dependency_prompt_rejects_bare_version_names(self) -> None:
+        assert "0.18.0" in AIBOM_AGENT_SYSTEM_PROMPT
+        assert "3.9.3" in AIBOM_AGENT_SYSTEM_PROMPT
+        assert "0.59b0" in AIBOM_AGENT_SYSTEM_PROMPT
+        assert "dependency names that are only version tokens" in AIBOM_AGENT_SYSTEM_PROMPT
+
+    def test_dependency_prompt_prefers_package_identifier_from_context(self) -> None:
+        assert "prefer the package identifier from the file context" in AIBOM_AGENT_SYSTEM_PROMPT
+        assert "fuzzywuzzy" in AIBOM_AGENT_SYSTEM_PROMPT
+
+    def test_embedding_prompt_rejects_helper_and_template_false_positives(self) -> None:
+        prompt = _normalized_aibom_prompt()
+        assert "storage paths, file templates, copy jobs, and helper functions are not embedding assets" in prompt
+        assert "s3 key templates" in prompt
+        assert "class name alone is not enough to confirm an embedding" in prompt
+
+    def test_cache_replay_prompt_preserves_validated_relationships(self) -> None:
+        prompt = _normalized_aibom_prompt()
+        assert "treat replayed/cache-restored findings the same way you would treat fresh reasoning" in prompt
+        assert "preserve it" in prompt
+        assert "validated cross-component links" in prompt
+
+    def test_cache_replay_prompt_rejects_only_spurious_extras(self) -> None:
+        prompt = _normalized_aibom_prompt()
+        assert "partial-cache results contain relationships or risk findings that conflict with the current code context" in prompt
+        assert "reject only the spurious extras" in prompt
+        assert "do not silently drop validated cross-component links" in prompt
+
+    def test_dependency_prompt_rejects_generic_non_ai_packages(self) -> None:
+        prompt = _normalized_aibom_prompt()
+        assert "requests" in prompt
+        assert "lodash" in prompt
+        assert "github.com/google/uuid" in prompt
+        assert "generic infra, db, telemetry, auth, test, or utility packages" in prompt
+
+    def test_prompt_distinguishes_remove_vs_reclassify(self) -> None:
+        prompt = _normalized_aibom_prompt()
+        assert "use `remove_components` when the row is not an ai asset at all" in prompt
+        assert "use `reclassify_components` when the row is ai-relevant but typed incorrectly" in prompt
+        assert "do not leave a wrong type in `enriched_components` without a matching `reclassify_components` entry" in prompt
+
+    def test_prompt_rejects_prompt_plumbing_non_ai_secrets_and_metric_constants(self) -> None:
+        prompt = _normalized_aibom_prompt()
+        assert "load_prompt" in prompt
+        assert "all_messages" in prompt
+        assert "dialog" in prompt
+        assert "ld_api_key" in prompt
+        assert "guardrail_input_token_count" in prompt
+
+    def test_prompt_rejects_generic_helper_prompt_kwargs(self) -> None:
+        prompt = _normalized_aibom_prompt()
+        assert "render_prompt(prompt=...)" in prompt
+        assert "requestbuilder.create(messages=payload)" in prompt
+        assert "real ai client or agent framework call" in prompt
+
+    def test_prompt_rejects_vector_db_files_and_test_only_agents(self) -> None:
+        prompt = _normalized_aibom_prompt()
+        assert "data_level0.bin" in prompt
+        assert "link_lists.bin" in prompt
+        assert "fakeagentrouter" in prompt
+        assert "testagentloop" in prompt
+
+    def test_prompt_rejects_kb_method_helper_matches_without_store_evidence(self) -> None:
+        prompt = _normalized_aibom_prompt()
+        assert "create_store_adapter" in prompt
+        assert "build_index_client" in prompt
+        assert "kb method matches are usually operations, not assets" in prompt
+        assert "concrete store/client instance, endpoint, or persisted asset identifier" in prompt
+
+    def test_prompt_handles_conflicting_vector_backend_selectors(self) -> None:
+        prompt = _normalized_aibom_prompt()
+        assert "vector_db_type" in prompt
+        assert "weaviate_endpoint" in prompt
+        assert "explicit backend selection beats provider-name hints" in prompt
+        assert "treat the row as ambiguous" in prompt
+
+    def test_prompt_preserves_deployment_ids_without_inventing_canonical_models(self) -> None:
+        prompt = _normalized_aibom_prompt()
+        assert "prod-chat-gpt4o" in prompt
+        assert "embed-prod-westus" in prompt
+        assert "do not invent a canonical public model name without supporting evidence" in prompt

--- a/aibom/tests/test_asset_category_detection.py
+++ b/aibom/tests/test_asset_category_detection.py
@@ -90,6 +90,50 @@ class TestEmbeddingImportDetection:
         assert len(emb_comps) >= 1
         assert all(c.component_type != AIComponentType.MODEL for c in comps if "Embed" in c.name)
 
+    def test_embedding_helper_function_import_is_not_detected(self, tmp_path: Path):
+        (tmp_path / "helpers.py").write_text(
+            "from storage_helpers import get_embeddings_archive_path\n"
+            "\n"
+            "def build_path() -> str:\n"
+            "    return get_embeddings_archive_path('foo', '1.0')\n"
+        )
+        from aibom.cst_parser import parse_source_code
+        from aibom.scanners.kb_enrichment_scanner import _detect_import_based_assets
+
+        source = (tmp_path / "helpers.py").read_text()
+        result = parse_source_code(str(tmp_path / "helpers.py"), source)
+        comps = _detect_import_based_assets(result)
+        assert comps == []
+
+    def test_embedding_constant_import_is_not_detected(self, tmp_path: Path):
+        (tmp_path / "constants_user.py").write_text(
+            "from storage_constants import EMBEDDINGS_ARCHIVE_TEMPLATE\n"
+            "\n"
+            "def build_key(product_name: str, version: str) -> str:\n"
+            "    return EMBEDDINGS_ARCHIVE_TEMPLATE.format(product_name=product_name, version=version)\n"
+        )
+        from aibom.cst_parser import parse_source_code
+        from aibom.scanners.kb_enrichment_scanner import _detect_import_based_assets
+
+        source = (tmp_path / "constants_user.py").read_text()
+        result = parse_source_code(str(tmp_path / "constants_user.py"), source)
+        comps = _detect_import_based_assets(result)
+        assert comps == []
+
+    def test_copy_embeddings_activity_is_not_suggestive_embedding(self, tmp_path: Path):
+        emb_dir = tmp_path / "etl" / "embeddings"
+        emb_dir.mkdir(parents=True)
+        activity = emb_dir / "copy.py"
+        activity.write_text(
+            "from base_activity import BaseActivity\n"
+            "\n"
+            "copy_job = CopyEmbeddingsArchiveToBucket(source_bucket='dev-bucket')\n"
+        )
+        from aibom.scanners.kb_enrichment_scanner import _emit_suggestive_candidates
+
+        comps = _emit_suggestive_candidates(activity, activity.read_text())
+        assert comps == []
+
 
 # ---------------------------------------------------------------------------
 # Gap 2: MCP Client detection
@@ -155,13 +199,13 @@ class TestGuardrailDetection:
         gr = [c for c in comps if "llm-guard" in c.name.lower()]
         assert len(gr) >= 1
 
-    def test_cisco_aidefense_sdk_in_requirements(self, tmp_path: Path):
-        (tmp_path / "requirements.txt").write_text("cisco-aidefense-sdk==1.0.0\n")
+    def test_rebuff_in_requirements(self, tmp_path: Path):
+        (tmp_path / "requirements.txt").write_text("rebuff==0.1.0\n")
         scanner = DependencyScanner()
         ctx = ScanContext(paths=[str(tmp_path)])
         comps, _ = scanner.scan(ctx)
-        cisco = [c for c in comps if "cisco-aidefense" in c.name.lower()]
-        assert len(cisco) >= 1
+        rebuff = [c for c in comps if "rebuff" in c.name.lower()]
+        assert len(rebuff) >= 1
 
     def test_guardrail_import_detected(self, tmp_path: Path):
         (tmp_path / "guard.py").write_text(

--- a/aibom/tests/test_cli_basic.py
+++ b/aibom/tests/test_cli_basic.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from aibom.cli import app
+from aibom.scan_pipeline import PipelineResult
 
 runner = CliRunner()
 
@@ -27,6 +28,51 @@ def test_analyze_rejects_legacy_ui_output_format():
     result = runner.invoke(app, ["analyze", "src", "--output-format", "ui"])
     assert result.exit_code != 0
     assert "Invalid output format" in result.output
+
+
+def test_analyze_defaults_cache_root_for_scan_and_agentic(tmp_path):
+    source_dir = tmp_path / "repo"
+    source_dir.mkdir()
+    (source_dir / "app.py").write_text("print('hello')\n", encoding="utf-8")
+    report = tmp_path / "report.json"
+    shared_root = tmp_path / "shared-cache"
+    seen: dict[str, object] = {}
+
+    def fake_pipeline_run(self):
+        seen["agentic_cache_dir"] = self.agentic_cache_dir
+        return PipelineResult(
+            components=[],
+            relationships=[],
+            agentic_risk_flags=[],
+            agentic_candidate_count=0,
+            external_deps=[],
+            timings=[],
+            total_elapsed_s=0.0,
+        )
+
+    with patch("aibom.cli.ensure_llm_runtime_available"):
+        with patch("aibom.cli.resolve_cache_root", return_value=shared_root):
+            with patch("aibom.scan_cache.load_cached", return_value=None) as mock_load:
+                with patch("aibom.scan_cache.save_cached") as mock_save:
+                    with patch("aibom.scan_pipeline.ScanPipeline.run", fake_pipeline_run):
+                        result = runner.invoke(
+                            app,
+                            [
+                                "analyze",
+                                str(source_dir),
+                                "--output-format",
+                                "json",
+                                "--output-file",
+                                str(report),
+                                "--llm-model",
+                                "test-model",
+                            ],
+                        )
+
+    assert result.exit_code == 0
+    assert mock_load.call_args.args[0] == shared_root / "scan"
+    assert mock_save.call_args.args[0] == shared_root / "scan"
+    assert seen["agentic_cache_dir"] == shared_root / "agentic"
 
 
 @patch("aibom.multi_repo.is_git_url", return_value=True)

--- a/aibom/tests/test_cli_basic.py
+++ b/aibom/tests/test_cli_basic.py
@@ -75,9 +75,10 @@ def test_analyze_defaults_cache_root_for_scan_and_agentic(tmp_path):
     assert seen["agentic_cache_dir"] == shared_root / "agentic"
 
 
+@patch("aibom.cli.ensure_llm_runtime_available", return_value=None)
 @patch("aibom.multi_repo.is_git_url", return_value=True)
 @patch("aibom.multi_repo.ClonedRepo")
-def test_analyze_records_clone_failures_in_json_output(mock_cloned_repo, _mock_is_git_url, tmp_path):
+def test_analyze_records_clone_failures_in_json_output(mock_cloned_repo, _mock_is_git_url, _mock_preflight, tmp_path):
     report = tmp_path / "report.json"
     mock_cloned_repo.return_value.__enter__.side_effect = RuntimeError("network down")
 

--- a/aibom/tests/test_cli_cache.py
+++ b/aibom/tests/test_cli_cache.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from aibom.cli import app
+from aibom.models import AIComponent, AIComponentType, ScanResult, SourceResult
+from aibom.scan_cache import save_cached
+
+runner = CliRunner()
+
+
+def test_cache_list_defaults_to_scan_type_under_root(tmp_path: Path):
+    save_cached(
+        tmp_path / "scan",
+        "scan-key-1234567890abcdef",
+        {
+            "_v2": True,
+            "components": [],
+            "relationships": [],
+            "_agentic_risk_flags": [],
+            "_agentic_candidate_count": 0,
+        },
+    )
+
+    result = runner.invoke(app, ["cache", "list", "--cache-dir", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "scan-key-12345678" in result.output
+
+
+def test_cache_list_supports_agentic_type(tmp_path: Path):
+    cache_file = tmp_path / "agentic" / "tier_abc123.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(
+        json.dumps(
+            {
+                "_tier_cache_version": 1,
+                "tier_enriched": [],
+                "tier_new": [],
+                "tier_rels": [],
+                "tier_flags": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["cache", "list", "--type", "agentic", "--cache-dir", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    assert "tier" in result.output.lower()
+
+
+def test_cache_get_scan_entry_by_prefix(tmp_path: Path):
+    key = "scan-key-1234567890abcdef"
+    save_cached(
+        tmp_path / "scan",
+        key,
+        {
+            "_v2": True,
+            "components": [{"name": "router_agent", "component_type": "agent"}],
+            "relationships": [],
+            "_agentic_risk_flags": [],
+            "_agentic_candidate_count": 0,
+        },
+    )
+
+    result = runner.invoke(
+        app,
+        ["cache", "get", "scan", "scan-key-1234", "--cache-dir", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    assert key in result.output
+    assert "router_agent" in result.output
+
+
+def test_cache_get_scan_prefix_ambiguity_fails(tmp_path: Path):
+    for key in ("shared-prefix-aaa111", "shared-prefix-bbb222"):
+        save_cached(
+            tmp_path / "scan",
+            key,
+            {
+                "_v2": True,
+                "components": [],
+                "relationships": [],
+                "_agentic_risk_flags": [],
+                "_agentic_candidate_count": 0,
+            },
+        )
+
+    result = runner.invoke(
+        app,
+        ["cache", "get", "scan", "shared-prefix", "--cache-dir", str(tmp_path)],
+    )
+
+    assert result.exit_code == 1
+    assert "ambiguous" in result.output.lower()
+
+
+def test_cache_get_org_entry_by_repo_path_and_sha(tmp_path: Path):
+    repo_path = tmp_path / "repos" / "service-a"
+    repo_path.mkdir(parents=True, exist_ok=True)
+    sha = "deadbeef"
+
+    from aibom.incremental import _repo_bucket_key
+
+    cache_file = tmp_path / "org" / _repo_bucket_key(str(repo_path)) / f"{sha}.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(
+        json.dumps(
+            ScanResult(
+                metadata={"run_id": "run-1"},
+                sources=[
+                    SourceResult(
+                        path=str(repo_path),
+                        components=[
+                            AIComponent(
+                                name="router_agent",
+                                component_type=AIComponentType.AGENT,
+                                file_path=str(repo_path / "app.py"),
+                                line_number=12,
+                            )
+                        ],
+                        relationships=[],
+                    )
+                ],
+                errors=[],
+            ).model_dump(mode="json")
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "cache",
+            "get",
+            "org",
+            str(repo_path),
+            "--sha",
+            sha,
+            "--cache-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert str(repo_path) in result.output
+    assert sha in result.output
+
+
+def test_cache_get_model_entry(tmp_path: Path):
+    cache_file = tmp_path / "model" / "model_catalog.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(
+        json.dumps(
+            {
+                "_ts": time.time(),
+                "models": {
+                    "gpt-5.4": {"provider": "openai", "source": "model_catalog"}
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["cache", "get", "model", "model_catalog.json", "--cache-dir", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    assert "model_catalog.json" in result.output
+    assert "gpt-5.4" in result.output
+
+
+def test_cache_get_package_entry(tmp_path: Path):
+    cache_file = tmp_path / "packages" / "pypi" / "openai.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(
+        json.dumps({"name": "openai", "summary": "OpenAI SDK"}),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["cache", "get", "packages", "pypi/openai", "--cache-dir", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    assert "pypi/openai" in result.output
+    assert "OpenAI SDK" in result.output

--- a/aibom/tests/test_cli_report.py
+++ b/aibom/tests/test_cli_report.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from aibom.cli import app
+from aibom.models import AIComponent, AIComponentType, RiskScore, ScanResult, SourceResult
+from aibom.reporters.json_reporter import JsonReporter
+
+runner = CliRunner()
+
+
+def _write_report(path: Path, *, include_version: bool = True) -> dict:
+    result = ScanResult(
+        metadata={
+            "run_id": "run-123",
+            "analyzer_version": "1.2.3",
+            "completed_at": "2026-04-11T12:00:00Z",
+        },
+        sources=[
+            SourceResult(
+                path="/repo/service-a",
+                components=[
+                    AIComponent(
+                        name="router_agent",
+                        component_type=AIComponentType.AGENT,
+                        file_path="/repo/service-a/app.py",
+                        line_number=12,
+                    )
+                ],
+                relationships=[],
+            )
+        ],
+        risk=RiskScore(),
+        errors=[],
+    )
+    buf = StringIO()
+    JsonReporter().render(result, buf)
+    data = json.loads(buf.getvalue())
+    if not include_version:
+        data["aibom_analysis"]["metadata"].pop("report_schema_version", None)
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return data
+
+
+def test_report_root_compatibility_renders_report(tmp_path: Path):
+    report_file = tmp_path / "report.json"
+    _write_report(report_file)
+
+    result = runner.invoke(app, ["report", str(report_file)])
+
+    assert result.exit_code == 0
+    assert "Report Summary" in result.output
+
+
+def test_report_show_renders_report(tmp_path: Path):
+    report_file = tmp_path / "report.json"
+    _write_report(report_file)
+
+    result = runner.invoke(app, ["report", "show", str(report_file)])
+
+    assert result.exit_code == 0
+    assert "Report Summary" in result.output
+
+
+@patch("aibom.cli.post_report_with_retries")
+def test_report_upload_posts_submission_payload(mock_post, tmp_path: Path):
+    report_file = tmp_path / "report.json"
+    _write_report(report_file)
+
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            "upload",
+            str(report_file),
+            "--format",
+            "json",
+            "--post-url",
+            "https://mgmt.example.test/upload",
+            "--ai-defense-api-key",
+            "tenant-key",
+        ],
+    )
+
+    assert result.exit_code == 0
+    mock_post.assert_called_once()
+    payload = mock_post.call_args.args[1]
+    assert payload["run_id"] == "run-123"
+    assert payload["source_kind"] == "SOURCE_KIND_LOCAL_PATH"
+    assert payload["sources"] == [{"name": "service-a", "path": "/repo/service-a"}]
+
+
+@patch("aibom.cli.post_report_with_retries")
+def test_report_upload_accepts_unversioned_json_with_warning(mock_post, tmp_path: Path):
+    report_file = tmp_path / "report.json"
+    _write_report(report_file, include_version=False)
+
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            "upload",
+            str(report_file),
+            "--format",
+            "json",
+            "--post-url",
+            "https://mgmt.example.test/upload",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "deprecated schema" in result.output.lower()
+    mock_post.assert_called_once()
+
+
+def test_report_upload_rejects_non_aibom_json(tmp_path: Path):
+    report_file = tmp_path / "report.json"
+    report_file.write_text(json.dumps({"not": "aibom"}), encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            "upload",
+            str(report_file),
+            "--format",
+            "json",
+            "--post-url",
+            "https://mgmt.example.test/upload",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "aibom_analysis" in result.output

--- a/aibom/tests/test_config_scanner.py
+++ b/aibom/tests/test_config_scanner.py
@@ -43,6 +43,34 @@ class TestConfigScanner:
             "LLM_NAME",
         }
 
+    def test_env_embedding_model_is_embedding(self, tmp_path: Path) -> None:
+        env = "OPENAI_EMBEDDING_MODEL=text-embedding-3-large\n"
+        comps, _ = run_scanner(ConfigScanner, tmp_path, {".env": env})
+        assert any(
+            c.component_type == AIComponentType.EMBEDDING
+            and c.model_name == "text-embedding-3-large"
+            for c in comps
+        )
+        assert not any(
+            c.component_type == AIComponentType.MODEL
+            and c.model_name == "text-embedding-3-large"
+            for c in comps
+        )
+
+    def test_env_weaviate_endpoint_is_vector_store(self, tmp_path: Path) -> None:
+        env = "WEAVIATE_CLOUD_ENDPOINT=https://cluster.example.weaviate.cloud\n"
+        comps, _ = run_scanner(ConfigScanner, tmp_path, {".env": env})
+        assert any(
+            c.component_type == AIComponentType.VECTOR_STORE
+            and c.metadata.get("env_var") == "WEAVIATE_CLOUD_ENDPOINT"
+            for c in comps
+        )
+        assert not any(
+            c.component_type == AIComponentType.LLM_ENDPOINT
+            and c.metadata.get("env_var") == "WEAVIATE_CLOUD_ENDPOINT"
+            for c in comps
+        )
+
     def test_crewai_yaml_agents(self, tmp_path: Path) -> None:
         cfg = "agents:\n  - name: Researcher\n    role: analyst\n"
         comps, _ = run_scanner(ConfigScanner, tmp_path, {"crewai.yaml": cfg})

--- a/aibom/tests/test_dependency_scanner.py
+++ b/aibom/tests/test_dependency_scanner.py
@@ -54,6 +54,58 @@ class TestDependencyScanner:
         assert "openai" in names
         assert "anthropic" in names
 
+    def test_parse_poetry_dependencies_uses_key_not_version_value(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            DependencyScanner,
+            tmp_path,
+            {
+                "pyproject.toml": (
+                    "[tool.poetry]\n"
+                    'name = "demo"\n'
+                    'version = "0.1.0"\n'
+                    "\n"
+                    "[tool.poetry.dependencies]\n"
+                    'python = "^3.12"\n'
+                    'stub-nonai-one = "0.18.0"\n'
+                    'stub-nonai-two = "3.9.3"\n'
+                    'freeplay = "0.5.4"\n'
+                ),
+            },
+        )
+        by_name = {c.name: c for c in comps}
+        names = set(by_name)
+        assert "freeplay" in names
+        assert "stub-nonai-one" not in names
+        assert "stub-nonai-two" not in names
+        assert "0.18.0" not in names
+        assert "3.9.3" not in names
+        assert "0.5.4" not in names
+        assert by_name["freeplay"].metadata["version_spec"] == "0.5.4"
+        assert by_name["freeplay"].sdk_version == "0.5.4"
+
+    def test_parse_pyproject_ignores_bare_version_strings(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            DependencyScanner,
+            tmp_path,
+            {
+                "pyproject.toml": (
+                    "[tool.poetry]\n"
+                    'name = "demo"\n'
+                    'version = "0.1.0"\n'
+                    "\n"
+                    "[tool.poetry.dependencies]\n"
+                    'python = "^3.12"\n'
+                    '"0.18.0"\n'
+                    '"3.9.3"\n'
+                    'openai = "^1.99.9"\n'
+                ),
+            },
+        )
+        names = {c.name for c in comps}
+        assert "openai" in names
+        assert "0.18.0" not in names
+        assert "3.9.3" not in names
+
     def test_parse_go_mod_ai_packages(self, tmp_path: Path) -> None:
         comps, _ = run_scanner(
             DependencyScanner,
@@ -84,7 +136,7 @@ class TestDependencyScanner:
         names = {c.name for c in comps}
         assert "async-openai" in names
 
-    def test_emits_all_packages_with_known_ai_hint(self, tmp_path: Path) -> None:
+    def test_emits_only_ai_packages_from_mixed_manifests(self, tmp_path: Path) -> None:
         comps, _ = run_scanner(
             DependencyScanner,
             tmp_path,
@@ -94,9 +146,46 @@ class TestDependencyScanner:
             },
         )
         by_name = {c.name: c for c in comps}
-        assert "requests" in by_name
         assert "openai" in by_name
-        assert "lodash" in by_name
         assert by_name["openai"].metadata["known_ai_package"] is True
-        assert by_name["requests"].metadata["known_ai_package"] is False
-        assert by_name["lodash"].metadata["known_ai_package"] is False
+        assert "requests" not in by_name
+        assert "lodash" not in by_name
+
+    def test_emits_only_ai_packages_from_go_mod(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            DependencyScanner,
+            tmp_path,
+            {
+                "go.mod": (
+                    "module example.com/x\n"
+                    "go 1.22\n"
+                    "require (\n"
+                    "\tgithub.com/sashabaranov/go-openai v1.17.9\n"
+                    "\tgithub.com/google/uuid v1.6.0\n"
+                    ")\n"
+                ),
+            },
+        )
+        names = {c.name for c in comps}
+        assert "github.com/sashabaranov/go-openai" in names
+        assert "github.com/google/uuid" not in names
+
+    def test_recognizes_additional_public_ai_packages(self, tmp_path: Path) -> None:
+        comps, _ = run_scanner(
+            DependencyScanner,
+            tmp_path,
+            {
+                "pyproject.toml": (
+                    "[project.dependencies]\n"
+                    '"guardrails>=0.5"\n'
+                    '"google-genai>=1.0"\n'
+                    '"openai-agents>=0.2"\n'
+                    '"llmetry>=0.1"\n'
+                ),
+            },
+        )
+        names = {c.name for c in comps}
+        assert "guardrails" in names
+        assert "google-genai" in names
+        assert "openai-agents" in names
+        assert "llmetry" in names

--- a/aibom/tests/test_deployment_detector.py
+++ b/aibom/tests/test_deployment_detector.py
@@ -62,6 +62,106 @@ data:
         assert any(c.model_name == "gpt-4o-mini" for c in models)
         assert any("vllm" in (c.metadata.get("image") or "").lower() for c in deps)
 
+    def test_helm_weaviate_endpoint_is_vector_store(self, tmp_path: Path) -> None:
+        yml = """env:
+  WEAVIATE:
+    CLOUD_ENDPOINT: https://cluster.example.weaviate.cloud
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"values.yaml": yml})
+        url = "https://cluster.example.weaviate.cloud"
+        assert any(
+            c.component_type == AIComponentType.VECTOR_STORE
+            and c.metadata.get("endpoint_url") == url
+            for c in comps
+        )
+        assert not any(
+            c.component_type == AIComponentType.LLM_ENDPOINT
+            and c.metadata.get("endpoint_url") == url
+            for c in comps
+        )
+
+    def test_helm_conflicting_vector_backend_requires_agentic_review(self, tmp_path: Path) -> None:
+        yml = """orchestrator:
+  env:
+    WEAVIATE:
+      WEAVIATE_ENDPOINT: http://vector.example.internal
+      VECTOR_DB_TYPE: chroma
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"values.yaml": yml})
+        matches = [c for c in comps if c.name == "env:WEAVIATE_ENDPOINT"]
+        assert len(matches) == 1
+        comp = matches[0]
+        assert comp.component_type == AIComponentType.VECTOR_STORE
+        assert comp.needs_agentic is True
+        assert comp.metadata.get("store_technology") == "chromadb"
+        assert "vector_db_type" in comp.agentic_hint.lower()
+        assert "weaviate_endpoint" in comp.agentic_hint.lower()
+
+    def test_helm_embedding_endpoint_and_engine_use_correct_types(self, tmp_path: Path) -> None:
+        yml = """env:
+  AZURE:
+    EMBEDDING:
+      LARGE3:
+        ENDPOINT: https://example.openai.azure.com/
+        ENGINE: text-embedding-3-large
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"values.yaml": yml})
+        endpoint_url = "https://example.openai.azure.com/"
+        assert any(
+            c.component_type == AIComponentType.MODEL_ENDPOINT
+            and c.metadata.get("endpoint_url") == endpoint_url
+            for c in comps
+        )
+        assert any(
+            c.component_type == AIComponentType.EMBEDDING
+            and c.model_name == "text-embedding-3-large"
+            for c in comps
+        )
+        assert not any(
+            c.component_type == AIComponentType.MODEL
+            and c.model_name == "text-embedding-3-large"
+            for c in comps
+        )
+
+    def test_helm_endpoint_with_sibling_engine_is_model_endpoint(self, tmp_path: Path) -> None:
+        yml = """env:
+  AZURE:
+    CHAT_SERVICE:
+      ENDPOINT: https://example.openai.azure.com/
+      ENGINE: chat-model-deployment
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"values.yaml": yml})
+        endpoint_url = "https://example.openai.azure.com/"
+        assert any(
+            c.component_type == AIComponentType.MODEL_ENDPOINT
+            and c.metadata.get("endpoint_url") == endpoint_url
+            for c in comps
+        )
+        assert not any(
+            c.component_type == AIComponentType.LLM_ENDPOINT
+            and c.metadata.get("endpoint_url") == endpoint_url
+            for c in comps
+        )
+
+    def test_helm_endpoint_with_sibling_model_name_is_model_endpoint(self, tmp_path: Path) -> None:
+        yml = """env:
+  CHAT_SERVICE:
+    ENDPOINT: https://example.openai.azure.com/
+    MODEL_NAME: assistant-model
+"""
+        comps, _ = run_scanner(DeploymentDetector, tmp_path, {"values.yaml": yml})
+        endpoint_url = "https://example.openai.azure.com/"
+        assert any(
+            c.component_type == AIComponentType.MODEL_ENDPOINT
+            and c.metadata.get("endpoint_url") == endpoint_url
+            for c in comps
+        )
+        assert not any(
+            c.component_type == AIComponentType.LLM_ENDPOINT
+            and c.metadata.get("endpoint_url") == endpoint_url
+            for c in comps
+        )
+
     def test_detects_training_job(self, tmp_path: Path) -> None:
         yml = """apiVersion: batch/v1
 kind: Job

--- a/aibom/tests/test_env_var_resolver.py
+++ b/aibom/tests/test_env_var_resolver.py
@@ -53,6 +53,24 @@ class TestPythonEnvVarExtraction:
         assert comps[0].metadata["env"] == "AZURE_ENDPOINT"
         assert comps[0].metadata["env_context"] == "endpoint_kwarg"
 
+    def test_embedding_endpoint_kwarg_is_model_endpoint(self, tmp_path: Path) -> None:
+        (tmp_path / "svc.py").write_text(
+            'client = AzureOpenAI(azure_endpoint=os.environ.get("AZURE_EMBEDDING_ENDPOINT"))\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].component_type == AIComponentType.MODEL_ENDPOINT
+
+    def test_vector_store_endpoint_kwarg_is_vector_store(self, tmp_path: Path) -> None:
+        (tmp_path / "svc.py").write_text(
+            'client = Client(endpoint=os.getenv("WEAVIATE_ENDPOINT"))\n'
+        )
+        scanner = EnvVarResolver()
+        comps, _ = scanner.scan(_make_ctx(tmp_path))
+        assert len(comps) == 1
+        assert comps[0].component_type == AIComponentType.VECTOR_STORE
+
     def test_model_name_assignment(self, tmp_path: Path) -> None:
         (tmp_path / "run.py").write_text(
             'model_name = os.getenv("MODEL_ID")\n'

--- a/aibom/tests/test_finding_annotations.py
+++ b/aibom/tests/test_finding_annotations.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from aibom.finding_annotations import annotate_findings
+from aibom.models import (
+    AIComponent,
+    AIComponentType,
+    ComponentRelationship,
+    DecisionAnnotation,
+    RelationshipType,
+)
+from aibom.models.scan import RiskFlag
+
+
+def test_annotate_findings_adds_default_annotations(tmp_path) -> None:
+    source_file = tmp_path / "app.py"
+    source_file.write_text("agent = RouterAgent()\nagent.run(task)\n", encoding="utf-8")
+
+    component = AIComponent(
+        name="router_agent",
+        component_type=AIComponentType.AGENT,
+        file_path=str(source_file),
+        line_number=1,
+        instance_id="agent-1",
+    )
+    model = AIComponent(
+        name="gpt-4o",
+        component_type=AIComponentType.MODEL,
+        file_path=str(source_file),
+        line_number=2,
+        instance_id="model-1",
+    )
+    relationship = ComponentRelationship(
+        source_instance_id=component.instance_id,
+        target_instance_id=model.instance_id,
+        source_name=component.name,
+        target_name=model.name,
+        relationship_type=RelationshipType.USES_MODEL,
+        source_type=component.component_type,
+        target_type=model.component_type,
+    )
+    risk_flag = RiskFlag(
+        flag="sensitive_prompt",
+        severity="medium",
+        weight=5,
+        description="Prompt content should be reviewed before deployment.",
+        file_path=str(source_file),
+        line_number=2,
+    )
+
+    components, relationships, risk_flags = annotate_findings(
+        [component, model],
+        [relationship],
+        [risk_flag],
+        include_code_snippets=False,
+    )
+
+    assert all(component.decision_annotation is not None for component in components)
+    assert relationships[0].decision_annotation is not None
+    assert relationships[0].decision_annotation.decision == "derived"
+    assert risk_flags[0].decision_annotation is not None
+    assert risk_flags[0].decision_annotation.decision == "flagged"
+    assert risk_flags[0].decision_annotation.code_snippet is None
+
+
+def test_annotate_findings_hydrates_snippets_when_enabled(tmp_path) -> None:
+    source_file = tmp_path / "flow.py"
+    source_file.write_text(
+        "client = OpenAI()\nresponse = client.responses.create()\n",
+        encoding="utf-8",
+    )
+    component = AIComponent(
+        name="openai_client",
+        component_type=AIComponentType.LLM_ENDPOINT,
+        file_path=str(source_file),
+        line_number=1,
+        instance_id="endpoint-1",
+        decision_annotation=DecisionAnnotation(
+            decision="confirmed",
+            justification="Client creation is present in the request path.",
+            evidence_kinds=["code_context"],
+            evidence_locations=[],
+        ),
+    )
+
+    components, _, _ = annotate_findings(
+        [component],
+        [],
+        [],
+        include_code_snippets=True,
+    )
+
+    assert components[0].decision_annotation is not None
+    assert components[0].decision_annotation.code_snippet is not None
+    assert "client = OpenAI()" in components[0].decision_annotation.code_snippet.text

--- a/aibom/tests/test_finding_annotations.py
+++ b/aibom/tests/test_finding_annotations.py
@@ -92,3 +92,41 @@ def test_annotate_findings_hydrates_snippets_when_enabled(tmp_path) -> None:
     assert components[0].decision_annotation is not None
     assert components[0].decision_annotation.code_snippet is not None
     assert "client = OpenAI()" in components[0].decision_annotation.code_snippet.text
+
+
+def test_snippet_blocked_for_out_of_repo_path(tmp_path) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    in_repo = repo_dir / "app.py"
+    in_repo.write_text("agent = RouterAgent()\n", encoding="utf-8")
+
+    outside = tmp_path / "secret.txt"
+    outside.write_text("TOP SECRET DATA\n", encoding="utf-8")
+
+    legit = AIComponent(
+        name="router",
+        component_type=AIComponentType.AGENT,
+        file_path=str(in_repo),
+        line_number=1,
+        instance_id="a-1",
+    )
+    hostile = AIComponent(
+        name="exfil",
+        component_type=AIComponentType.AGENT,
+        file_path=str(outside),
+        line_number=1,
+        instance_id="a-2",
+    )
+
+    components, _, _ = annotate_findings(
+        [legit, hostile],
+        [],
+        [],
+        include_code_snippets=True,
+        allowed_roots=[str(repo_dir)],
+    )
+
+    assert components[0].decision_annotation.code_snippet is not None
+    assert "RouterAgent" in components[0].decision_annotation.code_snippet.text
+
+    assert components[1].decision_annotation.code_snippet is None

--- a/aibom/tests/test_incremental.py
+++ b/aibom/tests/test_incremental.py
@@ -114,6 +114,37 @@ def test_non_git_directory_skips_caching(tmp_path) -> None:
     assert sr.sources[0].components[0].name == "live"
 
 
+def test_corrupt_primary_falls_through_to_fallback(tmp_path) -> None:
+    repo = tmp_path / "r"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    (repo / "f.txt").write_text("1", encoding="utf-8")
+    _git_commit(repo)
+
+    primary = tmp_path / "primary"
+    legacy = tmp_path / "legacy"
+    legacy_cache = OrgCache(base_dir=legacy)
+    legacy_cache.store(str(repo.resolve()), _make_scan("from-legacy"))
+
+    sha = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repo, text=True,
+    ).strip()
+
+    corrupt_dir = primary / OrgCache(base_dir=primary)._repo_dir(
+        str(repo.resolve()), primary
+    ).relative_to(primary)
+    corrupt_dir.mkdir(parents=True, exist_ok=True)
+    (corrupt_dir / f"{sha}.json").write_text("{BAD", encoding="utf-8")
+
+    cache = OrgCache.__new__(OrgCache)
+    cache.base_dir = primary
+    cache.fallback_dirs = [legacy]
+
+    result = cache.get_cached(str(repo.resolve()))
+    assert result is not None
+    assert result.sources[0].components[0].name == "from-legacy"
+
+
 def test_incremental_scan_cache_hit(tmp_path) -> None:
     repo = tmp_path / "r"
     repo.mkdir()

--- a/aibom/tests/test_kb_enrichment_scanner.py
+++ b/aibom/tests/test_kb_enrichment_scanner.py
@@ -30,6 +30,7 @@ from unittest.mock import patch
 
 import pytest
 
+from aibom.cst_parser import parse_source_code
 from aibom.models import AIComponentType, DetectionSource, ScanContext
 from aibom.scanners.kb_enrichment_scanner import (
     ALLOWED_CONCEPTS,
@@ -42,6 +43,7 @@ from aibom.scanners.kb_enrichment_scanner import (
     _frameworks_related,
     _has_suggestive_signal,
     _match_observation_rich,
+    _process_file_with_cache,
     _resolve_kb_path,
 )
 
@@ -156,6 +158,54 @@ class TestMatchObservationRich:
         assert result.partial_kb_id == "langchain_community.llms.openai.OpenAI"
         assert result.partial_kb_framework == "langchain_community"
         assert result.obs_module == "models"
+
+
+class TestMethodLabelFiltering:
+    def test_kb_method_match_does_not_emit_vector_store_asset(self, tmp_path: Path):
+        helper = tmp_path / "helper.py"
+        helper.write_text(
+            "def create_store_adapter(config):\n"
+            "    return config\n"
+            "\n"
+            "store = create_store_adapter(config={})\n"
+        )
+
+        result = parse_source_code(str(helper), helper.read_text())
+        kb_entries = {
+            "langchain_community.utilities.fake.StoreFactory.create_store_adapter": {
+                "id": "langchain_community.utilities.fake.StoreFactory.create_store_adapter",
+                "concept": "datastore",
+                "framework": "langchain_community",
+                "label": "method",
+            },
+        }
+
+        comps = _process_file_with_cache(result, kb_entries)
+        assert [c for c in comps if c.component_type == AIComponentType.VECTOR_STORE] == []
+
+    def test_kb_class_match_still_emits_vector_store_asset(self, tmp_path: Path):
+        helper = tmp_path / "store.py"
+        helper.write_text(
+            "class FakeVectorStore:\n"
+            "    pass\n"
+            "\n"
+            "store = FakeVectorStore()\n"
+        )
+
+        result = parse_source_code(str(helper), helper.read_text())
+        kb_entries = {
+            "langchain_community.vectorstores.fake.FakeVectorStore": {
+                "id": "langchain_community.vectorstores.fake.FakeVectorStore",
+                "concept": "datastore",
+                "framework": "langchain_community",
+                "label": "class",
+            },
+        }
+
+        comps = _process_file_with_cache(result, kb_entries)
+        stores = [c for c in comps if c.component_type == AIComponentType.VECTOR_STORE]
+        assert len(stores) == 1
+        assert stores[0].name == "FakeVectorStore"
 
     def test_partial_match_wrapper_library(self):
         """Wrapper class that matches KB leaf via class segment extraction."""
@@ -497,10 +547,11 @@ class TestEmitSuggestiveCandidates:
     def test_emits_for_indicative_class(self, tmp_path: Path):
         f = tmp_path / "models" / "chat.py"
         f.parent.mkdir()
-        source = "client = OpenAIModel(api_key='x')\n"
+        source = "router = RouterAgent(api_key='x')\n"
         f.write_text(source)
         candidates = _emit_suggestive_candidates(f, source)
         assert len(candidates) == 1
+        assert candidates[0].component_type == AIComponentType.AGENT
         assert candidates[0].needs_agentic is True
         assert candidates[0].confidence == 0.2
         assert "suggestive_signal" in candidates[0].metadata
@@ -525,8 +576,8 @@ class TestEmitSuggestiveCandidates:
         f = tmp_path / "agents" / "multi.py"
         f.parent.mkdir()
         source = (
-            "llm = ChatModel()\n"
-            "emb = EmbeddingClient()\n"
+            "router = RouterAgent(api_key='x')\n"
+            "search = SearchTool(name='docs')\n"
         )
         f.write_text(source)
         candidates = _emit_suggestive_candidates(f, source)

--- a/aibom/tests/test_llm_client.py
+++ b/aibom/tests/test_llm_client.py
@@ -95,11 +95,18 @@ class TestLLMClient(unittest.TestCase):
         self.assertEqual(result, "tool description here")
 
 
+@patch(
+    "aibom.llm_factory.ensure_llm_runtime_available",
+    side_effect=lambda model_string, *, provider=None: (
+        __import__("aibom.llm_factory", fromlist=["resolve_provider"])
+        .resolve_provider(model_string, provider)
+    ),
+)
 class TestBuildChatModel(unittest.TestCase):
     """Tests that _build_chat_model delegates correctly to llm_factory."""
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_plain_model(self, mock_init):
+    def test_plain_model(self, mock_init, _mock_preflight):
         mock_init.return_value = MagicMock()
         _build_chat_model({"model": "gpt-4o", "api_key": "k"})
         _, kwargs = mock_init.call_args
@@ -107,7 +114,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertEqual(kwargs["api_key"], "k")
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_provider_prefix_bedrock(self, mock_init):
+    def test_provider_prefix_bedrock(self, mock_init, _mock_preflight):
         mock_init.return_value = MagicMock()
         _build_chat_model({"model": "bedrock/anthropic.claude-3-5-sonnet"})
         args, kwargs = mock_init.call_args
@@ -115,7 +122,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertEqual(kwargs["model_provider"], "bedrock")
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_explicit_provider_in_config(self, mock_init):
+    def test_explicit_provider_in_config(self, mock_init, _mock_preflight):
         """provider key in config is forwarded to build_chat_model."""
         mock_init.return_value = MagicMock()
         _build_chat_model({
@@ -127,7 +134,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertEqual(kwargs["model_provider"], "bedrock")
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_azure_endpoint_routing(self, mock_init):
+    def test_azure_endpoint_routing(self, mock_init, _mock_preflight):
         mock_init.return_value = MagicMock()
         _build_chat_model({
             "model": "gpt-4o",
@@ -143,7 +150,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertNotIn("base_url", kwargs)
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_base_url_passthrough(self, mock_init):
+    def test_base_url_passthrough(self, mock_init, _mock_preflight):
         mock_init.return_value = MagicMock()
         _build_chat_model({
             "model": "llama3",
@@ -154,7 +161,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertEqual(kwargs["base_url"], "http://localhost:11434")
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_max_tokens_100(self, mock_init):
+    def test_max_tokens_100(self, mock_init, _mock_preflight):
         """llm_client sets max_tokens=100 for short extraction prompts."""
         mock_init.return_value = MagicMock()
         _build_chat_model({"model": "gpt-4o"})

--- a/aibom/tests/test_llm_factory.py
+++ b/aibom/tests/test_llm_factory.py
@@ -18,11 +18,18 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 
+@patch(
+    "aibom.llm_factory.ensure_llm_runtime_available",
+    side_effect=lambda model_string, *, provider=None: (
+        __import__("aibom.llm_factory", fromlist=["resolve_provider"])
+        .resolve_provider(model_string, provider)
+    ),
+)
 class TestBuildChatModel(unittest.TestCase):
     """Tests for ``aibom.llm_factory.build_chat_model``."""
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_plain_model_no_provider(self, mock_init):
+    def test_plain_model_no_provider(self, mock_init, _mock_preflight):
         """LangChain infers provider when neither flag nor prefix is given."""
         from aibom.llm_factory import build_chat_model
 
@@ -34,7 +41,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertEqual(kwargs["api_key"], "k")
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_explicit_provider_flag(self, mock_init):
+    def test_explicit_provider_flag(self, mock_init, _mock_preflight):
         """--llm-provider bedrock sets model_provider without touching model_string."""
         from aibom.llm_factory import build_chat_model
 
@@ -48,7 +55,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertEqual(kwargs["model_provider"], "bedrock")
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_slash_prefix_backward_compat(self, mock_init):
+    def test_slash_prefix_backward_compat(self, mock_init, _mock_preflight):
         """Legacy provider/model slash convention still works."""
         from aibom.llm_factory import build_chat_model
 
@@ -59,7 +66,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertEqual(kwargs["model_provider"], "bedrock")
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_explicit_provider_overrides_slash(self, mock_init):
+    def test_explicit_provider_overrides_slash(self, mock_init, _mock_preflight):
         """--llm-provider takes precedence over a slash in the model string."""
         from aibom.llm_factory import build_chat_model
 
@@ -73,7 +80,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertEqual(kwargs["model_provider"], "bedrock_converse")
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_azure_endpoint_routing(self, mock_init):
+    def test_azure_endpoint_routing(self, mock_init, _mock_preflight):
         """azure_openai maps api_base to azure_endpoint, passes api_version."""
         from aibom.llm_factory import build_chat_model
 
@@ -92,7 +99,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertNotIn("base_url", kwargs)
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_base_url_for_non_azure(self, mock_init):
+    def test_base_url_for_non_azure(self, mock_init, _mock_preflight):
         """Non-azure providers get api_base mapped to base_url."""
         from aibom.llm_factory import build_chat_model
 
@@ -107,7 +114,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertNotIn("azure_endpoint", kwargs)
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_api_version_ignored_for_non_azure(self, mock_init):
+    def test_api_version_ignored_for_non_azure(self, mock_init, _mock_preflight):
         """api_version is only passed for azure_openai provider."""
         from aibom.llm_factory import build_chat_model
 
@@ -117,7 +124,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertNotIn("api_version", kwargs)
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_temperature_default(self, mock_init):
+    def test_temperature_default(self, mock_init, _mock_preflight):
         """Default temperature is 0.0."""
         from aibom.llm_factory import build_chat_model
 
@@ -127,7 +134,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertEqual(kwargs["temperature"], 0.0)
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_max_tokens_passed_when_set(self, mock_init):
+    def test_max_tokens_passed_when_set(self, mock_init, _mock_preflight):
         """max_tokens forwarded only when explicitly provided."""
         from aibom.llm_factory import build_chat_model
 
@@ -137,7 +144,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertEqual(kwargs["max_tokens"], 100)
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_max_tokens_omitted_when_none(self, mock_init):
+    def test_max_tokens_omitted_when_none(self, mock_init, _mock_preflight):
         """max_tokens not in kwargs when left as None."""
         from aibom.llm_factory import build_chat_model
 
@@ -147,7 +154,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertNotIn("max_tokens", kwargs)
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_rate_limiter_forwarded(self, mock_init):
+    def test_rate_limiter_forwarded(self, mock_init, _mock_preflight):
         """rate_limiter object is passed through to init_chat_model."""
         from aibom.llm_factory import build_chat_model
 
@@ -158,7 +165,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertIs(kwargs["rate_limiter"], limiter)
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_rate_limiter_omitted_when_none(self, mock_init):
+    def test_rate_limiter_omitted_when_none(self, mock_init, _mock_preflight):
         """rate_limiter not in kwargs when left as None."""
         from aibom.llm_factory import build_chat_model
 
@@ -168,7 +175,7 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertNotIn("rate_limiter", kwargs)
 
     @patch("aibom.llm_factory.init_chat_model")
-    def test_bedrock_model_without_slash(self, mock_init):
+    def test_bedrock_model_without_slash(self, mock_init, _mock_preflight):
         """Bedrock model ID without slash + explicit provider works."""
         from aibom.llm_factory import build_chat_model
 

--- a/aibom/tests/test_precision_recall.py
+++ b/aibom/tests/test_precision_recall.py
@@ -113,6 +113,56 @@ class TestPromptDetection:
         assert len(prompt_comps) >= 1
         assert prompt_comps[0].text == "You are a helpful assistant."
 
+    def test_resolves_ai_client_chain_for_prompt_kwargs(self, tmp_path: Path):
+        (tmp_path / "client.py").write_text(
+            "import openai\n"
+            "client = openai.OpenAI()\n"
+            'response = client.responses.create(instructions="Answer briefly.")\n'
+        )
+        from aibom.scanners.kb_enrichment_scanner import _detect_prompt_kwargs
+        from aibom.cst_parser import parse_source_code
+
+        source = (tmp_path / "client.py").read_text()
+        result = parse_source_code(str(tmp_path / "client.py"), source)
+        comps = _detect_prompt_kwargs(result)
+        prompt_comps = [c for c in comps if c.component_type == AIComponentType.PROMPT]
+        assert len(prompt_comps) == 1
+        assert prompt_comps[0].text == "Answer briefly."
+        assert prompt_comps[0].metadata["enclosing_call"] == "openai.OpenAI.responses.create"
+
+    def test_ignores_prompt_kwargs_on_non_ai_helpers(self, tmp_path: Path):
+        (tmp_path / "helpers.py").write_text(
+            "def render_prompt(prompt: str):\n"
+            "    return prompt\n"
+            "\n"
+            'render_prompt(prompt="local helper text")\n'
+        )
+        from aibom.scanners.kb_enrichment_scanner import _detect_prompt_kwargs
+        from aibom.cst_parser import parse_source_code
+
+        source = (tmp_path / "helpers.py").read_text()
+        result = parse_source_code(str(tmp_path / "helpers.py"), source)
+        comps = _detect_prompt_kwargs(result)
+        assert [c for c in comps if c.component_type == AIComponentType.PROMPT] == []
+
+    def test_ignores_variable_messages_on_non_ai_methods(self, tmp_path: Path):
+        (tmp_path / "helpers.py").write_text(
+            "class RequestBuilder:\n"
+            "    def create(self, messages):\n"
+            "        return messages\n"
+            "\n"
+            "payload = ['status']\n"
+            "builder = RequestBuilder()\n"
+            "request = builder.create(messages=payload)\n"
+        )
+        from aibom.scanners.kb_enrichment_scanner import _detect_prompt_kwargs
+        from aibom.cst_parser import parse_source_code
+
+        source = (tmp_path / "helpers.py").read_text()
+        result = parse_source_code(str(tmp_path / "helpers.py"), source)
+        comps = _detect_prompt_kwargs(result)
+        assert [c for c in comps if c.component_type == AIComponentType.PROMPT] == []
+
 
 class TestEmbeddingDetection:
     """6.0d: Cross-repo embedding detection via suggestive-signal regex."""

--- a/aibom/tests/test_reporters.py
+++ b/aibom/tests/test_reporters.py
@@ -25,7 +25,10 @@ import pytest
 from aibom.models import (
     AIComponent,
     AIComponentType,
+    CodeSnippet,
     ComponentRelationship,
+    DecisionAnnotation,
+    EvidenceLocation,
     RelationshipType,
     RiskFlag,
     RiskScore,
@@ -186,6 +189,7 @@ def test_json_reporter_render(sample_scan_result: ScanResult):
     analysis = data["aibom_analysis"]
     assert analysis["metadata"]["analyzer_version"] == "2.0.0-test"
     assert analysis["metadata"]["run_id"] == "run-test-001"
+    assert analysis["metadata"]["report_schema_version"] == "1"
     source_keys = set(analysis["sources"].keys())
     assert source_keys == {"alpha", "beta"}
     for src_path, src_data in analysis["sources"].items():
@@ -195,6 +199,49 @@ def test_json_reporter_render(sample_scan_result: ScanResult):
         assert len(comps["agent"]) == 1
         assert len(comps["tool"]) == 1
         assert "summary" in src_data
+
+
+def test_json_reporter_preserves_decision_annotations():
+    component = AIComponent(
+        name="router_agent",
+        component_type=AIComponentType.AGENT,
+        file_path="/proj/src/app.py",
+        line_number=12,
+        decision_annotation=DecisionAnnotation(
+            decision="confirmed",
+            justification="The code instantiates and invokes the agent in the request path.",
+            evidence_kinds=["code_context"],
+            evidence_locations=[
+                EvidenceLocation(
+                    file_path="/proj/src/app.py",
+                    start_line=12,
+                    end_line=18,
+                    role="primary",
+                )
+            ],
+            code_snippet=CodeSnippet(
+                file_path="/proj/src/app.py",
+                start_line=12,
+                end_line=14,
+                text="agent = RouterAgent()\nagent.run(task)\n",
+                truncated=False,
+            ),
+        ),
+    )
+    result = ScanResult(
+        metadata={"analyzer_version": "2.0.0-test", "run_id": "run-test-annotations"},
+        sources=[SourceResult(path="/proj/src", components=[component], relationships=[])],
+        risk=RiskScore(),
+    )
+
+    buf = StringIO()
+    JsonReporter().render(result, buf)
+    data = json.loads(buf.getvalue())
+
+    rendered = data["aibom_analysis"]["sources"]["src"]["components"]["agent"][0]
+    assert rendered["decision_annotation"]["decision"] == "confirmed"
+    assert rendered["decision_annotation"]["evidence_locations"][0]["role"] == "primary"
+    assert rendered["decision_annotation"]["code_snippet"]["truncated"] is False
 
 
 def test_json_reporter_disambiguates_colliding_source_names(sample_scan_result: ScanResult):

--- a/aibom/tests/test_scan_cache.py
+++ b/aibom/tests/test_scan_cache.py
@@ -85,3 +85,34 @@ class TestCacheInfo:
     def test_empty_returns_empty(self, tmp_path: Path) -> None:
         cd = tmp_path / "cache"
         assert cache_info(cd) == []
+
+
+class TestFallbackOnCorruptPrimary:
+    def test_corrupt_primary_falls_through_to_legacy(self, tmp_path: Path) -> None:
+        primary = tmp_path / "primary"
+        legacy = tmp_path / "legacy"
+        primary.mkdir(parents=True)
+        legacy.mkdir(parents=True)
+
+        save_cached(legacy, "abc", {"components": [{"name": "good"}]})
+
+        corrupt_file = primary / "abc.json"
+        corrupt_file.write_text("{INVALID JSON", encoding="utf-8")
+
+        result = load_cached(primary, "abc", search_dirs=[legacy])
+        assert result is not None
+        assert result["components"] == [{"name": "good"}]
+
+    def test_version_mismatch_primary_falls_through_to_legacy(self, tmp_path: Path) -> None:
+        primary = tmp_path / "primary"
+        legacy = tmp_path / "legacy"
+        primary.mkdir(parents=True)
+
+        save_cached(legacy, "abc", {"components": [{"name": "good"}]})
+
+        stale = primary / "abc.json"
+        stale.write_text('{"_cache_version": 999}', encoding="utf-8")
+
+        result = load_cached(primary, "abc", search_dirs=[legacy])
+        assert result is not None
+        assert result["components"] == [{"name": "good"}]

--- a/aibom/tests/test_scan_pipeline.py
+++ b/aibom/tests/test_scan_pipeline.py
@@ -119,6 +119,27 @@ class TestPipelineTiming:
         scan_timing = next(t for t in result.timings if t.name == "scan")
         assert "file cache" in scan_timing.detail
 
+    def test_progress_callback_receives_stage_and_scanner_events(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text("import openai\n")
+        events: list[dict[str, object]] = []
+        result = ScanPipeline(
+            scan_paths=[str(tmp_path)],
+            progress_callback=events.append,
+        ).run()
+
+        assert result.components is not None
+        event_names = [str(event["event"]) for event in events]
+        assert event_names[0] == "stage_started"
+        assert "scanners_discovered" in event_names
+        assert "scanner_completed" in event_names
+        assert event_names[-1] == "stage_completed"
+        stage_names = [
+            str(event["stage"])
+            for event in events
+            if event["event"] == "stage_started"
+        ]
+        assert stage_names == ["scan", "cross_ref", "agentic", "assemble"]
+
 
 class TestAgenticScope:
     def test_all_components_sent_to_agent(self, tmp_path: Path) -> None:
@@ -151,6 +172,23 @@ class TestAgenticScope:
             mock_enrich.return_value = ([], [], [])
             pipeline.run()
         assert mock_enrich.call_args.kwargs["cache_dir"] == agentic_cache_dir
+
+    def test_include_code_snippets_is_forwarded(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text(
+            'from openai import OpenAI\nclient = OpenAI(model="gpt-4o")\n'
+        )
+        llm_cfg = {"model": "test/model", "api_key": "fake", "api_base": "http://x"}
+        pipeline = ScanPipeline(
+            scan_paths=[str(tmp_path)],
+            llm_config=llm_cfg,
+            include_code_snippets=True,
+        )
+        with patch("aibom.scan_pipeline.ensure_llm_runtime_available") as mock_runtime:
+            with patch("aibom.agentic.agent.run_agentic_enrichment") as mock_enrich:
+                mock_enrich.return_value = ([], [], [])
+                pipeline.run()
+        mock_runtime.assert_called_once()
+        assert mock_enrich.call_args.kwargs["include_code_snippets"] is True
 
 
 class TestFileCache:
@@ -361,3 +399,266 @@ class TestPropagateRemovals:
         )
 
         assert [c.name for c in result] == ["gpt-5"]
+
+
+class TestDefaultBomScope:
+    def test_stage_assemble_excludes_test_only_components(self):
+        component = AIComponent(
+            name="FakeTool",
+            component_type=AIComponentType.TOOL,
+            file_path="repo/tests/test_agent.py",
+            line_number=10,
+            confidence=0.8,
+        )
+        pipeline = ScanPipeline(scan_paths=["/tmp"])
+
+        components, agentic_count = pipeline._stage_assemble([component])
+
+        assert components == []
+        assert agentic_count == 0
+
+    def test_stage_assemble_excludes_test_prefix_filename_components(self):
+        component = AIComponent(
+            name="gpt-4o-mini",
+            component_type=AIComponentType.MODEL,
+            file_path="repo/src/orchestrator/test_firewall_routing.py",
+            line_number=14,
+            confidence=0.8,
+        )
+        pipeline = ScanPipeline(scan_paths=["/tmp"])
+
+        components, agentic_count = pipeline._stage_assemble([component])
+
+        assert components == []
+        assert agentic_count == 0
+
+    def test_stage_assemble_excludes_test_suffix_filename_components(self):
+        component = AIComponent(
+            name="gpt-4o-mini",
+            component_type=AIComponentType.MODEL,
+            file_path="repo/src/orchestrator/firewall_routing_test.py",
+            line_number=21,
+            confidence=0.8,
+        )
+        pipeline = ScanPipeline(scan_paths=["/tmp"])
+
+        components, agentic_count = pipeline._stage_assemble([component])
+
+        assert components == []
+        assert agentic_count == 0
+
+    def test_stage_assemble_keeps_non_test_prefixed_production_files(self):
+        component = AIComponent(
+            name="gpt-4o-mini",
+            component_type=AIComponentType.MODEL,
+            file_path="repo/src/orchestrator/testimony_router.py",
+            line_number=8,
+            confidence=0.8,
+        )
+        pipeline = ScanPipeline(scan_paths=["/tmp"])
+
+        components, _ = pipeline._stage_assemble([component])
+
+        assert [c.name for c in components] == ["gpt-4o-mini"]
+
+    def test_stage_assemble_excludes_fixture_components(self):
+        component = AIComponent(
+            name="FakePrompt",
+            component_type=AIComponentType.PROMPT,
+            file_path="repo/fixtures/sample_prompt.py",
+            line_number=4,
+            confidence=0.8,
+        )
+        pipeline = ScanPipeline(scan_paths=["/tmp"])
+
+        components, agentic_count = pipeline._stage_assemble([component])
+
+        assert components == []
+        assert agentic_count == 0
+
+    def test_stage_assemble_keeps_components_with_production_evidence(self):
+        prod = AIComponent(
+            name="gpt-4o",
+            component_type=AIComponentType.MODEL,
+            file_path="repo/app/service.py",
+            line_number=12,
+            confidence=0.9,
+        )
+        test = AIComponent(
+            name="gpt-4o",
+            component_type=AIComponentType.MODEL,
+            file_path="repo/tests/test_service.py",
+            line_number=18,
+            confidence=0.7,
+        )
+        pipeline = ScanPipeline(scan_paths=["/tmp"])
+
+        components, _ = pipeline._stage_assemble([prod, test])
+
+        assert len(components) == 1
+        assert components[0].name == "gpt-4o"
+        assert components[0].metadata.get("test_only") is not True
+
+    def test_stage_assemble_keeps_github_automation_components(self):
+        component = AIComponent(
+            name="env:LLM_API_BASE",
+            component_type=AIComponentType.LLM_ENDPOINT,
+            file_path="repo/.github/workflows/ai-review.yml",
+            line_number=42,
+            confidence=0.8,
+        )
+        pipeline = ScanPipeline(scan_paths=["/tmp"])
+
+        components, _ = pipeline._stage_assemble([component])
+
+        assert len(components) == 1
+        assert components[0].file_path.endswith(".github/workflows/ai-review.yml")
+
+    def test_run_filters_test_scope_relationships_and_risk_flags(self):
+        from aibom.models.scan import ComponentRelationship, RiskFlag
+        from aibom.models.enums import RelationshipType, Severity
+
+        prod = AIComponent(
+            name="gpt-4o",
+            component_type=AIComponentType.MODEL,
+            file_path="repo/app/service.py",
+            line_number=12,
+            confidence=0.9,
+            needs_agentic=False,
+        )
+        test = AIComponent(
+            name="FakeTool",
+            component_type=AIComponentType.TOOL,
+            file_path="repo/tests/test_agent.py",
+            line_number=10,
+            confidence=0.8,
+            needs_agentic=False,
+        )
+        kept_rel = ComponentRelationship(
+            source_instance_id=prod.instance_id,
+            target_instance_id=prod.instance_id,
+            relationship_type=RelationshipType.USES_MODEL,
+            source_name=prod.name,
+            target_name=prod.name,
+            source_type=prod.component_type,
+            target_type=prod.component_type,
+        )
+        dropped_rel = ComponentRelationship(
+            source_instance_id=test.instance_id,
+            target_instance_id=prod.instance_id,
+            relationship_type=RelationshipType.USES_TOOL,
+            source_name=test.name,
+            target_name=prod.name,
+            source_type=test.component_type,
+            target_type=prod.component_type,
+        )
+        kept_flag = RiskFlag(
+            flag="prod-risk",
+            severity=Severity.LOW,
+            weight=1,
+            description="prod",
+            file_path=prod.file_path,
+            line_number=prod.line_number,
+        )
+        dropped_flag = RiskFlag(
+            flag="test-risk",
+            severity=Severity.LOW,
+            weight=1,
+            description="test",
+            file_path=test.file_path,
+            line_number=test.line_number,
+        )
+        pipeline = ScanPipeline(scan_paths=["/tmp"])
+
+        with (
+            patch.object(pipeline, "_stage_scan", return_value=([prod, test], [kept_rel, dropped_rel])),
+            patch.object(pipeline, "_stage_cross_ref", return_value=([prod, test], MagicMock(), MagicMock(), [])),
+            patch.object(pipeline, "_stage_agentic", return_value=([prod, test], [kept_rel, dropped_rel], [kept_flag, dropped_flag])),
+        ):
+            result = pipeline.run()
+
+        assert [c.name for c in result.components] == ["gpt-4o"]
+        assert result.relationships == [kept_rel]
+
+
+class TestDependencyPolicyScope:
+    def test_stage_assemble_drops_non_ai_dependencies(self) -> None:
+        ai_dep = AIComponent(
+            name="openai",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="/repo/requirements.txt",
+            line_number=1,
+            metadata={
+                "ecosystem": "pypi",
+                "known_ai_package": True,
+            },
+            needs_agentic=False,
+        )
+        generic_dep = AIComponent(
+            name="requests",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="/repo/requirements.txt",
+            line_number=2,
+            metadata={
+                "ecosystem": "pypi",
+                "known_ai_package": False,
+            },
+            needs_agentic=False,
+        )
+        pipeline = ScanPipeline(scan_paths=["/repo"])
+
+        components, agentic_count = pipeline._stage_assemble([ai_dep, generic_dep])
+
+        assert agentic_count == 0
+        assert [c.name for c in components] == ["openai"]
+
+    def test_run_keeps_name_only_agentic_relationships_for_kept_components(self):
+        from aibom.models.scan import ComponentRelationship
+        from aibom.models.enums import RelationshipType
+
+        prod = AIComponent(
+            name="gpt-4o",
+            component_type=AIComponentType.MODEL,
+            file_path="repo/app/service.py",
+            line_number=12,
+            confidence=0.9,
+            needs_agentic=False,
+            model_name="gpt-4o",
+        )
+        test = AIComponent(
+            name="FakeTool",
+            component_type=AIComponentType.TOOL,
+            file_path="repo/tests/test_agent.py",
+            line_number=10,
+            confidence=0.8,
+            needs_agentic=False,
+        )
+        kept_rel = ComponentRelationship(
+            source_instance_id="",
+            target_instance_id="",
+            relationship_type=RelationshipType.USES_MODEL,
+            source_name="gpt-4o",
+            target_name="gpt-4o",
+            source_type=prod.component_type,
+            target_type=prod.component_type,
+        )
+        dropped_rel = ComponentRelationship(
+            source_instance_id="",
+            target_instance_id="",
+            relationship_type=RelationshipType.USES_TOOL,
+            source_name="FakeTool",
+            target_name="gpt-4o",
+            source_type=test.component_type,
+            target_type=prod.component_type,
+        )
+        pipeline = ScanPipeline(scan_paths=["/tmp"])
+
+        with (
+            patch.object(pipeline, "_stage_scan", return_value=([prod, test], [kept_rel, dropped_rel])),
+            patch.object(pipeline, "_stage_cross_ref", return_value=([prod, test], MagicMock(), MagicMock(), [])),
+            patch.object(pipeline, "_stage_agentic", return_value=([prod, test], [kept_rel, dropped_rel], [])),
+        ):
+            result = pipeline.run()
+
+        assert [c.name for c in result.components] == ["gpt-4o"]
+        assert result.relationships == [kept_rel]

--- a/aibom/tests/test_scan_pipeline.py
+++ b/aibom/tests/test_scan_pipeline.py
@@ -152,9 +152,10 @@ class TestAgenticScope:
             scan_paths=[str(tmp_path)],
             llm_config=llm_cfg,
         )
-        with patch("aibom.agentic.agent.run_agentic_enrichment") as mock_enrich:
-            mock_enrich.return_value = ([], [], [])
-            result = pipeline.run()
+        with patch("aibom.scan_pipeline.ensure_llm_runtime_available"):
+            with patch("aibom.agentic.agent.run_agentic_enrichment") as mock_enrich:
+                mock_enrich.return_value = ([], [], [])
+                result = pipeline.run()
         mock_enrich.assert_called_once()
 
     def test_agentic_cache_dir_is_forwarded(self, tmp_path: Path) -> None:
@@ -168,9 +169,10 @@ class TestAgenticScope:
             llm_config=llm_cfg,
             agentic_cache_dir=agentic_cache_dir,
         )
-        with patch("aibom.agentic.agent.run_agentic_enrichment") as mock_enrich:
-            mock_enrich.return_value = ([], [], [])
-            pipeline.run()
+        with patch("aibom.scan_pipeline.ensure_llm_runtime_available"):
+            with patch("aibom.agentic.agent.run_agentic_enrichment") as mock_enrich:
+                mock_enrich.return_value = ([], [], [])
+                pipeline.run()
         assert mock_enrich.call_args.kwargs["cache_dir"] == agentic_cache_dir
 
     def test_include_code_snippets_is_forwarded(self, tmp_path: Path) -> None:

--- a/aibom/tests/test_vector_store_dedup.py
+++ b/aibom/tests/test_vector_store_dedup.py
@@ -113,3 +113,17 @@ class TestConsolidateVectorStores:
         out = _consolidate_vector_stores(comps)
         assert len(out) == 1
         assert out[0].metadata.get("store_technology") == "milvus"
+
+    def test_metadata_store_technology_overrides_name_hint(self) -> None:
+        comps = [
+            AIComponent(
+                name="env:WEAVIATE_ENDPOINT",
+                component_type=AIComponentType.VECTOR_STORE,
+                file_path="values.yaml",
+                line_number=12,
+                metadata={"store_technology": "chromadb"},
+            ),
+        ]
+        out = _consolidate_vector_stores(comps)
+        assert len(out) == 1
+        assert out[0].metadata.get("store_technology") == "chromadb"

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "cisco-aibom"
-version = "1.0.0rc1"
+version = "1.0.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/docs/AGENTIC_MODE.md
+++ b/docs/AGENTIC_MODE.md
@@ -4,6 +4,8 @@ Cisco AI BOM uses a three-tier detection architecture. Tiers 1 and 2 generate ca
 
 The `--llm-model` option (or `AIBOM_LLM_MODEL` env var) is **required**.
 
+If the required runtime extras are missing, `cisco-aibom analyze` fails fast with the exact `uv tool install ...` command to add the missing agentic or provider integration packages.
+
 ## Three-Tier Detection
 
 | Tier | Method | Purpose | Examples |
@@ -115,10 +117,12 @@ Environment variables set in the shell take precedence over `.env` values.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--agentic-batch-size` | `15` | Max components grouped into a single LLM invocation. Larger batches reduce API calls but may hit token limits. |
+| `--agentic-batch-size` | `5` | Max components grouped into a single LLM invocation. Larger batches reduce API calls but may hit token limits. |
 | `--agentic-concurrency` | `1` | Max parallel LLM batches. Increase for faster scans if your provider allows concurrent requests. |
 | `--agentic-timeout` | `120` | Wall-clock timeout in seconds per batch. Batches exceeding this are marked as `batch_timeout` and skipped. |
 | `--agentic-fast-model` | — | A cheaper/faster model for simple confirmations (e.g. registry lookups, dependency checks). The primary `--llm-model` is used for complex reasoning. |
+| `--progress` | `auto` | Show live per-stage and per-scanner progress in interactive terminals. |
+| `--include-code-snippets` | `off` | Include raw code snippets inside per-finding decision annotations. |
 
 ### Batch sizing guidance
 
@@ -131,8 +135,8 @@ Environment variables set in the shell take precedence over `.env` values.
 1. **Candidate triage** — After deterministic scanning, all candidates are split into "simple" (registry-confirmable, e.g. known model IDs, manifest dependencies) and "complex" (needs deeper reasoning) tiers.
 2. **Locality-aware batching** — Candidates are grouped by directory to provide better code context per batch.
 3. **Agent tools** — The agent has access to tools: `read_file_lines`, `search_package_info` (queries PyPI/npm/Go registries), and code context. It uses these to confirm or reject each candidate.
-4. **Structured output** — Each batch returns a structured JSON response with confirmed components, removed false positives, reclassifications, and risk findings.
-5. **Caching** — Results are cached by content hash at `~/.cache/cisco-aibom/agentic/`. Unchanged components reuse cached results on subsequent runs.
+4. **Structured output** — Each batch returns a structured JSON response with confirmed components, removed false positives, reclassifications, relationships, and risk findings. Kept findings carry `decision_annotation` metadata with justification and evidence references. Raw code snippets are only included when `--include-code-snippets` is enabled.
+5. **Caching** — Results are cached by content hash at `~/.aibom/cache/agentic/`. Unchanged components reuse cached results on subsequent runs.
 
 ## Circuit Breaker
 
@@ -144,7 +148,7 @@ To protect against runaway API costs, a circuit breaker trips after 3 consecutiv
 
 ## Cache Management
 
-Agentic results are cached on disk at `~/.cache/cisco-aibom/agentic/`. To clear:
+Agentic results are cached on disk at `~/.aibom/cache/agentic/`. To inspect or clear them:
 
 ```bash
 # Clear both scan cache and agentic cache
@@ -152,6 +156,12 @@ cisco-aibom cache clear
 
 # Clear scan cache only (skip agentic)
 cisco-aibom cache clear --no-agentic
+
+# List cached agentic entries
+cisco-aibom cache list --type agentic
+
+# Inspect one cached agentic entry
+cisco-aibom cache get agentic 0123456789ab
 ```
 
 ## Strict Mode

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -40,7 +40,7 @@ cisco-aibom analyze [OPTIONS] [SOURCES]...
 | `--repo-topic` | — | Filter discovered repos by topic/tag. |
 | `--max-repos` | — | Max repos when using discovery (sorted by last push, most recent first). |
 | `--parallel-repos` | — | Number of repositories to scan in parallel (default `1`). |
-| `--incremental` | — | Skip repos whose HEAD is unchanged since last cached scan. |
+| `--skip-unchanged` | — | Skip repos whose HEAD is unchanged since last cached scan. Org-cache writes default to `~/.aibom/cache/org` and still read legacy locations for compatibility. |
 
 ### Output Options
 
@@ -51,6 +51,7 @@ cisco-aibom analyze [OPTIONS] [SOURCES]...
 | `--validate` | — | Validate output against the format's schema and report errors. |
 | `--show-summary` / `--no-show-summary` | — | Display a Rich summary table after analysis (default on). |
 | `--timing` | — | Print per-stage and per-scanner timing breakdown. |
+| `--progress` / `--no-progress` | — | Show live per-stage and per-scanner progress. Defaults to auto for interactive terminals. |
 
 ### Report Submission
 
@@ -65,12 +66,12 @@ cisco-aibom analyze [OPTIONS] [SOURCES]...
 
 | Option | Env Var | Description |
 |--------|---------|-------------|
-| `--llm-model` | `AIBOM_LLM_MODEL` | **Required.** LLM model name (e.g. `gpt-5.4`, `us.anthropic.claude-sonnet-4-20250514-v1:0`). The LLM agent classifies every scanner candidate (requires `cisco-aibom[agentic]`). |
+| `--llm-model` | `AIBOM_LLM_MODEL` | **Required.** LLM model name (e.g. `gpt-5.4`, `us.anthropic.claude-sonnet-4-20250514-v1:0`). The LLM agent classifies every scanner candidate and requires `cisco-aibom[agentic]` plus any provider-specific integration extra. |
 | `--llm-provider` | `AIBOM_LLM_PROVIDER` | LangChain provider name: `openai`, `azure_openai`, `bedrock`, `anthropic`, `google_genai`, `ollama`, etc. Inferred from the model name if not set. |
 | `--llm-api-key` | `AIBOM_LLM_API_KEY` | LLM API key. Optional for local LLMs and AWS Bedrock. |
 | `--llm-api-base` | `AIBOM_LLM_API_BASE` | LLM API base URL. |
 | `--llm-api-version` | `AIBOM_LLM_API_VERSION` | LLM API version (required for Azure OpenAI). |
-| `--agentic-batch-size` | — | Max components per LLM invocation (default `15`). |
+| `--agentic-batch-size` | — | Max components per LLM invocation (default `5`). |
 | `--agentic-concurrency` | — | Max parallel agentic LLM batches (default `1`). |
 | `--agentic-fast-model` | — | Cheaper/faster model for simple confirmations (e.g. dependency checks). |
 | `--agentic-timeout` | — | Wall-clock timeout in seconds per agentic batch (default `120`). |
@@ -86,7 +87,8 @@ cisco-aibom analyze [OPTIONS] [SOURCES]...
 | `--fail-on` | Exit non-zero if risk severity meets or exceeds: `critical`, `high`, `medium`, `low`. |
 | `--policy` | Path to a YAML policy file. Exits `1` if the policy does not pass. |
 | `--compliance` | Advisory compliance mapping: `eu-ai-act`, `owasp-agentic`, `nist-ai-rmf`, or `all`. |
-| `--cache-dir` | Directory for caching scan results keyed by `repo@commit_sha`. |
+| `--cache-dir` | Shared cache root. Defaults to `~/.aibom/cache` and stores `scan`, `agentic`, `org`, `model`, and `packages` caches beneath it. |
+| `--include-code-snippets` / `--no-code-snippets` | Include raw code snippets in per-finding decision annotations. Off by default. |
 
 ### Examples
 
@@ -137,29 +139,48 @@ cisco-aibom analyze ./my-app -o json -O report.json \
 
 ## `cisco-aibom report`
 
-Render a previously generated JSON report using Rich formatting.
+Show or upload a previously generated JSON report.
 
 ```bash
-cisco-aibom report [OPTIONS] REPORT_FILE
+cisco-aibom report REPORT_FILE
+cisco-aibom report show REPORT_FILE [--raw-json]
+cisco-aibom report upload REPORT_FILE --format json --post-url URL [OPTIONS]
 ```
+
+The JSON reporter writes `aibom_analysis.metadata.report_schema_version = "1"`. Unversioned legacy JSON reports are still accepted for `report upload`; the CLI warns and synthesizes the current schema version before submitting.
+
+### `report show`
 
 | Argument / Option | Description |
 |-------------------|-------------|
 | `REPORT_FILE` | Path to a JSON report file. |
 | `--raw-json` | Display the raw JSON with syntax highlighting before the summary. |
 
-### Example
+### `report upload`
+
+| Option | Env Var | Description |
+|--------|---------|-------------|
+| `--format` | — | Upload format. Only `json` is currently supported. |
+| `--post-url` | `AIBOM_POST_URL` | HTTP endpoint to POST the JSON report to. Required for upload. |
+| `--ai-defense-api-key` | `AI_DEFENSE_API_KEY` | API key sent as `x-cisco-ai-defense-tenant-api-key`. |
+| `--post-timeout` | `AIBOM_POST_TIMEOUT` | Timeout in seconds for POSTing the report (default `30`). |
+| `--post-verify-tls` / `--no-post-verify-tls` | `AIBOM_POST_VERIFY_TLS` | Verify TLS certificates when POSTing (default on). |
+
+### Examples
 
 ```bash
 cisco-aibom report report.json
-cisco-aibom report report.json --raw-json
+cisco-aibom report show report.json --raw-json
+cisco-aibom report upload report.json --format json \
+  --post-url https://example.invalid/aibom/reports \
+  --ai-defense-api-key $AI_DEFENSE_API_KEY
 ```
 
 ---
 
 ## `cisco-aibom watch`
 
-Poll directories for file-system changes and re-run the scan pipeline, printing component deltas.
+Poll directories for file-system changes and re-run the deterministic scan pipeline, printing component deltas. This command does not invoke the agentic classification stage; use `analyze` for the full LLM-backed pipeline.
 
 ```bash
 cisco-aibom watch [OPTIONS] SOURCES...
@@ -313,7 +334,7 @@ cisco-aibom kb list-requests [OPTIONS]
 
 ## `cisco-aibom cache`
 
-Manage the scan result cache.
+Manage AIBOM cache entries under the shared cache root (`~/.aibom/cache` by default).
 
 ### `cache clear`
 
@@ -325,12 +346,12 @@ cisco-aibom cache clear [OPTIONS]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--cache-dir` | `~/.aibom/cache` | Directory where cached scan results are stored. |
-| `--include-agentic` / `--no-agentic` | Include | Also clear the agentic enrichment cache at `~/.cache/cisco-aibom/agentic/`. |
+| `--cache-dir` | `~/.aibom/cache` | Cache root directory. |
+| `--include-agentic` / `--no-agentic` | Include | Also clear the agentic enrichment cache. |
 
 ### `cache list`
 
-List all cached scan result entries.
+List cached entries for a specific cache family.
 
 ```bash
 cisco-aibom cache list [OPTIONS]
@@ -338,7 +359,34 @@ cisco-aibom cache list [OPTIONS]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--cache-dir` | `~/.aibom/cache` | Directory where cached scan results are stored. |
+| `--type` | `scan` | Cache family: `scan`, `agentic`, `org`, `model`, `packages`. |
+| `--cache-dir` | `~/.aibom/cache` | Cache root directory. |
+
+### `cache get`
+
+Inspect a specific cache entry by type.
+
+```bash
+cisco-aibom cache get CACHE_TYPE ENTRY_REF [OPTIONS]
+```
+
+| Argument / Option | Description |
+|-------------------|-------------|
+| `CACHE_TYPE` | Cache family: `scan`, `agentic`, `org`, `model`, `packages`. |
+| `ENTRY_REF` | Entry id, prefix, or logical reference. |
+| `--cache-dir` | Cache root directory (default `~/.aibom/cache`). |
+| `--sha` | Commit SHA for `org` cache lookups. |
+| `--model-id` | Optional model id filter for `model` cache lookups. |
+| `--raw-json` | Print the raw cache payload instead of a summary. |
+
+### Cache examples
+
+```bash
+cisco-aibom cache list --type scan
+cisco-aibom cache list --type agentic
+cisco-aibom cache get scan 0123456789ab
+cisco-aibom cache get org /path/to/repo --sha deadbeef
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- harden false-positive handling across deterministic and agent-assisted analysis by teaching the agent to remove malformed dependency detections that are really version literals such as `0.18.0`, `3.9.3`, and `0.59b0`, prefer the package key from the file context instead of quoted version values, and require an explicit keep/remove decision for every candidate so false positives do not survive by omission
- tighten classification behavior around repeated and ambiguous findings by propagating remove/reclassify decisions across duplicated component instances, preserving cached removals, and improving endpoint typing so selector-backed service references are emitted as `model_endpoint` findings instead of staying in a more generic bucket
- add explainability to kept findings by persisting `decision_annotation` metadata on components, relationships, and risk flags, including a concise justification plus evidence locations by default, with raw code snippets available only when `--include-code-snippets` is explicitly enabled
- add operator-facing report and cache workflows by introducing `report upload` for existing JSON reports, tagging generated JSON with a report schema version for upload validation, standardizing cache roots under `~/.aibom/cache`, adding typed cache inspection through `cache list --type ...` and `cache get ...`, and keeping legacy cache reads for compatibility during the transition
- improve CLI behavior and release readiness by adding live progress reporting for long deterministic scans, failing fast when required agentic or provider runtime extras are missing, aligning the docs with the shipped commands and defaults, and bumping the packaged release metadata to `1.0.0rc2`

## Test plan
- [x] run the full `uv` pytest suite from the repo environment with analysis and provider env vars unset on the command line: `963 passed, 13 warnings`
- [x] run the full `uv` pytest suite in a fresh `uv` venv with only `.[test]` installed and the same env vars unset on the command line: `963 passed, 13 warnings`