### PR TITLE
Prepare stable cisco-aibom release without vulnerable LiteLLM

### DIFF
--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-aibom"
-version = "1.0.0rc4"
+version = "1.0.0"
 description = "A tool to generate an AI BOM from source code."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/aibom/src/aibom/manifest.json
+++ b/aibom/src/aibom/manifest.json
@@ -1,8 +1,8 @@
 {
-  "analyzer_version": "1.0.0rc4",
-  "schema_version": "1.0.0rc4",
+  "analyzer_version": "1.0.0",
+  "schema_version": "1.0.0",
   "duckdb_sha256": "b1165384a646094aa6a4762d676f285c1c68b6d7f9367c90a129b529904a3268",
-  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.0rc4.duckdb",
+  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.0.duckdb",
   "upload_mode": "direct",
   "max_direct_upload_mb": 25,
   "log_level": "INFO"

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "cisco-aibom"
-version = "1.0.0rc4"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Prepare a stable `cisco-aibom` release from the current `1.0.0rc4` source.
- Keep the existing package dependency set, which no longer includes `litellm`.
- Sync `pyproject.toml`, `manifest.json`, and `uv.lock` to version `1.0.0`.

## Validation

- Version sync check passed for `1.0.0`.
- `uv run pytest` passed: 1716 passed, 23 skipped.
