### PR TITLE
Broaden AI component coverage and add source attribution to the BOM

### DIFF
--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -903,11 +903,31 @@ def _circuit_breaker_skipped_batch(batch: list[AIComponent]) -> list[AIComponent
     return _degraded_batch_components(batch, hint="circuit_breaker_tripped")
 
 
-class _BatchTimeout(Exception):
-    """Raised when a synchronous batch invocation exceeds its deadline."""
+class _InvokeTimeout(Exception):
+    """Raised when a synchronous ``agent.invoke`` exceeds its wall-clock deadline.
+
+    The generic timeout sentinel for every synchronous agent-invocation site.
+    Subclasses :class:`Exception` (not ``BaseException``) so a site-level
+    ``except Exception`` still catches it and fails open.
+    """
 
 
-def _invoke_with_deadline(agent: Any, summary: str, timeout_s: int) -> Any:
+class _BatchTimeout(_InvokeTimeout):
+    """Raised when a synchronous *batch* invocation exceeds its deadline.
+
+    A subclass of :class:`_InvokeTimeout` so the batch path's existing
+    ``except _BatchTimeout`` handling is unchanged while the deadline mechanism
+    is shared with every other invoke site.
+    """
+
+
+def _invoke_agent_bounded(
+    agent: Any,
+    content: str,
+    timeout_s: int,
+    *,
+    recursion_limit: int | None = None,
+) -> Any:
     """Run ``agent.invoke`` in a daemon thread with a hard wall-clock deadline.
 
     ``agent.invoke`` is a blocking deep-agent loop that cannot be cancelled.
@@ -917,35 +937,63 @@ def _invoke_with_deadline(agent: Any, summary: str, timeout_s: int) -> Any:
     genuinely hung LLM call wedged the whole scan.
 
     Instead, run the call in a *daemon* thread and ``join`` it for at most
-    ``timeout_s``. On timeout we raise :class:`_BatchTimeout` and abandon the
+    ``timeout_s``. On timeout we raise :class:`_InvokeTimeout` and abandon the
     thread; being a daemon, it never blocks process/loop shutdown and dies with
-    the interpreter. This makes ``--agentic-timeout`` actually bound a hung
-    batch.
+    the interpreter. This is the single bounded-invoke primitive used by every
+    synchronous agent-invocation site (batch enrichment, cross-repo
+    coordination, container-layout resolution, and repo triage).
+
+    ``recursion_limit`` is forwarded as ``config={"recursion_limit": N}`` only
+    when set; left ``None`` the call passes no ``config`` so the agent applies
+    its own default (some sites intentionally do not cap recursion).
     """
     box: dict[str, Any] = {}
+    config: dict[str, Any] | None = (
+        {"recursion_limit": recursion_limit} if recursion_limit is not None else None
+    )
 
     def _worker() -> None:
         try:
-            box["result"] = agent.invoke(
-                {"messages": [{"role": "user", "content": summary}]},
-                config={"recursion_limit": _RECURSION_LIMIT},
-            )
+            message = {"messages": [{"role": "user", "content": content}]}
+            if config is not None:
+                box["result"] = agent.invoke(message, config=config)
+            else:
+                box["result"] = agent.invoke(message)
         except BaseException as exc:  # noqa: BLE001 - propagate to caller thread
             box["error"] = exc
 
     worker = threading.Thread(
         target=_worker,
-        name="aibom-agentic-batch",
+        name="aibom-agentic-invoke",
         daemon=True,
     )
     worker.start()
     worker.join(timeout_s)
 
     if worker.is_alive():
-        raise _BatchTimeout()
+        # Timed out: abandon the still-running daemon worker. If its invoke
+        # later completes it writes box["result"], but the caller never reads
+        # box again after raising, so that late write is harmless (and dict
+        # writes are GIL-atomic). The daemon dies with the interpreter.
+        raise _InvokeTimeout()
     if "error" in box:
         raise box["error"]
     return box.get("result")
+
+
+def _invoke_with_deadline(agent: Any, summary: str, timeout_s: int) -> Any:
+    """Bounded batch invocation — thin wrapper over :func:`_invoke_agent_bounded`.
+
+    Preserves the batch path's ``_BatchTimeout`` contract (so ``_run_batch``'s
+    ``except _BatchTimeout`` is unchanged) while sharing the daemon-thread
+    deadline mechanism with every other invoke site.
+    """
+    try:
+        return _invoke_agent_bounded(
+            agent, summary, timeout_s, recursion_limit=_RECURSION_LIMIT
+        )
+    except _InvokeTimeout as exc:
+        raise _BatchTimeout() from exc
 
 
 def _run_async_bounded(coro: Any) -> Any:
@@ -2316,17 +2364,11 @@ def run_cross_repo_coordination(
             tools=xrepo_tools,
             model=model_obj,
         )
-        result = asyncio.run(
-            asyncio.wait_for(
-                asyncio.to_thread(
-                    lambda: agent.invoke(
-                        {"messages": [{"role": "user", "content": prompt}]}
-                    ),
-                ),
-                timeout=_DEFAULT_AGENTIC_TIMEOUT_S,
-            )
-        )
-    except asyncio.TimeoutError:
+        # Daemon-thread deadline: a hung coordinator invoke is abandoned, never
+        # wedging the scan at teardown. No recursion_limit here —
+        # the coordinator intentionally uses the agent's default.
+        result = _invoke_agent_bounded(agent, prompt, _DEFAULT_AGENTIC_TIMEOUT_S)
+    except _InvokeTimeout:
         _LOGGER.warning(
             "Cross-repo coordination timed out after %ds",
             _DEFAULT_AGENTIC_TIMEOUT_S,
@@ -2494,16 +2536,11 @@ def resolve_container_layout(
             indent=2,
         )
 
-        result = asyncio.run(
-            asyncio.wait_for(
-                asyncio.to_thread(
-                    lambda: agent.invoke(
-                        {"messages": [{"role": "user", "content": user_message}]},
-                        config={"recursion_limit": 25},
-                    ),
-                ),
-                timeout=timeout_s,
-            )
+        # Daemon-thread deadline: a hung layout invoke is abandoned, never
+        # wedging the scan at teardown. _InvokeTimeout is an
+        # Exception subclass, so it is caught below and falls back cleanly.
+        result = _invoke_agent_bounded(
+            agent, user_message, timeout_s, recursion_limit=25
         )
     except Exception:
         _LOGGER.warning(

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -214,6 +216,7 @@ class AgentResponse(BaseModel):
     new_relationships: list[_Relationship] = Field(default_factory=list)
     risk_findings: list[_RiskFinding] = Field(default_factory=list)
 
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -348,11 +351,13 @@ _SIMPLE_CANDIDATE_TYPES = frozenset({"model", "dependency", "embedding"})
 _SUB_AGENT_THRESHOLD = 50
 
 _RETRY_COOLDOWN_S = 30
-_RETRYABLE_HINTS = frozenset({
-    "batch_timeout",
-    "batch_recursion_limit",
-    "circuit_breaker_tripped",
-})
+_RETRYABLE_HINTS = frozenset(
+    {
+        "batch_timeout",
+        "batch_recursion_limit",
+        "circuit_breaker_tripped",
+    }
+)
 
 
 def _collect_failed(
@@ -363,7 +368,9 @@ def _collect_failed(
     retry: list[AIComponent] = []
     for c in enriched:
         if c.agentic_hint in _RETRYABLE_HINTS:
-            retry.append(c.model_copy(update={"needs_agentic": True, "agentic_hint": ""}))
+            retry.append(
+                c.model_copy(update={"needs_agentic": True, "agentic_hint": ""})
+            )
         else:
             ok.append(c)
     return ok, retry
@@ -498,14 +505,25 @@ def _build_tier_cache_payload(
 
 def _load_tier_cache_payload(
     data: dict[str, Any] | None,
-) -> tuple[list[AIComponent], list[AIComponent], list[ComponentRelationship], list[RiskFlag]] | None:
+) -> (
+    tuple[
+        list[AIComponent],
+        list[AIComponent],
+        list[ComponentRelationship],
+        list[RiskFlag],
+    ]
+    | None
+):
     """Deserialize a cached tier payload, returning None for non-tier entries."""
     if not data or data.get("_tier_cache_version") != _TIER_CACHE_VERSION:
         return None
     return (
         [AIComponent.model_validate(item) for item in data.get("tier_enriched", [])],
         [AIComponent.model_validate(item) for item in data.get("tier_new", [])],
-        [ComponentRelationship.model_validate(item) for item in data.get("tier_rels", [])],
+        [
+            ComponentRelationship.model_validate(item)
+            for item in data.get("tier_rels", [])
+        ],
         [RiskFlag.model_validate(item) for item in data.get("tier_flags", [])],
     )
 
@@ -532,7 +550,10 @@ def _load_batch_cache_payload(
         return None
     return (
         [AIComponent.model_validate(item) for item in data.get("batch_new", [])],
-        [ComponentRelationship.model_validate(item) for item in data.get("batch_rels", [])],
+        [
+            ComponentRelationship.model_validate(item)
+            for item in data.get("batch_rels", [])
+        ],
         [RiskFlag.model_validate(item) for item in data.get("batch_flags", [])],
     )
 
@@ -672,15 +693,25 @@ class _AgenticResultCache:
     def put(self, key: str, value: dict[str, Any]) -> None:
         self._mem[key] = value
         if self._disk_dir:
+            # Write atomically: serialize to a temp file in the same directory,
+            # then os.replace() into place. A crash mid-write leaves only the
+            # temp file (ignored by the ``*.json`` resume glob), never a
+            # half-written ``key.json`` that a resume would read as a corrupt
+            # cache hit.
+            dest = self._disk_dir / f"{key}.json"
+            tmp = self._disk_dir / f".{key}.json.{os.getpid()}.tmp"
             try:
-                (self._disk_dir / f"{key}.json").write_text(
-                    json.dumps(value, default=str), encoding="utf-8",
-                )
+                tmp.write_text(json.dumps(value, default=str), encoding="utf-8")
+                os.replace(tmp, dest)
             except OSError:
-                pass
+                try:
+                    tmp.unlink()
+                except OSError:
+                    pass
 
     def partition(
-        self, components: list[AIComponent],
+        self,
+        components: list[AIComponent],
     ) -> tuple[list[AIComponent], list[AIComponent]]:
         """Split components into cached (hit) and uncached (miss)."""
         cached: list[AIComponent] = []
@@ -697,7 +728,12 @@ class _AgenticResultCache:
         self,
         components: list[AIComponent],
         middleware: AIBOMScannerMiddleware,
-    ) -> tuple[list[AIComponent], list[AIComponent], list[ComponentRelationship], list[RiskFlag]]:
+    ) -> tuple[
+        list[AIComponent],
+        list[AIComponent],
+        list[ComponentRelationship],
+        list[RiskFlag],
+    ]:
         """Apply cached agentic results to components."""
         enriched: list[AIComponent] = []
         all_new: list[AIComponent] = []
@@ -717,7 +753,11 @@ class _AgenticResultCache:
 
                 batch_key = data.get("batch_artifact_key")
                 batch_payload = None
-                if isinstance(batch_key, str) and batch_key and batch_key not in seen_batch_keys:
+                if (
+                    isinstance(batch_key, str)
+                    and batch_key
+                    and batch_key not in seen_batch_keys
+                ):
                     seen_batch_keys.add(batch_key)
                     batch_payload = _load_batch_cache_payload(self.get(batch_key))
 
@@ -734,9 +774,14 @@ class _AgenticResultCache:
         return enriched, all_new, all_rels, all_flags
 
 
-_MEMO_SAFE_TYPES: frozenset[str] = frozenset({
-    "dependency", "model", "model_artifact", "embedding",
-})
+_MEMO_SAFE_TYPES: frozenset[str] = frozenset(
+    {
+        "dependency",
+        "model",
+        "model_artifact",
+        "embedding",
+    }
+)
 
 
 class _DecisionMemo:
@@ -785,7 +830,8 @@ class _DecisionMemo:
         return self._verdicts.get(k) if k else None
 
     def partition(
-        self, components: list[AIComponent],
+        self,
+        components: list[AIComponent],
     ) -> tuple[list[AIComponent], list[AIComponent]]:
         """Split into (memo_hits, memo_misses)."""
         hits: list[AIComponent] = []
@@ -814,16 +860,28 @@ class _DecisionMemo:
                 except ValueError:
                     result.append(c)
                     continue
-                result.append(c.model_copy(update={
-                    "component_type": new_type,
-                    "heuristic_confidence": verdict.get("heuristic_confidence", c.heuristic_confidence),
-                    "needs_agentic": False,
-                }))
+                result.append(
+                    c.model_copy(
+                        update={
+                            "component_type": new_type,
+                            "heuristic_confidence": verdict.get(
+                                "heuristic_confidence", c.heuristic_confidence
+                            ),
+                            "needs_agentic": False,
+                        }
+                    )
+                )
             else:
-                result.append(c.model_copy(update={
-                    "heuristic_confidence": verdict.get("heuristic_confidence", c.heuristic_confidence),
-                    "needs_agentic": False,
-                }))
+                result.append(
+                    c.model_copy(
+                        update={
+                            "heuristic_confidence": verdict.get(
+                                "heuristic_confidence", c.heuristic_confidence
+                            ),
+                            "needs_agentic": False,
+                        }
+                    )
+                )
         return result
 
     def __len__(self) -> int:
@@ -845,6 +903,114 @@ def _circuit_breaker_skipped_batch(batch: list[AIComponent]) -> list[AIComponent
     return _degraded_batch_components(batch, hint="circuit_breaker_tripped")
 
 
+class _BatchTimeout(Exception):
+    """Raised when a synchronous batch invocation exceeds its deadline."""
+
+
+def _invoke_with_deadline(agent: Any, summary: str, timeout_s: int) -> Any:
+    """Run ``agent.invoke`` in a daemon thread with a hard wall-clock deadline.
+
+    ``agent.invoke`` is a blocking deep-agent loop that cannot be cancelled.
+    Running it via ``asyncio.run(asyncio.wait_for(asyncio.to_thread(...)))``
+    returned control on timeout but then blocked **forever** on event-loop
+    shutdown, which joins the orphaned (non-cancellable) executor thread — so a
+    genuinely hung LLM call wedged the whole scan.
+
+    Instead, run the call in a *daemon* thread and ``join`` it for at most
+    ``timeout_s``. On timeout we raise :class:`_BatchTimeout` and abandon the
+    thread; being a daemon, it never blocks process/loop shutdown and dies with
+    the interpreter. This makes ``--agentic-timeout`` actually bound a hung
+    batch.
+    """
+    box: dict[str, Any] = {}
+
+    def _worker() -> None:
+        try:
+            box["result"] = agent.invoke(
+                {"messages": [{"role": "user", "content": summary}]},
+                config={"recursion_limit": _RECURSION_LIMIT},
+            )
+        except BaseException as exc:  # noqa: BLE001 - propagate to caller thread
+            box["error"] = exc
+
+    worker = threading.Thread(
+        target=_worker,
+        name="aibom-agentic-batch",
+        daemon=True,
+    )
+    worker.start()
+    worker.join(timeout_s)
+
+    if worker.is_alive():
+        raise _BatchTimeout()
+    if "error" in box:
+        raise box["error"]
+    return box.get("result")
+
+
+def _run_async_bounded(coro: Any) -> Any:
+    """Run *coro* to completion on a private event loop without wedging the
+    scan, then return its result (re-raising any exception).
+
+    Each batch in *coro* is wrapped in ``asyncio.timeout``, so a stalled
+    ``agent.ainvoke`` is cancelled at the coroutine level and the batch fails
+    open. The problem this helper solves is teardown: ``asyncio.run`` finishes
+    by calling ``loop.shutdown_default_executor()``, which *joins* the loop's
+    default ``ThreadPoolExecutor`` with ``wait=True``. If the provider stack
+    offloaded any blocking work via ``run_in_executor`` and that worker is
+    slow/stuck, the scan blocks there long after every batch has timed out —
+    the same class of hang fixed on the sync path.
+
+    Instead we run the loop with ``run_until_complete`` inside a daemon thread
+    and tear it down manually, deliberately **not** calling
+    ``shutdown_default_executor``; the executor is abandoned with
+    ``shutdown(wait=False)``. So once the bounded *coro* returns, the scan
+    returns immediately regardless of executor state. Running inside a daemon
+    thread also makes any executor workers daemon (threads inherit daemon
+    status from their creator), so they don't keep the interpreter alive.
+
+    Caveat (Python limitation, not specific to this code): if a provider hands
+    a *truly blocking* call to ``run_in_executor`` that never returns, that
+    worker cannot be hard-cancelled by any means, and ``concurrent.futures``
+    joins pool workers in its own ``atexit`` handler — so process *exit* can
+    lag on that single orphan. The scan itself still completes on time. Real
+    langchain async providers use native-async I/O, which cancels cleanly.
+    """
+    import concurrent.futures
+
+    box: dict[str, Any] = {}
+
+    def _runner() -> None:
+        loop = asyncio.new_event_loop()
+        # Created inside this daemon thread, so its workers are daemon too.
+        executor = concurrent.futures.ThreadPoolExecutor(
+            thread_name_prefix="aibom-agentic-io",
+        )
+        loop.set_default_executor(executor)
+        asyncio.set_event_loop(loop)
+        try:
+            box["result"] = loop.run_until_complete(coro)
+        except BaseException as exc:  # noqa: BLE001 - propagate to caller
+            box["error"] = exc
+        finally:
+            try:
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            except Exception:  # noqa: BLE001
+                pass
+            # Abandon (do NOT join) any in-flight executor work, then close.
+            # Daemon workers die with the process; nothing blocks teardown.
+            executor.shutdown(wait=False)
+            asyncio.set_event_loop(None)
+            loop.close()
+
+    thread = threading.Thread(target=_runner, name="aibom-agentic-loop", daemon=True)
+    thread.start()
+    thread.join()
+    if "error" in box:
+        raise box["error"]
+    return box.get("result")
+
+
 def _run_batch(
     agent: Any,
     middleware: AIBOMScannerMiddleware,
@@ -857,18 +1023,28 @@ def _run_batch(
     *,
     timeout_s: int = _DEFAULT_AGENTIC_TIMEOUT_S,
     dossier_index: DossierIndex | None = None,
-) -> tuple[list[AIComponent], list[AIComponent], list[ComponentRelationship], list[RiskFlag], bool]:
+) -> tuple[
+    list[AIComponent],
+    list[AIComponent],
+    list[ComponentRelationship],
+    list[RiskFlag],
+    bool,
+]:
     """Invoke the agent on a single batch and return parsed results."""
     from .tools import _reset_tool_stats, get_tool_stats
 
     _reset_tool_stats()
     _LOGGER.info(
         "Agentic batch %d/%d — %d components [%s]",
-        batch_num, total_batches, len(batch),
+        batch_num,
+        total_batches,
+        len(batch),
         ", ".join(c.name for c in batch),
     )
     summary = _build_context_message(
-        batch, relationships, scan_paths,
+        batch,
+        relationships,
+        scan_paths,
         all_components=all_components,
         dossier_index=dossier_index,
     )
@@ -876,25 +1052,16 @@ def _run_batch(
 
     result = None
 
-    async def _invoke_timed() -> Any:
-        return await asyncio.wait_for(
-            asyncio.to_thread(
-                lambda: agent.invoke(
-                    {"messages": [{"role": "user", "content": summary}]},
-                    config={"recursion_limit": _RECURSION_LIMIT},
-                ),
-            ),
-            timeout=timeout_s,
-        )
-
     try:
-        result = asyncio.run(_invoke_timed())
-    except asyncio.TimeoutError:
+        result = _invoke_with_deadline(agent, summary, timeout_s)
+    except _BatchTimeout:
         elapsed = time.monotonic() - t0
         stats = get_tool_stats()
         _LOGGER.warning(
             "Batch %d timed out after %.1fs | tool_stats=%s",
-            batch_num, elapsed, json.dumps(stats),
+            batch_num,
+            elapsed,
+            json.dumps(stats),
         )
         enriched = _degraded_batch_components(batch, hint="batch_timeout")
         return enriched, [], [], [], True
@@ -903,13 +1070,18 @@ def _run_batch(
         stats = get_tool_stats()
         _LOGGER.warning(
             "Batch %d failed after %.1fs: %s | tool_stats=%s",
-            batch_num, elapsed, exc, json.dumps(stats),
+            batch_num,
+            elapsed,
+            exc,
+            json.dumps(stats),
         )
         if result is not None:
             _accumulate_token_usage(result)
             data = _extract_structured_response(result)
             if data:
-                _LOGGER.info("Batch %d: recovering partial results from failed run", batch_num)
+                _LOGGER.info(
+                    "Batch %d: recovering partial results from failed run", batch_num
+                )
                 new_c, new_r, rf = middleware.extract_findings_from_dict(data)
                 enriched = middleware.apply_enrichments_from_dict(batch, data)
                 return enriched, new_c, new_r, rf, False
@@ -924,7 +1096,10 @@ def _run_batch(
 
     _LOGGER.info(
         "Batch %d completed in %.1fs — %d tool calls (%.1fs tool time) | breakdown=%s",
-        batch_num, elapsed, total_tool_calls, total_tool_time,
+        batch_num,
+        elapsed,
+        total_tool_calls,
+        total_tool_time,
         json.dumps(stats),
     )
 
@@ -950,18 +1125,28 @@ async def _run_batch_async(
     *,
     timeout_s: int = _DEFAULT_AGENTIC_TIMEOUT_S,
     dossier_index: DossierIndex | None = None,
-) -> tuple[list[AIComponent], list[AIComponent], list[ComponentRelationship], list[RiskFlag], bool]:
+) -> tuple[
+    list[AIComponent],
+    list[AIComponent],
+    list[ComponentRelationship],
+    list[RiskFlag],
+    bool,
+]:
     """Async version of _run_batch using agent.ainvoke()."""
     from .tools import _reset_tool_stats, get_tool_stats
 
     _reset_tool_stats()
     _LOGGER.info(
         "Agentic batch %d/%d — %d components [%s]",
-        batch_num, total_batches, len(batch),
+        batch_num,
+        total_batches,
+        len(batch),
         ", ".join(c.name for c in batch),
     )
     summary = _build_context_message(
-        batch, relationships, scan_paths,
+        batch,
+        relationships,
+        scan_paths,
         all_components=all_components,
         dossier_index=dossier_index,
     )
@@ -969,19 +1154,24 @@ async def _run_batch_async(
 
     result = None
     try:
-        result = await asyncio.wait_for(
-            agent.ainvoke(
+        # asyncio.timeout() (3.11+) is the recommended primitive over
+        # wait_for: it cancels the awaited ainvoke at the coroutine level and
+        # raises TimeoutError outside the block. Any blocking work the provider
+        # stack offloaded to the loop executor is abandoned at teardown by
+        # _run_async_bounded rather than joined.
+        async with asyncio.timeout(timeout_s):
+            result = await agent.ainvoke(
                 {"messages": [{"role": "user", "content": summary}]},
                 config={"recursion_limit": _RECURSION_LIMIT},
-            ),
-            timeout=timeout_s,
-        )
+            )
     except asyncio.TimeoutError:
         elapsed = time.monotonic() - t0
         stats = get_tool_stats()
         _LOGGER.warning(
             "Batch %d timed out after %.1fs | tool_stats=%s",
-            batch_num, elapsed, json.dumps(stats),
+            batch_num,
+            elapsed,
+            json.dumps(stats),
         )
         enriched = _degraded_batch_components(batch, hint="batch_timeout")
         return enriched, [], [], [], True
@@ -990,13 +1180,18 @@ async def _run_batch_async(
         stats = get_tool_stats()
         _LOGGER.warning(
             "Batch %d failed after %.1fs: %s | tool_stats=%s",
-            batch_num, elapsed, exc, json.dumps(stats),
+            batch_num,
+            elapsed,
+            exc,
+            json.dumps(stats),
         )
         if result is not None:
             _accumulate_token_usage(result)
             data = _extract_structured_response(result)
             if data:
-                _LOGGER.info("Batch %d: recovering partial results from failed run", batch_num)
+                _LOGGER.info(
+                    "Batch %d: recovering partial results from failed run", batch_num
+                )
                 new_c, new_r, rf = middleware.extract_findings_from_dict(data)
                 enriched = middleware.apply_enrichments_from_dict(batch, data)
                 return enriched, new_c, new_r, rf, False
@@ -1011,7 +1206,10 @@ async def _run_batch_async(
 
     _LOGGER.info(
         "Batch %d completed in %.1fs — %d tool calls (%.1fs tool time) | breakdown=%s",
-        batch_num, elapsed, total_tool_calls, total_tool_time,
+        batch_num,
+        elapsed,
+        total_tool_calls,
+        total_tool_time,
         json.dumps(stats),
     )
 
@@ -1070,12 +1268,24 @@ async def _run_batches_parallel(
             return idx, batch, _circuit_breaker_skipped_batch(batch), [], [], [], True
         async with sem:
             if tripped.is_set():
-                return idx, batch, _circuit_breaker_skipped_batch(batch), [], [], [], True
+                return (
+                    idx,
+                    batch,
+                    _circuit_breaker_skipped_batch(batch),
+                    [],
+                    [],
+                    [],
+                    True,
+                )
             try:
                 enriched, new, rels, flags, failed = await _run_batch_async(
-                    agent, middleware, batch,
-                    relationships, scan_paths,
-                    idx, total,
+                    agent,
+                    middleware,
+                    batch,
+                    relationships,
+                    scan_paths,
+                    idx,
+                    total,
                     all_components=all_components,
                     timeout_s=timeout_s,
                     dossier_index=dossier_index,
@@ -1148,7 +1358,9 @@ def _run_tier(
     timeout_s: int = _DEFAULT_AGENTIC_TIMEOUT_S,
     max_consecutive_failures: int = _DEFAULT_MAX_CONSECUTIVE_FAILURES,
     dossier_index: DossierIndex | None = None,
-) -> tuple[list[AIComponent], list[AIComponent], list[ComponentRelationship], list[RiskFlag]]:
+) -> tuple[
+    list[AIComponent], list[AIComponent], list[ComponentRelationship], list[RiskFlag]
+]:
     """Execute a single tier (simple or complex) with caching and parallel batches."""
     tier_enriched: list[AIComponent] = []
     tier_new: list[AIComponent] = []
@@ -1172,7 +1384,8 @@ def _run_tier(
         if cached_comps:
             _LOGGER.info(
                 "Cache hit for %d/%d components — skipping LLM",
-                len(cached_comps), len(components),
+                len(cached_comps),
+                len(components),
             )
             e, n, r, f = cache.apply_cached(cached_comps, middleware)
             tier_enriched.extend(e)
@@ -1185,7 +1398,8 @@ def _run_tier(
         if memo_hits:
             _LOGGER.info(
                 "Memo hit for %d/%d components — reusing earlier verdicts",
-                len(memo_hits), len(memo_hits) + len(to_send),
+                len(memo_hits),
+                len(memo_hits) + len(to_send),
             )
             memo_results = memo.apply(memo_hits)
             tier_enriched.extend(memo_results)
@@ -1195,21 +1409,28 @@ def _run_tier(
         if cache and tier_cache_key is not None:
             cache.put(
                 tier_cache_key,
-                _build_tier_cache_payload(tier_enriched, tier_new, tier_rels, tier_flags),
+                _build_tier_cache_payload(
+                    tier_enriched, tier_new, tier_rels, tier_flags
+                ),
             )
         return tier_enriched, tier_new, tier_rels, tier_flags
 
     batches = _locality_aware_batches(to_send, batch_size)
     _LOGGER.info(
         "%d components → %d locality-aware batches (concurrency=%d)",
-        len(to_send), len(batches), max_concurrent,
+        len(to_send),
+        len(batches),
+        max_concurrent,
     )
 
     if max_concurrent > 1 and len(batches) > 1:
-        enriched, new, rels, flags, batch_artifacts = asyncio.run(
+        enriched, new, rels, flags, batch_artifacts = _run_async_bounded(
             _run_batches_parallel(
-                agent, middleware, batches,
-                relationships, scan_paths,
+                agent,
+                middleware,
+                batches,
+                relationships,
+                scan_paths,
                 all_components=all_components,
                 max_concurrent=max_concurrent,
                 timeout_s=timeout_s,
@@ -1229,15 +1450,21 @@ def _run_tier(
                 _LOGGER.warning(
                     "Agentic circuit breaker: skipping batches %d–%d after "
                     "%d consecutive failures",
-                    idx, len(batches), max_consecutive_failures,
+                    idx,
+                    len(batches),
+                    max_consecutive_failures,
                 )
-                for b in batches[idx - 1:]:
+                for b in batches[idx - 1 :]:
                     enriched.extend(_circuit_breaker_skipped_batch(b))
                 break
             e, n, r, f, batch_failed = _run_batch(
-                agent, middleware, batch,
-                relationships, scan_paths,
-                idx, len(batches),
+                agent,
+                middleware,
+                batch,
+                relationships,
+                scan_paths,
+                idx,
+                len(batches),
                 all_components=all_components,
                 timeout_s=timeout_s,
                 dossier_index=dossier_index,
@@ -1256,7 +1483,8 @@ def _run_tier(
     if retry_candidates:
         _LOGGER.info(
             "Retry pass: %d degraded components, cooling down %ds",
-            len(retry_candidates), _RETRY_COOLDOWN_S,
+            len(retry_candidates),
+            _RETRY_COOLDOWN_S,
         )
         time.sleep(_RETRY_COOLDOWN_S)
 
@@ -1272,7 +1500,8 @@ def _run_tier(
         retry_batches = _locality_aware_batches(retry_candidates, retry_batch_size)
         _LOGGER.info(
             "Retrying %d batches sequentially (batch_size=%d)",
-            len(retry_batches), retry_batch_size,
+            len(retry_batches),
+            retry_batch_size,
         )
 
         retry_enriched: list[AIComponent] = []
@@ -1284,15 +1513,22 @@ def _run_tier(
             if retry_consecutive >= max_consecutive_failures:
                 _LOGGER.warning(
                     "Retry circuit breaker: skipping retry batches %d–%d",
-                    idx, len(retry_batches),
+                    idx,
+                    len(retry_batches),
                 )
-                for b in retry_batches[idx - 1:]:
-                    retry_enriched.extend(_degraded_batch_components(b, hint="retry_failed"))
+                for b in retry_batches[idx - 1 :]:
+                    retry_enriched.extend(
+                        _degraded_batch_components(b, hint="retry_failed")
+                    )
                 break
             e, n, r, f, batch_failed = _run_batch(
-                agent, middleware, batch,
-                relationships, scan_paths,
-                idx, len(retry_batches),
+                agent,
+                middleware,
+                batch,
+                relationships,
+                scan_paths,
+                idx,
+                len(retry_batches),
                 all_components=all_components,
                 timeout_s=timeout_s,
                 dossier_index=dossier_index,
@@ -1307,11 +1543,18 @@ def _run_tier(
             else:
                 retry_consecutive = 0
 
-        recovered = sum(1 for c in retry_enriched if c.agentic_hint not in _RETRYABLE_HINTS and c.agentic_hint != "retry_failed")
+        recovered = sum(
+            1
+            for c in retry_enriched
+            if c.agentic_hint not in _RETRYABLE_HINTS
+            and c.agentic_hint != "retry_failed"
+        )
         still_degraded = len(retry_candidates) - recovered
         _LOGGER.info(
             "Retry pass complete: %d/%d recovered, %d still degraded",
-            recovered, len(retry_candidates), still_degraded,
+            recovered,
+            len(retry_candidates),
+            still_degraded,
         )
 
         enriched = ok + retry_enriched
@@ -1327,9 +1570,7 @@ def _run_tier(
             batch_key = _batch_cache_key(artifact.inputs)
             cache.put(
                 batch_key,
-                _build_batch_cache_payload(
-                    artifact.new, artifact.rels, artifact.flags
-                ),
+                _build_batch_cache_payload(artifact.new, artifact.rels, artifact.flags),
             )
             for c_in in artifact.inputs:
                 artifact_key_by_instance_id[c_in.instance_id] = batch_key
@@ -1343,7 +1584,12 @@ def _run_tier(
                 entry: dict[str, Any] = {
                     "enriched_components": [],
                     "new_components": [],
-                    "remove_components": [{"instance_id": c_before.instance_id, "reason": "cached_removal"}],
+                    "remove_components": [
+                        {
+                            "instance_id": c_before.instance_id,
+                            "reason": "cached_removal",
+                        }
+                    ],
                     "reclassify_components": [],
                     "new_relationships": [],
                     "risk_findings": [],
@@ -1485,10 +1731,14 @@ def run_agentic_enrichment(
             len(dossier_index),
         )
 
-    resolved_cache_dir = cache_dir if cache_dir is not None else _default_agentic_cache_dir()
+    resolved_cache_dir = (
+        cache_dir if cache_dir is not None else _default_agentic_cache_dir()
+    )
     fallback_dirs: list[Path] = []
     if cache_dir is None and resolved_cache_dir is not None:
-        fallback_dirs = [p for p in cache_read_dirs("agentic") if p != resolved_cache_dir]
+        fallback_dirs = [
+            p for p in cache_read_dirs("agentic") if p != resolved_cache_dir
+        ]
     cache = _AgenticResultCache(resolved_cache_dir, fallback_dirs=fallback_dirs)
     middleware = AIBOMScannerMiddleware(
         include_code_snippets=include_code_snippets,
@@ -1516,13 +1766,21 @@ def run_agentic_enrichment(
         if simple:
             _LOGGER.info(
                 "Tier 1 (simple confirmations): %d candidates via %s (batch=%d)",
-                len(simple), tier_model_name, simple_batch_size,
+                len(simple),
+                tier_model_name,
+                simple_batch_size,
             )
             agent = create_aibom_agent(tier_model_name, model=tier_model_obj)
             e, n, r, f = _run_tier(
-                agent, middleware, simple,
-                deterministic_relationships, scan_paths,
-                simple_batch_size, max_concurrent, deterministic_components, cache,
+                agent,
+                middleware,
+                simple,
+                deterministic_relationships,
+                scan_paths,
+                simple_batch_size,
+                max_concurrent,
+                deterministic_components,
+                cache,
                 memo=memo,
                 timeout_s=timeout_s,
                 max_consecutive_failures=max_consecutive_failures,
@@ -1536,26 +1794,36 @@ def run_agentic_enrichment(
         if complex_:
             dir_groups = _group_by_top_dir(complex_, scan_paths)
             use_sub_agents = (
-                len(dir_groups) > 1
-                and len(complex_) > _SUB_AGENT_THRESHOLD
+                len(dir_groups) > 1 and len(complex_) > _SUB_AGENT_THRESHOLD
             )
 
             if use_sub_agents:
                 _LOGGER.info(
                     "Sub-agent dispatch: %d directory groups for %d complex candidates",
-                    len(dir_groups), len(complex_),
+                    len(dir_groups),
+                    len(complex_),
                 )
                 for dir_key, group in sorted(dir_groups.items()):
-                    dir_label = Path(dir_key).name if dir_key != "__default__" else "default"
+                    dir_label = (
+                        Path(dir_key).name if dir_key != "__default__" else "default"
+                    )
                     _LOGGER.info(
                         "Sub-agent [%s]: %d candidates via %s",
-                        dir_label, len(group), model_string,
+                        dir_label,
+                        len(group),
+                        model_string,
                     )
                     agent = create_aibom_agent(model_string, model=complex_model_obj)
                     e, n, r, f = _run_tier(
-                        agent, middleware, group,
-                        deterministic_relationships, scan_paths,
-                        batch_size, max_concurrent, deterministic_components, cache,
+                        agent,
+                        middleware,
+                        group,
+                        deterministic_relationships,
+                        scan_paths,
+                        batch_size,
+                        max_concurrent,
+                        deterministic_components,
+                        cache,
                         memo=memo,
                         timeout_s=timeout_s,
                         max_consecutive_failures=max_consecutive_failures,
@@ -1568,13 +1836,20 @@ def run_agentic_enrichment(
             else:
                 _LOGGER.info(
                     "Tier 2 (complex reasoning): %d candidates via %s",
-                    len(complex_), model_string,
+                    len(complex_),
+                    model_string,
                 )
                 agent = create_aibom_agent(model_string, model=complex_model_obj)
                 e, n, r, f = _run_tier(
-                    agent, middleware, complex_,
-                    deterministic_relationships, scan_paths,
-                    batch_size, max_concurrent, deterministic_components, cache,
+                    agent,
+                    middleware,
+                    complex_,
+                    deterministic_relationships,
+                    scan_paths,
+                    batch_size,
+                    max_concurrent,
+                    deterministic_components,
+                    cache,
                     memo=memo,
                     timeout_s=timeout_s,
                     max_consecutive_failures=max_consecutive_failures,
@@ -1632,7 +1907,7 @@ def _truncate_class_body(body: str) -> tuple[str, bool]:
     """Cap *body* at :data:`_MAX_CLASS_BODY_CHARS`. Returns (text, truncated?)."""
     if len(body) <= _MAX_CLASS_BODY_CHARS:
         return body, False
-    head = body[: _MAX_CLASS_BODY_CHARS]
+    head = body[:_MAX_CLASS_BODY_CHARS]
     return head, True
 
 
@@ -1677,8 +1952,8 @@ def _component_to_summary(
             entry["code_context"] = snippet
 
     if enrich_target and dossier_index:
-        from .evidence_injection import lookup_dossier
         from ..scanners.agent_evidence_builder import render_dossier_for_prompt
+        from .evidence_injection import lookup_dossier
 
         dossier = lookup_dossier(c, dossier_index)
         if dossier is not None:
@@ -1958,11 +2233,11 @@ def run_cross_repo_coordination(
     scan_paths = list(per_repo_results.keys())
 
     # --- Deterministic pre-computation -----------------------------------
+    from ..cross_ref import build_env_index
     from .cross_repo import (
         build_cross_repo_tools,
         cross_repo_summary_tool,
     )
-    from ..cross_ref import build_env_index
 
     summary_json = cross_repo_summary_tool(scan_paths)
     summary = json.loads(summary_json)
@@ -1978,13 +2253,17 @@ def run_cross_repo_coordination(
             var_name = mn[4:]
             entries = env_index.env.get(var_name, [])
             if entries:
-                pre_resolved.append({
-                    "component": c.name if hasattr(c, "name") else c.get("name", ""),
-                    "repo": source,
-                    "env_var": var_name,
-                    "resolved_value": entries[0].value,
-                    "defined_in": entries[0].source_path,
-                })
+                pre_resolved.append(
+                    {
+                        "component": (
+                            c.name if hasattr(c, "name") else c.get("name", "")
+                        ),
+                        "repo": source,
+                        "env_var": var_name,
+                        "resolved_value": entries[0].value,
+                        "defined_in": entries[0].source_path,
+                    }
+                )
 
     repo_overview: list[dict[str, Any]] = []
     for source, data in per_repo_results.items():
@@ -1992,17 +2271,20 @@ def run_cross_repo_coordination(
         type_counts: dict[str, int] = {}
         for c in components:
             ct = (
-                c.component_type.value if hasattr(c, "component_type")
+                c.component_type.value
+                if hasattr(c, "component_type")
                 else c.get("type", "unknown")
             )
             type_counts[ct] = type_counts.get(ct, 0) + 1
         unresolved = data.get("_unresolved_env_vars", [])
-        repo_overview.append({
-            "repo": source,
-            "total_components": len(components),
-            "by_type": type_counts,
-            "unresolved_env_vars": unresolved,
-        })
+        repo_overview.append(
+            {
+                "repo": source,
+                "total_components": len(components),
+                "by_type": type_counts,
+                "unresolved_env_vars": unresolved,
+            }
+        )
 
     orientation = {
         "repos": repo_overview,
@@ -2020,7 +2302,8 @@ def run_cross_repo_coordination(
 
     _LOGGER.info(
         "Running cross-repo coordination across %d repos with %s",
-        len(per_repo_results), model_string,
+        len(per_repo_results),
+        model_string,
     )
 
     xrepo_tools = build_cross_repo_tools(per_repo_results, scan_paths)
@@ -2045,7 +2328,8 @@ def run_cross_repo_coordination(
         )
     except asyncio.TimeoutError:
         _LOGGER.warning(
-            "Cross-repo coordination timed out after %ds", _DEFAULT_AGENTIC_TIMEOUT_S,
+            "Cross-repo coordination timed out after %ds",
+            _DEFAULT_AGENTIC_TIMEOUT_S,
         )
         return [], []
     except Exception as exc:
@@ -2064,15 +2348,17 @@ def run_cross_repo_coordination(
             rel_type = RelationshipType(item.get("relationship_type", "CUSTOM"))
         except ValueError:
             rel_type = RelationshipType.CUSTOM
-        rels.append(ComponentRelationship(
-            source_instance_id="",
-            target_instance_id="",
-            source_name=item.get("source_name", ""),
-            target_name=item.get("target_name", ""),
-            relationship_type=rel_type,
-            source_repo=item.get("source_repo", ""),
-            target_repo=item.get("target_repo", ""),
-        ))
+        rels.append(
+            ComponentRelationship(
+                source_instance_id="",
+                target_instance_id="",
+                source_name=item.get("source_name", ""),
+                target_name=item.get("target_name", ""),
+                relationship_type=rel_type,
+                source_repo=item.get("source_repo", ""),
+                target_repo=item.get("target_repo", ""),
+            )
+        )
 
     from ..models import Severity as Sev
 
@@ -2082,16 +2368,19 @@ def run_cross_repo_coordination(
             sev = Sev(item.get("severity", "info"))
         except ValueError:
             sev = Sev.INFO
-        flags.append(RiskFlag(
-            flag=item.get("flag", "cross_repo_issue"),
-            severity=sev,
-            weight=5,
-            description=item.get("description", ""),
-        ))
+        flags.append(
+            RiskFlag(
+                flag=item.get("flag", "cross_repo_issue"),
+                severity=sev,
+                weight=5,
+                description=item.get("description", ""),
+            )
+        )
 
     _LOGGER.info(
         "Cross-repo coordination: %d relationships, %d risk flags",
-        len(rels), len(flags),
+        len(rels),
+        len(flags),
     )
     cache.put(cache_key, _build_cross_repo_cache_payload(rels, flags))
     return rels, flags
@@ -2100,6 +2389,7 @@ def run_cross_repo_coordination(
 # ---------------------------------------------------------------------------
 # Container layout resolution (agentic)
 # ---------------------------------------------------------------------------
+
 
 class _SelectedDirectory(BaseModel):
     path: str = ""
@@ -2179,7 +2469,10 @@ def resolve_container_layout(
     try:
         model = _build_model(model_string, llm_config)
     except Exception:
-        _LOGGER.warning("Failed to init LLM for container layout, using all candidates", exc_info=True)
+        _LOGGER.warning(
+            "Failed to init LLM for container layout, using all candidates",
+            exc_info=True,
+        )
         return candidate_dirs
 
     try:
@@ -2192,11 +2485,14 @@ def resolve_container_layout(
         )
 
         file_sample = file_listing[:2000]
-        user_message = json.dumps({
-            "image_config": image_config,
-            "candidate_directories": candidate_dirs,
-            "file_listing_sample": file_sample,
-        }, indent=2)
+        user_message = json.dumps(
+            {
+                "image_config": image_config,
+                "candidate_directories": candidate_dirs,
+                "file_listing_sample": file_sample,
+            },
+            indent=2,
+        )
 
         result = asyncio.run(
             asyncio.wait_for(
@@ -2210,7 +2506,9 @@ def resolve_container_layout(
             )
         )
     except Exception:
-        _LOGGER.warning("Container layout agent failed, using all candidates", exc_info=True)
+        _LOGGER.warning(
+            "Container layout agent failed, using all candidates", exc_info=True
+        )
         return candidate_dirs
     finally:
         _close_model_clients(model)
@@ -2224,11 +2522,15 @@ def resolve_container_layout(
     selected = [d for d in selected if d]
 
     if not selected:
-        _LOGGER.info("Container layout agent selected no directories, using all candidates")
+        _LOGGER.info(
+            "Container layout agent selected no directories, using all candidates"
+        )
         return candidate_dirs
 
     _LOGGER.info(
         "Container layout agent selected %d of %d dirs: %s",
-        len(selected), len(candidate_dirs), selected,
+        len(selected),
+        len(candidate_dirs),
+        selected,
     )
     return selected

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -2348,10 +2348,12 @@ def run_cross_repo_coordination(
         f"```json\n{json.dumps(orientation, indent=2, default=str)}\n```"
     )
 
+    # Log only the repo count — the model id is already logged per tier during
+    # enrichment, and ``model_string`` is read from the credential-bearing
+    # ``llm_config`` dict, so logging it trips clear-text-logging taint analysis.
     _LOGGER.info(
-        "Running cross-repo coordination across %d repos with %s",
+        "Running cross-repo coordination across %d repos",
         len(per_repo_results),
-        model_string,
     )
 
     xrepo_tools = build_cross_repo_tools(per_repo_results, scan_paths)

--- a/aibom/src/aibom/agentic/prompts.py
+++ b/aibom/src/aibom/agentic/prompts.py
@@ -246,6 +246,10 @@ You receive two lists:
      ``agent`` it calls over the A2A protocol
    - ``EXPOSES_A2A_AGENT``: host service / server → ``agent`` exposed via
      an Agent Card at a well-known endpoint
+   - ``USES_AGENT``: agent → another ``agent`` it invokes or delegates to
+     (sub-agent, handoff, multi-agent orchestration) within the same process
+   - ``USES_SKILL``: agent → a ``skill`` it uses (Semantic Kernel / Copilot
+     plugin or skill definition)
    - ``HOSTS_MODEL``: endpoint → model ID it serves
    - ``CUSTOM``: ONLY as last resort when none of the above apply.
    For EVERY relationship, you MUST also specify:

--- a/aibom/src/aibom/categorizer.py
+++ b/aibom/src/aibom/categorizer.py
@@ -14,28 +14,28 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Dict, List, Optional, Set, Tuple
-from collections import defaultdict
 import logging
+from collections import defaultdict
+from typing import Any, Dict, List, Optional, Set, Tuple
 
-from .structures import (
-    CodeAnalysisResult,
-    AssignmentObservation,
-    CallObservation,
-    ClassDefObservation,
-    DecoratorObservation,
-    FunctionAnnotationObservation,
-    ComponentRelationship,
-    CategorizationOutput,
-)
 from .catalog_db import CatalogDB, is_excluded
 from .custom_catalog import CustomCatalogConfig
 from .llm_client import LLMClient
+from .structures import (
+    AssignmentObservation,
+    CallObservation,
+    CategorizationOutput,
+    ClassDefObservation,
+    CodeAnalysisResult,
+    ComponentRelationship,
+    DecoratorObservation,
+    FunctionAnnotationObservation,
+)
 from .workflow_analyzer import WorkflowIndex
-
 
 AGENT_CATEGORY_HINTS = {"agent"}
 TOOL_CATEGORY_HINTS = {"tool"}
+SKILL_CATEGORY_HINTS = {"skill"}
 LLM_CATEGORY_HINTS = {"llm", "model"}
 MEMORY_CATEGORY_HINTS = {"memory"}
 RETRIEVER_CATEGORY_HINTS = {"retriever"}
@@ -46,13 +46,32 @@ TOOL_ARGUMENT_HINTS = {"tool", "tools", "skills", "abilities"}
 LLM_ARGUMENT_HINTS = {"llm", "language_model", "chat_model", "model"}
 MEMORY_ARGUMENT_HINTS = {"memory", "checkpointer", "store", "saver", "chat_history"}
 RETRIEVER_ARGUMENT_HINTS = {"retriever", "retrievers", "search", "search_kwargs"}
-EMBEDDING_ARGUMENT_HINTS = {"embedding", "embeddings", "embedding_function", "embed", "embed_model"}
+EMBEDDING_ARGUMENT_HINTS = {
+    "embedding",
+    "embeddings",
+    "embedding_function",
+    "embed",
+    "embed_model",
+}
+# An agent referencing other agents (sub-agents, delegation, handoffs).
+AGENT_ARGUMENT_HINTS = {
+    "agent",
+    "agents",
+    "sub_agents",
+    "subagents",
+    "handoffs",
+    "delegates",
+}
+# An agent referencing skills (Semantic Kernel / Copilot-style plugins/skills).
+SKILL_ARGUMENT_HINTS = {"skill", "skills", "plugins", "abilities"}
 
 RELATIONSHIP_LABEL_TOOL = "USES_TOOL"
 RELATIONSHIP_LABEL_LLM = "USES_LLM"
 RELATIONSHIP_LABEL_MEMORY = "USES_MEMORY"
 RELATIONSHIP_LABEL_RETRIEVER = "USES_RETRIEVER"
 RELATIONSHIP_LABEL_EMBEDDING = "USES_EMBEDDING"
+RELATIONSHIP_LABEL_AGENT = "USES_AGENT"
+RELATIONSHIP_LABEL_SKILL = "USES_SKILL"
 
 
 _is_excluded = is_excluded  # re-export for backward compatibility
@@ -106,12 +125,14 @@ def categorize_symbols(
     for result in analysis_results:
         for assignment in result.assignments:
             if assignment.target_qualified_name and assignment.call.qualified_name:
-                variable_map[assignment.target_qualified_name] = assignment.call.qualified_name
+                variable_map[assignment.target_qualified_name] = (
+                    assignment.call.qualified_name
+                )
 
     # Collect all observations with enhanced tracking
     all_observations = []
     symbols_to_find = set()
-    
+
     for result in analysis_results:
         for obs_type in ["assignments", "decorators", "calls"]:
             for obs in getattr(result, obs_type):
@@ -123,13 +144,21 @@ def categorize_symbols(
                     original_name = obs.call.qualified_name
 
                 reconstructed_name = original_name
-                instance_variable = getattr(obs, 'instance_variable', None)
+                instance_variable = getattr(obs, "instance_variable", None)
                 if obs_type == "decorators" and instance_variable:
                     if instance_variable in variable_map:
                         base_class = variable_map[instance_variable]
-                        attribute = original_name.split('.', 1)[-1] if '.' in original_name else original_name
+                        attribute = (
+                            original_name.split(".", 1)[-1]
+                            if "." in original_name
+                            else original_name
+                        )
                         reconstructed_name = f"{base_class}.{attribute}"
-                        logging.debug("Reconstructed decorator: %s -> %s", original_name, reconstructed_name)
+                        logging.debug(
+                            "Reconstructed decorator: %s -> %s",
+                            original_name,
+                            reconstructed_name,
+                        )
 
                 # Method-chain resolution: e.g. "builder.compile" -> "langgraph.graph.StateGraph.compile"
                 if "." in reconstructed_name:
@@ -140,17 +169,23 @@ def categorize_symbols(
                         resolved_base = variable_map[local_var]
                         candidate = f"{resolved_base}.{attr_tail}"
                         reconstructed_name = candidate
-                        logging.debug("Method-chain resolved: %s -> %s", original_name, reconstructed_name)
+                        logging.debug(
+                            "Method-chain resolved: %s -> %s",
+                            original_name,
+                            reconstructed_name,
+                        )
 
                 if obs_type == "calls":
                     obs_arguments = obs.arguments
                     obs_raw_code = obs.raw_code
                 elif obs_type == "assignments":
                     obs_arguments = obs.call.arguments
-                    obs_raw_code = getattr(obs, 'raw_code', '') or getattr(obs.call, 'raw_code', '')
+                    obs_raw_code = getattr(obs, "raw_code", "") or getattr(
+                        obs.call, "raw_code", ""
+                    )
                 else:
                     obs_arguments = {}
-                    obs_raw_code = getattr(obs, 'raw_code', '')
+                    obs_raw_code = getattr(obs, "raw_code", "")
 
                 observation = {
                     "parser_name": reconstructed_name,
@@ -158,14 +193,22 @@ def categorize_symbols(
                     "file_path": result.file_path,
                     "line_number": obs.line_number,
                     "arguments": obs_arguments,
-                    "decorated_name": obs.decorated_function_name if obs_type == "decorators" else None,
+                    "decorated_name": (
+                        obs.decorated_function_name
+                        if obs_type == "decorators"
+                        else None
+                    ),
                     "type": obs_type[:-1] if obs_type != "calls" else "call",
                     "raw_code": obs_raw_code,
-                    "imports": getattr(result, 'imports', []),
+                    "imports": getattr(result, "imports", []),
                     "instance_variable": instance_variable,
-                    "assigned_target": getattr(obs, 'target_qualified_name', None) if obs_type == "assignments" else None,
+                    "assigned_target": (
+                        getattr(obs, "target_qualified_name", None)
+                        if obs_type == "assignments"
+                        else None
+                    ),
                 }
-                
+
                 all_observations.append(observation)
                 symbols_to_find.add(reconstructed_name)
 
@@ -182,7 +225,7 @@ def categorize_symbols(
                 "decorated_name": None,
                 "type": "type_annotation",
                 "raw_code": "",
-                "imports": getattr(result, 'imports', []),
+                "imports": getattr(result, "imports", []),
                 "instance_variable": None,
                 "annotation_target": annotation.target_qualified_name,
             }
@@ -202,7 +245,7 @@ def categorize_symbols(
                 "decorated_name": None,
                 "type": "context_manager",
                 "raw_code": "",
-                "imports": getattr(result, 'imports', []),
+                "imports": getattr(result, "imports", []),
                 "instance_variable": None,
                 "context_target": ctx.as_target,
             }
@@ -245,9 +288,14 @@ def categorize_symbols(
                 if label:
                     comp_details["name"] = label
 
-                if workflow_index and comp_details.get("file_path") and comp_details.get("line_number"):
+                if (
+                    workflow_index
+                    and comp_details.get("file_path")
+                    and comp_details.get("line_number")
+                ):
                     workflows = workflow_index.get_workflow_context(
-                        comp_details["file_path"], comp_details["line_number"],
+                        comp_details["file_path"],
+                        comp_details["line_number"],
                     )
                     if workflows:
                         comp_details["workflows"] = workflows
@@ -255,9 +303,14 @@ def categorize_symbols(
                 categorized_components[concept].append(comp_details)
                 comp_details["instance_id"] = _build_instance_id(comp_details)
                 detected_locations.add((result.file_path, class_obs.line_number))
-                _register_component_name(component_lookup_by_name, comp_details["name"], comp_details)
+                _register_component_name(
+                    component_lookup_by_name, comp_details["name"], comp_details
+                )
                 _register_component_target(
-                    component_lookup_by_var, result.file_path, comp_name, comp_details,
+                    component_lookup_by_var,
+                    result.file_path,
+                    comp_name,
+                    comp_details,
                 )
 
         for func_obs in getattr(result, "function_annotations", []):
@@ -277,9 +330,14 @@ def categorize_symbols(
             if label:
                 comp_details["name"] = label
 
-            if workflow_index and comp_details.get("file_path") and comp_details.get("line_number"):
+            if (
+                workflow_index
+                and comp_details.get("file_path")
+                and comp_details.get("line_number")
+            ):
                 workflows = workflow_index.get_workflow_context(
-                    comp_details["file_path"], comp_details["line_number"],
+                    comp_details["file_path"],
+                    comp_details["line_number"],
                 )
                 if workflows:
                     comp_details["workflows"] = workflows
@@ -287,9 +345,14 @@ def categorize_symbols(
             categorized_components[concept].append(comp_details)
             comp_details["instance_id"] = _build_instance_id(comp_details)
             detected_locations.add((result.file_path, func_obs.line_number))
-            _register_component_name(component_lookup_by_name, comp_details["name"], comp_details)
+            _register_component_name(
+                component_lookup_by_name, comp_details["name"], comp_details
+            )
             _register_component_target(
-                component_lookup_by_var, result.file_path, comp_name, comp_details,
+                component_lookup_by_var,
+                result.file_path,
+                comp_name,
+                comp_details,
             )
 
     # ── Pass 2: DuckDB catalog matching ──────────────────────────────────
@@ -314,12 +377,19 @@ def categorize_symbols(
                 matching_observations.append(obs)
 
         if not matching_observations:
-            logging.debug("Skipping symbol '%s' because it could not be matched to any code observation.", db_symbol_name)
+            logging.debug(
+                "Skipping symbol '%s' because it could not be matched to any code observation.",
+                db_symbol_name,
+            )
             continue
 
         # Process each matching observation
         for matched_obs in matching_observations:
-            obs_key = (matched_obs["file_path"], matched_obs["line_number"], matched_obs["parser_name"])
+            obs_key = (
+                matched_obs["file_path"],
+                matched_obs["line_number"],
+                matched_obs["parser_name"],
+            )
             if obs_key in processed_observations:
                 continue  # Skip if already processed by another DB symbol
 
@@ -339,20 +409,26 @@ def categorize_symbols(
             component_details["category"] = category
 
             description = None
-            if category == 'tool':
+            if category == "tool":
                 # Primary strategy: Get description from arguments
-                description = matched_obs.get('arguments', {}).get('description')
+                description = matched_obs.get("arguments", {}).get("description")
                 # Fallback strategy: Generate description with LLM if not found
-                if not description and llm_client and matched_obs.get('raw_code'):
+                if not description and llm_client and matched_obs.get("raw_code"):
                     try:
                         code_snippet = _reconstruct_code_snippet(matched_obs)
                         prompt = f"Please provide a concise, one-sentence description for the following tool based on its code. The tool's code is:\n\n{code_snippet}"
-                        logging.info("Generating description for tool: %s", db_symbol_name)
+                        logging.info(
+                            "Generating description for tool: %s", db_symbol_name
+                        )
                         description = llm_client.invoke(prompt)
                     except Exception as e:
-                        logging.warning("Failed to generate description for %s: %s", db_symbol_name, e)
+                        logging.warning(
+                            "Failed to generate description for %s: %s",
+                            db_symbol_name,
+                            e,
+                        )
                 if description:
-                    component_details['description'] = description
+                    component_details["description"] = description
 
             if matched_obs["type"] == "decorator":
                 component_details["name"] = matched_obs["decorated_name"]
@@ -360,31 +436,43 @@ def categorize_symbols(
 
             elif matched_obs["type"] in ("assignment", "call"):
                 if category == "prompt":
-                    prompt_text = matched_obs["arguments"].get("template") or matched_obs["arguments"].get("prompt")
+                    prompt_text = matched_obs["arguments"].get(
+                        "template"
+                    ) or matched_obs["arguments"].get("prompt")
                     if prompt_text:
                         component_details["text"] = prompt_text
 
                 elif category in ["model", "embedding"] and llm_client:
-                    class_name = db_symbol_name.split('.')[-1]
+                    class_name = db_symbol_name.split(".")[-1]
                     code_snippet = _reconstruct_code_snippet(matched_obs)
 
                     if category == "model":
-                        model_name = llm_client.extract_model_name(code_snippet, class_name)
+                        model_name = llm_client.extract_model_name(
+                            code_snippet, class_name
+                        )
                         if model_name:
                             component_details["model_name"] = model_name
 
                     elif category == "embedding":
-                        embedding_model = llm_client.extract_embedding_model(code_snippet, class_name)
+                        embedding_model = llm_client.extract_embedding_model(
+                            code_snippet, class_name
+                        )
                         if embedding_model:
                             component_details["model_name"] = embedding_model
 
             elif matched_obs["type"] == "type_annotation":
-                component_details["annotated_target"] = matched_obs.get("annotation_target")
+                component_details["annotated_target"] = matched_obs.get(
+                    "annotation_target"
+                )
 
             elif matched_obs["type"] == "context_manager":
                 component_details["context_target"] = matched_obs.get("context_target")
 
-            if workflow_index and component_details.get("file_path") and component_details.get("line_number"):
+            if (
+                workflow_index
+                and component_details.get("file_path")
+                and component_details.get("line_number")
+            ):
                 workflows = workflow_index.get_workflow_context(
                     component_details["file_path"],
                     component_details["line_number"],
@@ -418,7 +506,9 @@ def categorize_symbols(
                     component_details.update(meta)
                     break
 
-            _register_component_name(component_lookup_by_name, component_details["name"], component_details)
+            _register_component_name(
+                component_lookup_by_name, component_details["name"], component_details
+            )
 
     # ── Pass 3: Base class detection (lowest precedence) ─────────────────
     base_class_rules = custom_config.base_class_rules if custom_config else []
@@ -452,9 +542,14 @@ def categorize_symbols(
                             "base_class_matched": rule.base_class,
                         }
 
-                        if workflow_index and comp_details.get("file_path") and comp_details.get("line_number"):
+                        if (
+                            workflow_index
+                            and comp_details.get("file_path")
+                            and comp_details.get("line_number")
+                        ):
                             workflows = workflow_index.get_workflow_context(
-                                comp_details["file_path"], comp_details["line_number"],
+                                comp_details["file_path"],
+                                comp_details["line_number"],
                             )
                             if workflows:
                                 comp_details["workflows"] = workflows
@@ -462,9 +557,14 @@ def categorize_symbols(
                         categorized_components[rule.concept].append(comp_details)
                         comp_details["instance_id"] = _build_instance_id(comp_details)
                         detected_locations.add(loc_key)
-                        _register_component_name(component_lookup_by_name, comp_details["name"], comp_details)
+                        _register_component_name(
+                            component_lookup_by_name, comp_details["name"], comp_details
+                        )
                         _register_component_target(
-                            component_lookup_by_var, result.file_path, comp_name, comp_details,
+                            component_lookup_by_var,
+                            result.file_path,
+                            comp_name,
+                            comp_details,
                         )
                         break  # first matching rule wins
 
@@ -472,7 +572,8 @@ def categorize_symbols(
     if exclude_patterns:
         for category in list(categorized_components.keys()):
             categorized_components[category] = [
-                c for c in categorized_components[category]
+                c
+                for c in categorized_components[category]
                 if not _is_excluded(c.get("name", ""), exclude_patterns)
             ]
 
@@ -501,10 +602,14 @@ def categorize_symbols(
         effective_memory_hints=effective_memory_hints,
         effective_retriever_hints=effective_retriever_hints,
         effective_embedding_hints=effective_embedding_hints,
-        custom_relationships=custom_config.custom_relationships if custom_config else [],
+        custom_relationships=(
+            custom_config.custom_relationships if custom_config else []
+        ),
     )
 
-    return CategorizationOutput(components=dict(categorized_components), relationships=relationships)
+    return CategorizationOutput(
+        components=dict(categorized_components), relationships=relationships
+    )
 
 
 def _augment_agent_metadata_from_graph_wiring(
@@ -554,7 +659,9 @@ def _augment_agent_metadata_from_graph_wiring(
         return
 
     import_map, components_by_file, func_scope_obs = _build_graph_wiring_indices(
-        analysis_results, categorized_components, all_observations,
+        analysis_results,
+        categorized_components,
+        all_observations,
     )
 
     # ── Main add_node scanning loop ─────────────────────────────────────
@@ -638,7 +745,9 @@ def _augment_agent_metadata_from_graph_wiring(
                     if comp_name.endswith(call_name) or comp_name == call_name:
                         cat_lower = cat.lower()
                         if "tool" in cat_lower:
-                            existing_args.setdefault("tools", []).append(f"VARIABLE:{call_name}")
+                            existing_args.setdefault("tools", []).append(
+                                f"VARIABLE:{call_name}"
+                            )
                         elif "model" in cat_lower:
                             existing_args["llm"] = f"VARIABLE:{call_name}"
                         elif "memory" in cat_lower:
@@ -655,8 +764,12 @@ def _augment_agent_metadata_from_graph_wiring(
             qualified = file_imps.get(inner_ref)
             if qualified:
                 _resolve_cross_file_ref(
-                    inner_ref, qualified, components_by_file, analysis_results,
-                    categorized_components, existing_args,
+                    inner_ref,
+                    qualified,
+                    components_by_file,
+                    analysis_results,
+                    categorized_components,
+                    existing_args,
                 )
 
         # Check direct variable references
@@ -678,10 +791,17 @@ def _augment_agent_metadata_from_graph_wiring(
                     matched_inner = False
                     for cat, comp_list in categorized_components.items():
                         for comp in comp_list:
-                            if comp.get("name") and (comp["name"] == inner_name or inner_name.endswith(comp["name"])):
+                            if comp.get("name") and (
+                                comp["name"] == inner_name
+                                or inner_name.endswith(comp["name"])
+                            ):
                                 _merge_component_ref_into_args(
-                                    inner_obs.get("assigned_target", "").rsplit(".", 1)[-1] or inner_name,
-                                    comp, existing_args,
+                                    inner_obs.get("assigned_target", "").rsplit(".", 1)[
+                                        -1
+                                    ]
+                                    or inner_name,
+                                    comp,
+                                    existing_args,
                                 )
                                 matched_inner = True
                                 break
@@ -706,12 +826,22 @@ def _augment_agent_metadata_from_graph_wiring(
                                 fp_norm = fp.replace("/", ".").replace("\\", ".")
                                 if fp_norm.endswith(".py"):
                                     fp_norm = fp_norm[:-3]
-                                if fp_norm.endswith(module_part) or fp_norm.endswith("." + module_part):
+                                if fp_norm.endswith(module_part) or fp_norm.endswith(
+                                    "." + module_part
+                                ):
                                     for mod_comp in file_comps:
-                                        mod_cat = (mod_comp.get("category") or "").lower()
-                                        comp_ref = mod_comp.get("assigned_target") or mod_comp.get("name", "")
-                                        if not _category_matches(mod_cat, AGENT_CATEGORY_HINTS):
-                                            _merge_component_ref_into_args(comp_ref, mod_comp, existing_args)
+                                        mod_cat = (
+                                            mod_comp.get("category") or ""
+                                        ).lower()
+                                        comp_ref = mod_comp.get(
+                                            "assigned_target"
+                                        ) or mod_comp.get("name", "")
+                                        if not _category_matches(
+                                            mod_cat, AGENT_CATEGORY_HINTS
+                                        ):
+                                            _merge_component_ref_into_args(
+                                                comp_ref, mod_comp, existing_args
+                                            )
                                     found_module = True
                                     break
                             if found_module:
@@ -724,8 +854,12 @@ def _augment_agent_metadata_from_graph_wiring(
             qualified = file_imps.get(ref)
             if qualified:
                 _resolve_cross_file_ref(
-                    ref, qualified, components_by_file, analysis_results,
-                    categorized_components, existing_args,
+                    ref,
+                    qualified,
+                    components_by_file,
+                    analysis_results,
+                    categorized_components,
+                    existing_args,
                 )
                 continue
 
@@ -735,7 +869,9 @@ def _augment_agent_metadata_from_graph_wiring(
                 for cat, comp_list in categorized_components.items():
                     matched = False
                     for comp in comp_list:
-                        if comp.get("name", "") == resolved or comp.get("name", "").endswith(f".{ref}"):
+                        if comp.get("name", "") == resolved or comp.get(
+                            "name", ""
+                        ).endswith(f".{ref}"):
                             _merge_component_ref_into_args(ref, comp, existing_args)
                             matched = True
                             break
@@ -745,7 +881,9 @@ def _augment_agent_metadata_from_graph_wiring(
         metadata["arguments"] = existing_args
 
     _apply_same_file_inference(
-        agents_with_wiring, component_metadata_by_instance, components_by_file,
+        agents_with_wiring,
+        component_metadata_by_instance,
+        components_by_file,
     )
 
 
@@ -827,7 +965,10 @@ def _apply_same_file_inference(
         if not metadata:
             continue
         existing_args = metadata.get("arguments", {})
-        if any(k in existing_args for k in ("llm", "model", "tools", "memory", "retriever", "embedding")):
+        if any(
+            k in existing_args
+            for k in ("llm", "model", "tools", "memory", "retriever", "embedding")
+        ):
             continue
 
         agent_file = metadata.get("file_path", "")
@@ -891,7 +1032,11 @@ def _resolve_cross_file_ref(
     """
     # qualified_import is e.g. "react_agent.tools.TOOLS"
     # The variable name in the source file is the last segment
-    remote_var = qualified_import.rsplit(".", 1)[-1] if "." in qualified_import else qualified_import
+    remote_var = (
+        qualified_import.rsplit(".", 1)[-1]
+        if "." in qualified_import
+        else qualified_import
+    )
     # The module path is everything before the last segment
     module_path = qualified_import.rsplit(".", 1)[0] if "." in qualified_import else ""
 
@@ -905,7 +1050,9 @@ def _resolve_cross_file_ref(
         if fp_normalized.endswith(".py"):
             fp_normalized = fp_normalized[:-3]
 
-        if not fp_normalized.endswith(module_path) and not fp_normalized.endswith("." + module_path):
+        if not fp_normalized.endswith(module_path) and not fp_normalized.endswith(
+            "." + module_path
+        ):
             continue
 
         # Found a candidate source file; look for components assigned to remote_var
@@ -944,38 +1091,39 @@ def _is_symbol_match(parser_name: str, db_symbol_name: str, imports: List[str]) 
     """
     return parser_name == db_symbol_name
 
+
 def _reconstruct_code_snippet(observation: Dict[str, Any]) -> str:
     """
     Reconstruct code snippet from observation for LLM analysis.
-    
+
     Args:
         observation: The observation dictionary
-        
+
     Returns:
         Reconstructed code snippet
     """
     if observation.get("raw_code"):
         return observation["raw_code"]
-    
+
     # Fallback: reconstruct from available information
     parser_name = observation.get("parser_name", "")
     arguments = observation.get("arguments", {})
-    
+
     # Handle empty parser_name
     if not parser_name:
         return "()"
-    
-    class_name = parser_name.split('.')[-1] if parser_name else ""
-    
+
+    class_name = parser_name.split(".")[-1] if parser_name else ""
+
     # Build argument string
     arg_parts = []
     for key, value in arguments.items():
         if isinstance(value, str):
             arg_parts.append(f'{key}="{value}"')
         else:
-            arg_parts.append(f'{key}={value}')
-    
-    args_str = ', '.join(arg_parts)
+            arg_parts.append(f"{key}={value}")
+
+    args_str = ", ".join(arg_parts)
     return f"{class_name}({args_str})"
 
 
@@ -997,7 +1145,11 @@ def _register_component_target(
         index[(file_path, normalized)] = component
 
 
-def _register_component_name(index: Dict[str, List[Dict[str, Any]]], name: Optional[str], component: Dict[str, Any]) -> None:
+def _register_component_name(
+    index: Dict[str, List[Dict[str, Any]]],
+    name: Optional[str],
+    component: Dict[str, Any],
+) -> None:
     if not name:
         return
     for normalized in _normalize_reference_names(name):
@@ -1041,11 +1193,16 @@ def _derive_relationships(
             tool_refs = _collect_references(arguments, tool_hints)
             for reference in tool_refs:
                 target_component = _resolve_component_reference(
-                    reference, agent_file, component_lookup_by_var, component_lookup_by_name
+                    reference,
+                    agent_file,
+                    component_lookup_by_var,
+                    component_lookup_by_name,
                 )
                 if not target_component:
                     continue
-                if not _category_matches(target_component.get("category"), TOOL_CATEGORY_HINTS):
+                if not _category_matches(
+                    target_component.get("category"), TOOL_CATEGORY_HINTS
+                ):
                     continue
                 _append_relationship(
                     relationships,
@@ -1058,7 +1215,10 @@ def _derive_relationships(
             llm_refs = _collect_references(arguments, llm_hints)
             for reference in llm_refs:
                 target_component = _resolve_component_reference(
-                    reference, agent_file, component_lookup_by_var, component_lookup_by_name
+                    reference,
+                    agent_file,
+                    component_lookup_by_var,
+                    component_lookup_by_name,
                 )
                 if not target_component:
                     continue
@@ -1075,11 +1235,16 @@ def _derive_relationships(
             memory_refs = _collect_references(arguments, memory_hints)
             for reference in memory_refs:
                 target_component = _resolve_component_reference(
-                    reference, agent_file, component_lookup_by_var, component_lookup_by_name
+                    reference,
+                    agent_file,
+                    component_lookup_by_var,
+                    component_lookup_by_name,
                 )
                 if not target_component:
                     continue
-                if not _category_matches(target_component.get("category"), MEMORY_CATEGORY_HINTS):
+                if not _category_matches(
+                    target_component.get("category"), MEMORY_CATEGORY_HINTS
+                ):
                     continue
                 _append_relationship(
                     relationships,
@@ -1092,11 +1257,16 @@ def _derive_relationships(
             retriever_refs = _collect_references(arguments, retriever_hints)
             for reference in retriever_refs:
                 target_component = _resolve_component_reference(
-                    reference, agent_file, component_lookup_by_var, component_lookup_by_name
+                    reference,
+                    agent_file,
+                    component_lookup_by_var,
+                    component_lookup_by_name,
                 )
                 if not target_component:
                     continue
-                if not _category_matches(target_component.get("category"), RETRIEVER_CATEGORY_HINTS):
+                if not _category_matches(
+                    target_component.get("category"), RETRIEVER_CATEGORY_HINTS
+                ):
                     continue
                 _append_relationship(
                     relationships,
@@ -1109,11 +1279,16 @@ def _derive_relationships(
             embedding_refs = _collect_references(arguments, embedding_hints)
             for reference in embedding_refs:
                 target_component = _resolve_component_reference(
-                    reference, agent_file, component_lookup_by_var, component_lookup_by_name
+                    reference,
+                    agent_file,
+                    component_lookup_by_var,
+                    component_lookup_by_name,
                 )
                 if not target_component:
                     continue
-                if not _category_matches(target_component.get("category"), EMBEDDING_CATEGORY_HINTS):
+                if not _category_matches(
+                    target_component.get("category"), EMBEDDING_CATEGORY_HINTS
+                ):
                     continue
                 _append_relationship(
                     relationships,
@@ -1121,6 +1296,53 @@ def _derive_relationships(
                     component,
                     target_component,
                     RELATIONSHIP_LABEL_EMBEDDING,
+                )
+
+            agent_refs = _collect_references(arguments, AGENT_ARGUMENT_HINTS)
+            for reference in agent_refs:
+                target_component = _resolve_component_reference(
+                    reference,
+                    agent_file,
+                    component_lookup_by_var,
+                    component_lookup_by_name,
+                )
+                if not target_component:
+                    continue
+                if not _category_matches(
+                    target_component.get("category"), AGENT_CATEGORY_HINTS
+                ):
+                    continue
+                # An agent referencing itself is not a delegation edge.
+                if target_component.get("instance_id") == instance_id:
+                    continue
+                _append_relationship(
+                    relationships,
+                    seen_relationships,
+                    component,
+                    target_component,
+                    RELATIONSHIP_LABEL_AGENT,
+                )
+
+            skill_refs = _collect_references(arguments, SKILL_ARGUMENT_HINTS)
+            for reference in skill_refs:
+                target_component = _resolve_component_reference(
+                    reference,
+                    agent_file,
+                    component_lookup_by_var,
+                    component_lookup_by_name,
+                )
+                if not target_component:
+                    continue
+                if not _category_matches(
+                    target_component.get("category"), SKILL_CATEGORY_HINTS
+                ):
+                    continue
+                _append_relationship(
+                    relationships,
+                    seen_relationships,
+                    component,
+                    target_component,
+                    RELATIONSHIP_LABEL_SKILL,
                 )
 
     # Also derive USES_EMBEDDING from datastore components
@@ -1140,11 +1362,16 @@ def _derive_relationships(
             embedding_refs = _collect_references(arguments, embedding_hints)
             for reference in embedding_refs:
                 target_component = _resolve_component_reference(
-                    reference, ds_file, component_lookup_by_var, component_lookup_by_name
+                    reference,
+                    ds_file,
+                    component_lookup_by_var,
+                    component_lookup_by_name,
                 )
                 if not target_component:
                     continue
-                if not _category_matches(target_component.get("category"), EMBEDDING_CATEGORY_HINTS):
+                if not _category_matches(
+                    target_component.get("category"), EMBEDDING_CATEGORY_HINTS
+                ):
                     continue
                 _append_relationship(
                     relationships,
@@ -1180,7 +1407,10 @@ def _derive_relationships(
                     refs = _collect_references(arguments, arg_hint_set)
                     for reference in refs:
                         target_component = _resolve_component_reference(
-                            reference, comp_file, component_lookup_by_var, component_lookup_by_name
+                            reference,
+                            comp_file,
+                            component_lookup_by_var,
+                            component_lookup_by_name,
                         )
                         if not target_component:
                             continue

--- a/aibom/src/aibom/llm_factory.py
+++ b/aibom/src/aibom/llm_factory.py
@@ -23,9 +23,30 @@ from __future__ import annotations
 
 import importlib
 import logging
+import re
 from typing import Any
 
 _logger = logging.getLogger(__name__)
+
+# OpenAI reasoning-class models reject ``max_tokens`` (they require
+# ``max_completion_tokens``) and reject a non-default ``temperature``. Matches
+# the o-series (o1, o3, o4, …) and gpt-5.x reasoning families by the leaf model
+# id (after any ``provider/`` prefix and any date/version suffix).
+_REASONING_MODEL_RE = re.compile(
+    r"^(?:o\d+(?:-|$)|gpt-5)",
+    re.IGNORECASE,
+)
+
+
+def _is_reasoning_model(model_id: str) -> bool:
+    """True for OpenAI reasoning-class models (o-series, gpt-5.x).
+
+    These models do not accept ``max_tokens`` or a custom ``temperature``.
+    Detection is on the leaf model id with any ``provider/`` prefix stripped.
+    """
+    leaf = model_id.rsplit("/", 1)[-1].strip()
+    return bool(_REASONING_MODEL_RE.match(leaf))
+
 
 try:
     from langchain.chat_models import init_chat_model
@@ -33,11 +54,11 @@ except ImportError:
     init_chat_model = None  # agentic extras not installed
 
 _PROVIDER_IMPORT_HINTS: dict[str, tuple[str, str]] = {
-    "openai": ("langchain_openai", 'cisco-aibom[agentic,llm-openai]'),
-    "azure_openai": ("langchain_openai", 'cisco-aibom[agentic,llm-openai]'),
-    "bedrock": ("langchain_aws", 'cisco-aibom[agentic,llm-aws]'),
-    "anthropic": ("langchain_anthropic", 'cisco-aibom[agentic,llm-anthropic]'),
-    "google_genai": ("langchain_google_genai", 'cisco-aibom[agentic,llm-google]'),
+    "openai": ("langchain_openai", "cisco-aibom[agentic,llm-openai]"),
+    "azure_openai": ("langchain_openai", "cisco-aibom[agentic,llm-openai]"),
+    "bedrock": ("langchain_aws", "cisco-aibom[agentic,llm-aws]"),
+    "anthropic": ("langchain_anthropic", "cisco-aibom[agentic,llm-anthropic]"),
+    "google_genai": ("langchain_google_genai", "cisco-aibom[agentic,llm-google]"),
 }
 
 
@@ -149,9 +170,16 @@ def build_chat_model(
     if api_version and resolved_provider == "azure_openai":
         init_kwargs["api_version"] = api_version
 
-    init_kwargs["temperature"] = temperature
-    if max_tokens is not None:
-        init_kwargs["max_tokens"] = max_tokens
+    # Reasoning-class models (o-series, gpt-5.x) reject ``max_tokens`` and a
+    # non-default ``temperature``; emit ``max_completion_tokens`` instead and
+    # omit ``temperature`` so the provider applies its required default.
+    if _is_reasoning_model(model_id):
+        if max_tokens is not None:
+            init_kwargs["max_completion_tokens"] = max_tokens
+    else:
+        init_kwargs["temperature"] = temperature
+        if max_tokens is not None:
+            init_kwargs["max_tokens"] = max_tokens
 
     if rate_limiter is not None:
         init_kwargs["rate_limiter"] = rate_limiter

--- a/aibom/src/aibom/models/enums.py
+++ b/aibom/src/aibom/models/enums.py
@@ -175,6 +175,8 @@ class RelationshipType(str, Enum):
     HOSTS_MODEL = "HOSTS_MODEL"
     INVOKES_A2A_AGENT = "INVOKES_A2A_AGENT"
     EXPOSES_A2A_AGENT = "EXPOSES_A2A_AGENT"
+    # An agent invoking / delegating to another agent.
+    USES_AGENT = "USES_AGENT"
+    # An agent using a skill (Semantic Kernel / Copilot-style plugin or skill).
+    USES_SKILL = "USES_SKILL"
     CUSTOM = "CUSTOM"
-
-

--- a/aibom/src/aibom/repo_triage.py
+++ b/aibom/src/aibom/repo_triage.py
@@ -26,7 +26,6 @@ authority on whether a repository contains AI/ML assets.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from dataclasses import dataclass, field
@@ -143,19 +142,23 @@ class RepoTriager:
             )
 
     def _invoke_with_timeout(self, agent: Any, user_msg: str) -> Any:
-        """Invoke the agent with a wall-clock timeout."""
-        async def _run() -> Any:
-            return await asyncio.wait_for(
-                asyncio.to_thread(
-                    lambda: agent.invoke(
-                        {"messages": [{"role": "user", "content": user_msg}]},
-                        config={"recursion_limit": _TRIAGE_RECURSION_LIMIT},
-                    ),
-                ),
-                timeout=_TRIAGE_TIMEOUT_S,
-            )
+        """Invoke the agent with a hard wall-clock timeout.
 
-        return asyncio.run(_run())
+        Delegates to the shared daemon-thread deadline helper: a blocking
+        ``agent.invoke`` that hangs is abandoned after ``_TRIAGE_TIMEOUT_S``
+        rather than wedging the scan at event-loop/process shutdown.
+        The helper raises ``_InvokeTimeout`` (an ``Exception``),
+        which the caller's broad ``except Exception`` maps to a deep-scan
+        fallback. Imported lazily to keep the agentic extras optional.
+        """
+        from .agentic.agent import _invoke_agent_bounded
+
+        return _invoke_agent_bounded(
+            agent,
+            user_msg,
+            _TRIAGE_TIMEOUT_S,
+            recursion_limit=_TRIAGE_RECURSION_LIMIT,
+        )
 
     def _parse_result(self, repo_path: str, result: Any) -> TriageResult:
         """Extract the triage decision from the agent response."""

--- a/aibom/src/aibom/reporters/json_reporter.py
+++ b/aibom/src/aibom/reporters/json_reporter.py
@@ -44,7 +44,9 @@ def _friendly_source_name(path: str) -> str:
         try:
             result = subprocess.run(
                 ["git", "-C", str(resolved), "remote", "get-url", "origin"],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
             if result.returncode == 0:
                 m = _REMOTE_ORG_REPO_RE.search(result.stdout.strip())
@@ -55,7 +57,56 @@ def _friendly_source_name(path: str) -> str:
     return PurePosixPath(path).name or path
 
 
-def _components_by_type(components: Iterable[AIComponent]) -> dict[str, list[dict[str, Any]]]:
+def _source_attribution(path: str, detail: dict[str, Any]) -> dict[str, str]:
+    """Resolve the source-attribution triple for one scanned source.
+
+    Values supplied by the scan pipeline / cross-repo discovery (in ``detail``)
+    win, since that path may already know the resolved remote or image digest.
+    Otherwise the triple is derived deterministically from the local path:
+    ``source_kind`` from the working tree, ``source_ref_canonical`` from the
+    canonicalized ``origin`` remote, and ``source_ref_version`` from ``HEAD``.
+    """
+    from ..source_attribution import (
+        SOURCE_KIND_CONTAINER_IMAGE,
+        canonicalize_source_ref,
+        capture_git_remote,
+        capture_source_ref_version,
+        detect_source_kind,
+    )
+
+    is_image = (detail.get("source_kind") == SOURCE_KIND_CONTAINER_IMAGE) or None
+    source_kind = detail.get("source_kind") or detect_source_kind(
+        path, is_container_image=is_image
+    )
+
+    canonical = detail.get("source_ref_canonical")
+    if not canonical:
+        raw_ref = detail.get("source_ref")
+        if not raw_ref and source_kind != SOURCE_KIND_CONTAINER_IMAGE:
+            raw_ref = capture_git_remote(path)
+        canonical = canonicalize_source_ref(raw_ref, source_kind) if raw_ref else ""
+
+    version = detail.get("source_ref_version")
+    if not version:
+        version = (
+            capture_source_ref_version(
+                path,
+                source_kind,
+                image_digest=detail.get("image_digest"),
+            )
+            or ""
+        )
+
+    return {
+        "source_kind": source_kind,
+        "source_ref_canonical": canonical or "",
+        "source_ref_version": version or "",
+    }
+
+
+def _components_by_type(
+    components: Iterable[AIComponent],
+) -> dict[str, list[dict[str, Any]]]:
     grouped: dict[str, list[dict[str, Any]]] = {}
     for comp in components:
         key = comp.component_type.value
@@ -126,8 +177,13 @@ def _aibom_payload(
         source_name = detail.get("source_name") or _friendly_source_name(src.path)
         source_key = _disambiguate_source_key(source_name, seen_source_names)
         source_path = detail.get("source_path") or src.path
-        source_kind = detail.get("source_kind") or "local-path"
-        per_source_meta: dict[str, Any] = {}
+        attribution = _source_attribution(src.path, detail)
+        source_kind = attribution["source_kind"]
+        per_source_meta: dict[str, Any] = {
+            "source_kind": attribution["source_kind"],
+            "source_ref_canonical": attribution["source_ref_canonical"],
+            "source_ref_version": attribution["source_ref_version"],
+        }
         for mk in ("elapsed_s", "prompt_tokens", "completion_tokens", "total_tokens"):
             val = detail.get(mk)
             if val is not None:
@@ -140,18 +196,17 @@ def _aibom_payload(
             "summary": {
                 "status": detail.get("status") or "completed",
                 "source_kind": source_kind,
-                "assets_discovered": detail.get("assets_discovered") or total_components,
+                "assets_discovered": detail.get("assets_discovered")
+                or total_components,
                 "last_generated_at": (
-                    detail.get("last_generated_at")
-                    or raw_metadata.get("completed_at")
+                    detail.get("last_generated_at") or raw_metadata.get("completed_at")
                 ),
             },
-            **({"metadata": per_source_meta} if per_source_meta else {}),
+            "metadata": per_source_meta,
         }
         components_by_source[source_key] = list(src.components)
     cross_repo_links_out = [
-        link.model_dump(mode="json")
-        for link in result.cross_repo_links
+        link.model_dump(mode="json") for link in result.cross_repo_links
     ]
     analysis: dict[str, Any] = {
         "metadata": raw_metadata,

--- a/aibom/src/aibom/scan_pipeline.py
+++ b/aibom/src/aibom/scan_pipeline.py
@@ -522,30 +522,65 @@ def _evidence_gate(
     return result
 
 
+# Path segments that unambiguously denote test-only code on their own.
 _TEST_PATH_SEGMENTS: frozenset[str] = frozenset(
     {
         "tests",
         "test",
         "__tests__",
-        "spec",
-        "testing",
         "testdata",
         "test_data",
+    }
+)
+
+# Segments that are commonly used for test scaffolding but ALSO occur in
+# production trees (an OpenAPI ``spec/``, a shipped ``testing`` utility
+# package, a ``fixtures/`` data loader). These count as test-only only when
+# accompanied by another test signal — an unambiguous test directory ancestor
+# or a test-style filename — so a production asset living under one of these
+# directories is not silently dropped from the BOM.
+_AMBIGUOUS_TEST_PATH_SEGMENTS: frozenset[str] = frozenset(
+    {
+        "spec",
+        "testing",
         "fixtures",
     }
 )
 
 
+def _has_test_filename(path: "Path") -> bool:
+    """True when the filename itself follows a test naming convention."""
+    stem = path.stem.lower()
+    return stem.startswith("test_") or stem.endswith("_test")
+
+
 def _is_test_file(file_path: str) -> bool:
-    """Return True when the file is clearly test-only by path or filename."""
+    """Return True when the file is clearly test-only by path or filename.
+
+    Unambiguous test directories (``tests``, ``__tests__``, ``testdata`` …)
+    and test-style filenames (``test_*`` / ``*_test``) classify on their own.
+    The ambiguous segments (``spec``/``testing``/``fixtures``) classify only
+    when a second test signal is present, so production code under those
+    directory names is not misclassified as test-only.
+    """
     from pathlib import Path
 
     path = Path(file_path)
-    if any(seg in _TEST_PATH_SEGMENTS for seg in path.parts):
+    parts = set(path.parts)
+
+    if parts & _TEST_PATH_SEGMENTS:
         return True
 
-    stem = path.stem.lower()
-    return stem.startswith("test_") or stem.endswith("_test")
+    has_test_name = _has_test_filename(path)
+    if has_test_name:
+        return True
+
+    if parts & _AMBIGUOUS_TEST_PATH_SEGMENTS:
+        # Only test-only when corroborated by an unambiguous test directory
+        # ancestor (the filename signal is already handled above).
+        return bool(parts & _TEST_PATH_SEGMENTS)
+
+    return False
 
 
 def _has_instantiation_marker(c: "AIComponent") -> bool:

--- a/aibom/src/aibom/scan_pipeline.py
+++ b/aibom/src/aibom/scan_pipeline.py
@@ -28,9 +28,9 @@ from __future__ import annotations
 import logging
 import re
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from collections.abc import Callable
 from typing import Any
 
 _ENV_PLACEHOLDER_RE = re.compile(r"\$\{[^}]+\}")
@@ -54,8 +54,9 @@ def _strip_env_prefix(name: str) -> str:
     """
     for prefix in _ENV_NAME_PREFIXES:
         if name.startswith(prefix):
-            return name[len(prefix):]
+            return name[len(prefix) :]
     return name
+
 
 from .agent_signatures import AgentSignatureCatalog, resolve_catalog
 from .cross_ref import (
@@ -134,9 +135,14 @@ def _consolidation_key(c: "AIComponent") -> tuple[str, str]:
     return (canonical, c.component_type.value)
 
 
-_CONTEXT_FREE_TYPES: frozenset[str] = frozenset({
-    "dependency", "model", "model_artifact", "embedding",
-})
+_CONTEXT_FREE_TYPES: frozenset[str] = frozenset(
+    {
+        "dependency",
+        "model",
+        "model_artifact",
+        "embedding",
+    }
+)
 
 
 def _dedup_for_agentic(
@@ -215,6 +221,60 @@ def _is_import_only_candidate(c: "AIComponent") -> bool:
     return bool(md.get("import_statement")) and not md.get("call_pattern")
 
 
+def _is_protected_dependency(c: "AIComponent") -> bool:
+    """True for a dependency row that is a recognized AI package.
+
+    A dependency declared in a manifest and matched against the AI-package
+    allow-list is a deterministic, verifiable fact — not a heuristic candidate
+    that needs the agent's keep/prune judgment. The agentic stage may still
+    omit it from its returned set (it processes each candidate independently
+    and an unfamiliar SDK name can be pruned), which would otherwise cause
+    :func:`_propagate_removals` to drop every instance of that package. Such
+    rows must survive regardless of the agent's decision.
+    """
+    return c.component_type == AIComponentType.DEPENDENCY and bool(
+        (c.metadata or {}).get("known_ai_package")
+    )
+
+
+def _reinstate_protected_dependencies(
+    all_candidates: list["AIComponent"],
+    enriched: list["AIComponent"],
+) -> list["AIComponent"]:
+    """Re-add recognized AI dependencies the agent dropped.
+
+    Covers the case where the agent omits the sole dedup representative of a
+    package: fanout then restores none of its instances, so a dependency that
+    is a verified manifest fact would silently disappear. Any protected
+    dependency present in the original candidate set but absent from the
+    enriched output is re-appended (preserving any enrichment already applied
+    to a surviving instance with the same key).
+    """
+    present_keys = {
+        _consolidation_key(c) for c in enriched if _is_protected_dependency(c)
+    }
+    present_ids = {c.instance_id for c in enriched}
+    readded = 0
+    for c in all_candidates:
+        if not _is_protected_dependency(c):
+            continue
+        if c.instance_id in present_ids:
+            continue
+        if _consolidation_key(c) in present_keys:
+            continue
+        enriched.append(c)
+        present_keys.add(_consolidation_key(c))
+        present_ids.add(c.instance_id)
+        readded += 1
+    if readded:
+        _LOGGER.info(
+            "Reinstated %d recognized AI dependency component(s) dropped "
+            "by the agentic stage",
+            readded,
+        )
+    return enriched
+
+
 def _propagate_removals(
     sent: list["AIComponent"],
     received: list["AIComponent"],
@@ -266,6 +326,10 @@ def _propagate_removals(
     for c in sent:
         if c.instance_id not in removed_ids:
             continue
+        # A recognized AI dependency is a deterministic manifest fact; never
+        # let the agent omitting it become a removal signal for that package.
+        if _is_protected_dependency(c):
+            continue
         key = _consolidation_key(c)
         if _is_import_only_candidate(c):
             weak_keys.add(key)
@@ -277,6 +341,8 @@ def _propagate_removals(
     lookup_pool = all_candidates if all_candidates is not None else received
     drop_ids: set[str] = set()
     for c in lookup_pool:
+        if _is_protected_dependency(c):
+            continue
         key = _consolidation_key(c)
         if key in strong_keys:
             drop_ids.add(c.instance_id)
@@ -289,7 +355,9 @@ def _propagate_removals(
         _LOGGER.info(
             "Removal propagation: dropped %d additional component(s) "
             "(%d strong key(s), %d weak import-only key(s))",
-            dropped, len(strong_keys), len(weak_keys),
+            dropped,
+            len(strong_keys),
+            len(weak_keys),
         )
     return result
 
@@ -338,10 +406,12 @@ def _evidence_gate(
     before_map: dict[str, "AIComponent"] = {c.instance_id: c for c in before_agentic}
     allowed_roots = list(scan_paths or [])
 
-    _AGENT_TYPES: frozenset[AIComponentType] = frozenset({
-        AIComponentType.AGENT,
-        AIComponentType.AGENT_PROXY,
-    })
+    _AGENT_TYPES: frozenset[AIComponentType] = frozenset(
+        {
+            AIComponentType.AGENT,
+            AIComponentType.AGENT_PROXY,
+        }
+    )
 
     result: list["AIComponent"] = []
     gate_removed = 0
@@ -360,7 +430,8 @@ def _evidence_gate(
             _LOGGER.info(
                 "Evidence gate removed model '%s' (%s): "
                 "not found in any model registry and detection_source=kb_enrichment",
-                c.name, c.instance_id,
+                c.name,
+                c.instance_id,
             )
             gate_removed += 1
             continue
@@ -375,7 +446,8 @@ def _evidence_gate(
             _LOGGER.info(
                 "Evidence gate removed memory '%s' (%s): "
                 "agent kept kb_enrichment component unchanged",
-                c.name, c.instance_id,
+                c.name,
+                c.instance_id,
             )
             gate_removed += 1
             continue
@@ -388,7 +460,8 @@ def _evidence_gate(
             if is_structural or type_flipped or import_only:
                 raw_evidence = (c.metadata or {}).get("agent_evidence")
                 ok, reason = _verify_agent_evidence(
-                    raw_evidence, allowed_roots=allowed_roots,
+                    raw_evidence,
+                    allowed_roots=allowed_roots,
                 )
                 if not ok:
                     _LOGGER.warning(
@@ -412,15 +485,25 @@ def _evidence_gate(
         _LOGGER.info(
             "Evidence gate: removed %d component(s) "
             "(%d model/memory, %d agent/agent_proxy)",
-            total_removed, gate_removed, agent_evidence_removed,
+            total_removed,
+            gate_removed,
+            agent_evidence_removed,
         )
     return result
 
 
-_TEST_PATH_SEGMENTS: frozenset[str] = frozenset({
-    "tests", "test", "__tests__", "spec", "testing", "testdata",
-    "test_data", "fixtures",
-})
+_TEST_PATH_SEGMENTS: frozenset[str] = frozenset(
+    {
+        "tests",
+        "test",
+        "__tests__",
+        "spec",
+        "testing",
+        "testdata",
+        "test_data",
+        "fixtures",
+    }
+)
 
 
 def _is_test_file(file_path: str) -> bool:
@@ -487,12 +570,15 @@ def _consolidate_components(
             result.append(c)
             continue
 
-        best = max(group, key=lambda c: (
-            c.heuristic_confidence,
-            1 if _has_instantiation_marker(c) else 0,
-            0 if _is_test_file(c.file_path) else 1,
-            -c.line_number,
-        ))
+        best = max(
+            group,
+            key=lambda c: (
+                c.heuristic_confidence,
+                1 if _has_instantiation_marker(c) else 0,
+                0 if _is_test_file(c.file_path) else 1,
+                -c.line_number,
+            ),
+        )
         evidence = []
         evidence_files: list[str] = []
         seen_files: set[str] = set()
@@ -505,12 +591,14 @@ def _consolidate_components(
                 seen_files.add(c.file_path)
                 evidence_files.append(c.file_path)
             if c is not best:
-                evidence.append({
-                    "file": c.file_path,
-                    "line": c.line_number,
-                    "service": _service_dir(c.file_path),
-                    "test_only": is_test,
-                })
+                evidence.append(
+                    {
+                        "file": c.file_path,
+                        "line": c.line_number,
+                        "service": _service_dir(c.file_path),
+                        "test_only": is_test,
+                    }
+                )
 
         if not _is_test_file(best.file_path):
             all_test = False
@@ -525,10 +613,12 @@ def _consolidate_components(
 
         needs = any(c.needs_agentic for c in group)
 
-        merged = best.model_copy(update={
-            "metadata": merged_meta,
-            "needs_agentic": needs,
-        })
+        merged = best.model_copy(
+            update={
+                "metadata": merged_meta,
+                "needs_agentic": needs,
+            }
+        )
         result.append(merged)
 
     return result
@@ -559,7 +649,8 @@ def _canonicalize_env_var_names(
     out: list[AIComponent] = []
     for c in components:
         if c.component_type not in (
-            AIComponentType.MODEL, AIComponentType.EMBEDDING,
+            AIComponentType.MODEL,
+            AIComponentType.EMBEDDING,
         ):
             out.append(c)
             continue
@@ -568,19 +659,25 @@ def _canonicalize_env_var_names(
         env_var = meta.get("env_var") or meta.get("env")
         model_name = c.model_name
         if (
-            isinstance(env_var, str) and env_var
+            isinstance(env_var, str)
+            and env_var
             and _strip_env_prefix(c.name) == env_var
-            and isinstance(model_name, str) and model_name
+            and isinstance(model_name, str)
+            and model_name
             and model_name != c.name
             and not model_name.lower().startswith(("http://", "https://"))
             and not _ENV_PLACEHOLDER_RE.search(model_name)
         ):
             canon_meta = dict(meta)
             canon_meta.setdefault("env_var", env_var)
-            out.append(c.model_copy(update={
-                "name": model_name,
-                "metadata": canon_meta,
-            }))
+            out.append(
+                c.model_copy(
+                    update={
+                        "name": model_name,
+                        "metadata": canon_meta,
+                    }
+                )
+            )
         else:
             out.append(c)
     return out
@@ -599,12 +696,11 @@ def _dedup_mcp_clients(
     ``mcp_integration_mcp_client`` beats ``stdio_client``) and whose
     metadata carries ``call_pattern`` / ``assigned_to`` markers.
     """
+
     def _rank(c: "AIComponent") -> tuple[int, int, float]:
         meta = c.metadata or {}
         name = c.name or ""
-        basename_like = 1 if (
-            name.endswith("_client") and "_" in name
-        ) else 0
+        basename_like = 1 if (name.endswith("_client") and "_" in name) else 0
         marker = 1 if _has_instantiation_marker(c) else 0
         return (marker, basename_like, c.heuristic_confidence)
 
@@ -673,7 +769,8 @@ def _filter_relationships_for_components(
         return False
 
     return [
-        rel for rel in relationships
+        rel
+        for rel in relationships
         if _endpoint_present(rel.source_instance_id, rel.source_name)
         and _endpoint_present(rel.target_instance_id, rel.target_name)
     ]
@@ -745,11 +842,14 @@ def _consolidate_vector_stores(
             merged.append(c.model_copy(update={"metadata": meta}))
             continue
 
-        best = max(group, key=lambda c: (
-            c.heuristic_confidence,
-            0 if _is_test_file(c.file_path) else 1,
-            -c.line_number,
-        ))
+        best = max(
+            group,
+            key=lambda c: (
+                c.heuristic_confidence,
+                0 if _is_test_file(c.file_path) else 1,
+                -c.line_number,
+            ),
+        )
         seen: set[tuple[str, int]] = set()
         evidence: list[dict[str, Any]] = []
 
@@ -765,12 +865,14 @@ def _consolidate_vector_stores(
             if key in seen:
                 return
             seen.add(key)
-            evidence.append({
-                "file": file_path,
-                "line": line_number,
-                "service": _service_dir(file_path),
-                "test_only": test_only,
-            })
+            evidence.append(
+                {
+                    "file": file_path,
+                    "line": line_number,
+                    "service": _service_dir(file_path),
+                    "test_only": test_only,
+                }
+            )
 
         def _merge_prior_evidence(meta: dict[str, Any]) -> None:
             for ev in meta.get("evidence") or []:
@@ -794,7 +896,8 @@ def _consolidate_vector_stores(
 
         best_key = (best.file_path, best.line_number)
         merged_evidence = [
-            ev for ev in evidence
+            ev
+            for ev in evidence
             if (str(ev.get("file", "")), int(ev.get("line", 0) or 0)) != best_key
         ]
 
@@ -809,10 +912,14 @@ def _consolidate_vector_stores(
 
         needs = any(c.needs_agentic for c in group)
 
-        merged.append(best.model_copy(update={
-            "metadata": merged_meta,
-            "needs_agentic": needs,
-        }))
+        merged.append(
+            best.model_copy(
+                update={
+                    "metadata": merged_meta,
+                    "needs_agentic": needs,
+                }
+            )
+        )
 
     return merged
 
@@ -905,7 +1012,11 @@ def _propagate_model_from_relationships(
     result: list[AIComponent] = []
     for comp in components:
         if comp.model_name is None:
-            target = model_targets.get(f"id:{comp.instance_id}") if comp.instance_id else None
+            target = (
+                model_targets.get(f"id:{comp.instance_id}")
+                if comp.instance_id
+                else None
+            )
             if target is None:
                 target = model_targets.get(f"name:{comp.name}") if comp.name else None
             if target is not None:
@@ -976,9 +1087,7 @@ class ScanPipeline:
         self.agentic_fast_model = agentic_fast_model
         self.agentic_timeout = agentic_timeout
         self.agentic_cache_dir = (
-            Path(agentic_cache_dir)
-            if agentic_cache_dir is not None
-            else None
+            Path(agentic_cache_dir) if agentic_cache_dir is not None else None
         )
         self.include_code_snippets = include_code_snippets
         self.progress_callback = progress_callback
@@ -1018,11 +1127,14 @@ class ScanPipeline:
         components, relationships = self._stage_scan(ctx)
         elapsed = time.monotonic() - t0
         fc = cache_stats()
-        timings.append(StageTiming(
-            "scan", elapsed,
-            f"{len(components)} components, {len(relationships)} relationships, "
-            f"file cache {fc['hits']} hits / {fc['misses']} misses",
-        ))
+        timings.append(
+            StageTiming(
+                "scan",
+                elapsed,
+                f"{len(components)} components, {len(relationships)} relationships, "
+                f"file cache {fc['hits']} hits / {fc['misses']} misses",
+            )
+        )
         self._emit_progress(
             "stage_completed",
             stage="scan",
@@ -1032,15 +1144,16 @@ class ScanPipeline:
 
         self._emit_progress("stage_started", stage="cross_ref", total_stages=4)
         t0 = time.monotonic()
-        components, env_idx, pkg_idx, ext_deps = self._stage_cross_ref(
-            components
-        )
+        components, env_idx, pkg_idx, ext_deps = self._stage_cross_ref(components)
         elapsed = time.monotonic() - t0
-        timings.append(StageTiming(
-            "cross_ref", elapsed,
-            f"{sum(len(v) for v in env_idx.env.values())} env vars, "
-            f"{len(pkg_idx.packages)} packages, {len(ext_deps)} external deps",
-        ))
+        timings.append(
+            StageTiming(
+                "cross_ref",
+                elapsed,
+                f"{sum(len(v) for v in env_idx.env.values())} env vars, "
+                f"{len(pkg_idx.packages)} packages, {len(ext_deps)} external deps",
+            )
+        )
         self._emit_progress(
             "stage_completed",
             stage="cross_ref",
@@ -1055,10 +1168,17 @@ class ScanPipeline:
         )
         elapsed = time.monotonic() - t0
         skipped = not self.llm_config
-        timings.append(StageTiming(
-            "agentic", elapsed,
-            "skipped (no --llm-model)" if skipped else f"{len(agentic_flags)} risk flags",
-        ))
+        timings.append(
+            StageTiming(
+                "agentic",
+                elapsed,
+                (
+                    "skipped (no --llm-model)"
+                    if skipped
+                    else f"{len(agentic_flags)} risk flags"
+                ),
+            )
+        )
         self._emit_progress(
             "stage_completed",
             stage="agentic",
@@ -1070,9 +1190,13 @@ class ScanPipeline:
         t0 = time.monotonic()
         components, agentic_count = self._stage_assemble(components)
         elapsed = time.monotonic() - t0
-        timings.append(StageTiming(
-            "assemble", elapsed, f"{len(components)} final, {agentic_count} agentic",
-        ))
+        timings.append(
+            StageTiming(
+                "assemble",
+                elapsed,
+                f"{len(components)} final, {agentic_count} agentic",
+            )
+        )
         self._emit_progress(
             "stage_completed",
             stage="assemble",
@@ -1082,9 +1206,7 @@ class ScanPipeline:
         relationships = _resolve_relationship_types(relationships, components)
         components = _propagate_model_from_relationships(components, relationships)
         relationships = _dedup_relationships(relationships)
-        relationships = _filter_relationships_for_components(
-            relationships, components
-        )
+        relationships = _filter_relationships_for_components(relationships, components)
         agentic_flags = _filter_risk_flags_for_default_scope(agentic_flags)
 
         total_elapsed = time.monotonic() - pipeline_start
@@ -1121,8 +1243,7 @@ class ScanPipeline:
             _LOGGER.info(
                 "Pass 1: discovered %d AI package(s) from manifests: %s",
                 len(ai_pkgs),
-                ", ".join(sorted(ai_pkgs)[:10])
-                + ("…" if len(ai_pkgs) > 10 else ""),
+                ", ".join(sorted(ai_pkgs)[:10]) + ("…" if len(ai_pkgs) > 10 else ""),
             )
         else:
             _LOGGER.debug("Pass 1: no AI packages found in manifests")
@@ -1132,6 +1253,7 @@ class ScanPipeline:
         idx = ctx_pass2.file_index()
         if idx:
             import asyncio
+
             from .scanners.file_cache import warm_cache_async
 
             all_paths = [e.path for entries in idx.values() for e in entries]
@@ -1146,6 +1268,7 @@ class ScanPipeline:
 
             if loop and loop.is_running():
                 import concurrent.futures
+
                 with concurrent.futures.ThreadPoolExecutor(1) as pool:
                     warmed = pool.submit(
                         asyncio.run, warm_cache_async(all_paths)
@@ -1154,7 +1277,8 @@ class ScanPipeline:
                 warmed = asyncio.run(warm_cache_async(all_paths))
             _LOGGER.info(
                 "Pass 2 prep: pre-cached %d / %d files via async I/O",
-                warmed, len(all_paths),
+                warmed,
+                len(all_paths),
             )
             self._emit_progress(
                 "file_cache_prep_completed",
@@ -1188,9 +1312,7 @@ class ScanPipeline:
 
         ext_deps = detect_external_repo_deps(self.scan_paths)
         if ext_deps:
-            _LOGGER.info(
-                "Detected %d external repo dependency(ies)", len(ext_deps)
-            )
+            _LOGGER.info("Detected %d external repo dependency(ies)", len(ext_deps))
             escaping = [d for d in ext_deps if d.escapes_root]
             if escaping:
                 _LOGGER.warning(
@@ -1235,7 +1357,9 @@ class ScanPipeline:
             if len(deduped) < len(components):
                 _LOGGER.info(
                     "Pre-agentic dedup: %d → %d components (%d context-free duplicates removed)",
-                    len(components), len(deduped), len(components) - len(deduped),
+                    len(components),
+                    len(deduped),
+                    len(components) - len(deduped),
                 )
 
             model_str = self.llm_config["model"]
@@ -1253,32 +1377,41 @@ class ScanPipeline:
                     len(user_sigs.protocols),
                     len(user_sigs.anti_patterns),
                 )
-            enriched, agentic_rels, agentic_flags, agentic_token_usage = run_agentic_enrichment(
-                model_string=model_str,
-                deterministic_components=deduped,
-                deterministic_relationships=relationships,
-                scan_paths=self.scan_paths,
-                llm_config=self.llm_config,
-                batch_size=self.agentic_batch_size,
-                max_concurrent=self.agentic_concurrency,
-                fast_model=self.agentic_fast_model,
-                timeout_s=self.agentic_timeout,
-                cache_dir=self.agentic_cache_dir,
-                include_code_snippets=self.include_code_snippets,
-                agent_signature_catalog=agent_catalog,
+            enriched, agentic_rels, agentic_flags, agentic_token_usage = (
+                run_agentic_enrichment(
+                    model_string=model_str,
+                    deterministic_components=deduped,
+                    deterministic_relationships=relationships,
+                    scan_paths=self.scan_paths,
+                    llm_config=self.llm_config,
+                    batch_size=self.agentic_batch_size,
+                    max_concurrent=self.agentic_concurrency,
+                    fast_model=self.agentic_fast_model,
+                    timeout_s=self.agentic_timeout,
+                    cache_dir=self.agentic_cache_dir,
+                    include_code_snippets=self.include_code_snippets,
+                    agent_signature_catalog=agent_catalog,
+                )
             )
             deduped_ids = {c.instance_id for c in deduped}
-            enriched_deduped_ids = {c.instance_id for c in enriched if c.instance_id in deduped_ids}
+            enriched_deduped_ids = {
+                c.instance_id for c in enriched if c.instance_id in deduped_ids
+            }
             new_components = [c for c in enriched if c.instance_id not in deduped_ids]
             pre_fanout_removed = deduped_ids - enriched_deduped_ids
             enriched_for_fanout = [c for c in enriched if c.instance_id in deduped_ids]
             enriched = _fanout_agentic_results(enriched_for_fanout, fanout)
             enriched = _propagate_removals(
-                deduped, enriched, all_candidates=components,
+                deduped,
+                enriched,
+                all_candidates=components,
                 pre_fanout_removed_ids=pre_fanout_removed,
             )
+            enriched = _reinstate_protected_dependencies(components, enriched)
             enriched = _evidence_gate(
-                components, enriched, scan_paths=self.scan_paths,
+                components,
+                enriched,
+                scan_paths=self.scan_paths,
             )
             if new_components:
                 enriched = enriched + new_components
@@ -1288,6 +1421,7 @@ class ScanPipeline:
                 _reject_class_name_models,
                 _remove_unresolved_embedders,
             )
+
             enriched = _reject_class_name_models(enriched)
             all_rels = relationships + agentic_rels
             enriched = _remove_unresolved_embedders(enriched, all_rels)
@@ -1315,7 +1449,8 @@ class ScanPipeline:
         components = _canonicalize_env_var_names(components)
         if before_canon:
             _LOGGER.debug(
-                "Env-var canonicalization applied to %d components", before_canon,
+                "Env-var canonicalization applied to %d components",
+                before_canon,
             )
 
         before_mcp = len(components)
@@ -1323,7 +1458,9 @@ class ScanPipeline:
         if before_mcp != len(components):
             _LOGGER.info(
                 "MCP client dedup: %d → %d components (-%d)",
-                before_mcp, len(components), before_mcp - len(components),
+                before_mcp,
+                len(components),
+                before_mcp - len(components),
             )
 
         # Normalize MODEL → EMBEDDING for components whose name is a
@@ -1354,7 +1491,9 @@ class ScanPipeline:
         if before != after:
             _LOGGER.info(
                 "Consolidation: %d → %d components (-%d duplicates)",
-                before, after, before - after,
+                before,
+                after,
+                before - after,
             )
 
         before_vs = len(components)
@@ -1363,7 +1502,9 @@ class ScanPipeline:
         if before_vs != after_vs:
             _LOGGER.info(
                 "Vector store dedup: %d → %d components (-%d)",
-                before_vs, after_vs, before_vs - after_vs,
+                before_vs,
+                after_vs,
+                before_vs - after_vs,
             )
 
         before_td = len(components)
@@ -1372,7 +1513,9 @@ class ScanPipeline:
         if before_td != after_td:
             _LOGGER.info(
                 "Tool/vector_store priority dedup: %d → %d (-%d)",
-                before_td, after_td, before_td - after_td,
+                before_td,
+                after_td,
+                before_td - after_td,
             )
 
         before_scope = len(components)
@@ -1381,7 +1524,9 @@ class ScanPipeline:
         if before_scope != after_scope:
             _LOGGER.info(
                 "Default BOM scope: %d → %d components (-%d test/fixture-only)",
-                before_scope, after_scope, before_scope - after_scope,
+                before_scope,
+                after_scope,
+                before_scope - after_scope,
             )
 
         before_deps = len(components)
@@ -1390,15 +1535,15 @@ class ScanPipeline:
         if before_deps != after_deps:
             _LOGGER.info(
                 "AI-only dependency policy: %d → %d components (-%d non-AI dependencies)",
-                before_deps, after_deps, before_deps - after_deps,
+                before_deps,
+                after_deps,
+                before_deps - after_deps,
             )
 
         agentic_count = sum(1 for c in components if c.needs_agentic)
 
         if self.strict:
             components = [c for c in components if not c.needs_agentic]
-            _LOGGER.info(
-                "Strict mode: filtered %d agentic candidates", agentic_count
-            )
+            _LOGGER.info("Strict mode: filtered %d agentic candidates", agentic_count)
 
         return components, agentic_count

--- a/aibom/src/aibom/scan_pipeline.py
+++ b/aibom/src/aibom/scan_pipeline.py
@@ -964,6 +964,60 @@ def _rel_endpoint_key(instance_id: str, name: str) -> str:
     return ""
 
 
+def _backfill_relationship_instance_ids(
+    relationships: list[ComponentRelationship],
+    components: list[AIComponent],
+) -> list[ComponentRelationship]:
+    """Deterministically populate blank endpoint ``instance_id``s on edges.
+
+    The agentic/LLM path emits relationships with empty
+    ``source_instance_id``/``target_instance_id`` even though every component
+    carries a stable, deterministic ``instance_id``. Downstream consumers that
+    link edges to components by id therefore drop those edges entirely.
+
+    This pass resolves a blank endpoint by matching its ``*_name`` against the
+    final component set, using the same rule as the deterministic resolver:
+    assign the component's ``instance_id`` only when the name resolves to
+    exactly one component (or when a model-name alias resolves uniquely).
+    Ambiguous or unresolvable endpoints are left blank — no guessed ids, so
+    the existing safe name-fallback behaviour is preserved. Resolution is
+    fully deterministic and never depends on LLM output.
+    """
+    by_name: dict[str, list[AIComponent]] = {}
+    for comp in components:
+        if comp.name:
+            by_name.setdefault(comp.name, []).append(comp)
+        if comp.model_name and comp.model_name != comp.name:
+            by_name.setdefault(comp.model_name, []).append(comp)
+
+    def _resolve(name: str) -> str | None:
+        candidates = by_name.get(name)
+        if candidates and len(candidates) == 1:
+            return candidates[0].instance_id
+        return None
+
+    result: list[ComponentRelationship] = []
+    filled = 0
+    for rel in relationships:
+        updates: dict[str, Any] = {}
+        if not rel.source_instance_id and rel.source_name:
+            resolved = _resolve(rel.source_name)
+            if resolved:
+                updates["source_instance_id"] = resolved
+        if not rel.target_instance_id and rel.target_name:
+            resolved = _resolve(rel.target_name)
+            if resolved:
+                updates["target_instance_id"] = resolved
+        if updates:
+            filled += 1
+            result.append(rel.model_copy(update=updates))
+        else:
+            result.append(rel)
+    if filled:
+        _LOGGER.info("Backfilled endpoint instance_ids on %d relationship(s)", filled)
+    return result
+
+
 def _resolve_relationship_types(
     relationships: list[ComponentRelationship],
     components: list[AIComponent],
@@ -1426,6 +1480,7 @@ class ScanPipeline:
             all_rels = relationships + agentic_rels
             enriched = _remove_unresolved_embedders(enriched, all_rels)
             enriched = _drop_env_placeholder_identifiers(enriched)
+            all_rels = _backfill_relationship_instance_ids(all_rels, enriched)
             self._agentic_token_usage = agentic_token_usage
             return enriched, all_rels, agentic_flags
 

--- a/aibom/src/aibom/scan_pipeline.py
+++ b/aibom/src/aibom/scan_pipeline.py
@@ -283,8 +283,14 @@ def _propagate_removals(
     pre_fanout_removed_ids: set[str] | None = None,
 ) -> list["AIComponent"]:
     """If the agent removed ANY instance of (name, type), remove ALL — with
-    one asymmetry: import-only removals are *weak* and only cascade to
-    other import-only siblings.
+    two asymmetries that *compose*: (1) import-only removals are *weak* and
+    only cascade to other import-only siblings; (2) removals of a *test-file*
+    instance are *test-scoped* and only cascade to other test-file siblings,
+    never to a production sibling sharing the same canonical key. A removal's
+    reach is the intersection of these restrictions, so e.g. a test-file
+    import-only removal cascades only to siblings that are *both* import-only
+    *and* in test files. An unrestricted production call-site removal cascades
+    to all siblings, as before.
 
     The agent processes each instance independently and sometimes makes
     inconsistent decisions (removes the usage at line 595 but keeps the
@@ -321,8 +327,18 @@ def _propagate_removals(
     if not removed_ids:
         return received
 
-    strong_keys: set[tuple] = set()
-    weak_keys: set[tuple] = set()
+    # For each consolidation key, record how *restricted* its removal cascade
+    # is. A removal's reach is the intersection of two independent axes:
+    #   * import-only ("weak"): may only cascade to other import-only siblings
+    #     (an import alone is not evidence the usage-line is invalid);
+    #   * test-file ("test-scoped"): may only cascade to other test-file
+    #     siblings (pruning a test artifact must not delete a production one).
+    # A production call-site removal is unrestricted (cascades to all). When
+    # the SAME key is removed from multiple instances, the cascade takes the
+    # LEAST restrictive removal seen (e.g. a production call-site removal
+    # overrides a test-file one for that key).
+    restrict_import: dict[tuple, bool] = {}
+    restrict_test: dict[tuple, bool] = {}
     for c in sent:
         if c.instance_id not in removed_ids:
             continue
@@ -331,11 +347,15 @@ def _propagate_removals(
         if _is_protected_dependency(c):
             continue
         key = _consolidation_key(c)
-        if _is_import_only_candidate(c):
-            weak_keys.add(key)
+        weak = _is_import_only_candidate(c)
+        test = _is_test_file(c.file_path)
+        if key in restrict_import:
+            restrict_import[key] = restrict_import[key] and weak
+            restrict_test[key] = restrict_test[key] and test
         else:
-            strong_keys.add(key)
-    if not strong_keys and not weak_keys:
+            restrict_import[key] = weak
+            restrict_test[key] = test
+    if not restrict_import:
         return received
 
     lookup_pool = all_candidates if all_candidates is not None else received
@@ -344,20 +364,30 @@ def _propagate_removals(
         if _is_protected_dependency(c):
             continue
         key = _consolidation_key(c)
-        if key in strong_keys:
-            drop_ids.add(c.instance_id)
-        elif key in weak_keys and _is_import_only_candidate(c):
-            drop_ids.add(c.instance_id)
+        if key not in restrict_import:
+            continue
+        # Drop only if the sibling satisfies every restriction the removal
+        # carries: an import-only-restricted removal drops only import-only
+        # siblings; a test-scoped-restricted removal drops only test-file
+        # siblings.
+        if restrict_import[key] and not _is_import_only_candidate(c):
+            continue
+        if restrict_test[key] and not _is_test_file(c.file_path):
+            continue
+        drop_ids.add(c.instance_id)
 
     result = [c for c in lookup_pool if c.instance_id not in drop_ids]
     dropped = len(lookup_pool) - len(result)
     if dropped:
+        weak_n = sum(1 for v in restrict_import.values() if v)
+        test_n = sum(1 for v in restrict_test.values() if v)
         _LOGGER.info(
             "Removal propagation: dropped %d additional component(s) "
-            "(%d strong key(s), %d weak import-only key(s))",
+            "(%d key(s); %d import-only-restricted, %d test-scoped)",
             dropped,
-            len(strong_keys),
-            len(weak_keys),
+            len(restrict_import),
+            weak_n,
+            test_n,
         )
     return result
 

--- a/aibom/src/aibom/scanners/dependency_scanner.py
+++ b/aibom/src/aibom/scanners/dependency_scanner.py
@@ -54,6 +54,12 @@ KNOWN_AI_PACKAGES: dict[str, set[str]] = {
         "crewai",
         "autogen",
         "autogen-agentchat",
+        "autogen-ext",
+        "ag2",
+        "langgraph",
+        "langgraph-prebuilt",
+        "langgraph-checkpoint",
+        "google-adk",
         "mcp",
         "fastmcp",
         "llama-index",
@@ -371,7 +377,10 @@ def _parse_pyproject_toml(text: str) -> list[tuple[str, str, int, Optional[str],
                             "pypi",
                         ),
                     )
-    poetry_re = re.compile(r"^\[(tool\.poetry(?:\.group\.[^.]+)?\.dependencies)\]\s*$", re.MULTILINE | re.IGNORECASE)
+    poetry_re = re.compile(
+        r"^\[(tool\.poetry(?:\.group\.[^.]+)?\.dependencies)\]\s*$",
+        re.MULTILINE | re.IGNORECASE,
+    )
     for m in poetry_re.finditer(text):
         start = m.end()
         rest = text[start:]
@@ -957,9 +966,7 @@ def _iter_scan_paths(context: ScanContext) -> Iterator[Path]:
             yield root
             continue
         for dirpath, dirnames, filenames in os.walk(root):
-            dirnames[:] = [
-                d for d in dirnames if not should_skip_dir(d)
-            ]
+            dirnames[:] = [d for d in dirnames if not should_skip_dir(d)]
             for fname in filenames:
                 f = Path(dirpath) / fname
                 try:

--- a/aibom/src/aibom/scanners/kb_enrichment_scanner.py
+++ b/aibom/src/aibom/scanners/kb_enrichment_scanner.py
@@ -52,29 +52,56 @@ _LOGGER = logging.getLogger(__name__)
 def _import_strings(imports: list) -> list[str]:
     """Extract plain import statement strings from a list that may contain
     ``(line_number, stmt)`` tuples or bare strings."""
-    return [
-        entry[1] if isinstance(entry, tuple) else entry
-        for entry in imports
-    ]
+    return [entry[1] if isinstance(entry, tuple) else entry for entry in imports]
 
 
-ALLOWED_CONCEPTS: frozenset[str] = frozenset(
-    {"agent", "model", "tool", "datastore", "embedding", "prompt",
-     "memory", "retriever", "knowledge_base", "feature_store"}
-)
-
+# Concept -> component type mapping.
+#
+# This is the single source of truth for which knowledge-base concepts the
+# CLI is willing to surface; ``ALLOWED_CONCEPTS`` is derived from its keys so
+# the two never drift. The original set covered ten concepts. The expanded
+# vocabulary adds the operational and MCP concepts (guardrail, mcp_server,
+# mcp_client, skill, observability) plus the ML-lifecycle and data concepts
+# (dataset, training_run, model_artifact, vector_store) so that knowledge-base
+# rows carrying those concepts are mapped to a component type instead of being
+# silently dropped at lookup time.
+#
+# Concepts that have no dedicated ``AIComponentType`` yet (reranker, evaluator,
+# framework_core) are mapped to ``OTHER`` rather than dropped, so the evidence
+# survives with the original concept preserved in ``kb_concept`` for downstream
+# refinement. ``datastore`` remains an alias for the vector-store type.
 _CONCEPT_TO_TYPE: dict[str, AIComponentType] = {
     "agent": AIComponentType.AGENT,
     "model": AIComponentType.MODEL,
     "tool": AIComponentType.TOOL,
     "datastore": AIComponentType.VECTOR_STORE,
+    "vector_store": AIComponentType.VECTOR_STORE,
     "embedding": AIComponentType.EMBEDDING,
     "prompt": AIComponentType.PROMPT,
     "memory": AIComponentType.MEMORY,
     "retriever": AIComponentType.RETRIEVER,
     "knowledge_base": AIComponentType.KNOWLEDGE_BASE,
     "feature_store": AIComponentType.FEATURE_STORE,
+    # Operational + MCP concepts.
+    "guardrail": AIComponentType.GUARDRAIL,
+    "mcp_server": AIComponentType.MCP_SERVER,
+    "mcp_client": AIComponentType.MCP_CLIENT,
+    "skill": AIComponentType.SKILL,
+    "observability": AIComponentType.OBSERVABILITY,
+    # Data + ML-lifecycle concepts.
+    "dataset": AIComponentType.DATASET,
+    "training_run": AIComponentType.TRAINING_RUN,
+    "model_artifact": AIComponentType.MODEL_ARTIFACT,
+    # Concepts without a dedicated type yet: keep the evidence as OTHER and
+    # preserve the original concept in ``kb_concept`` instead of dropping.
+    "reranker": AIComponentType.OTHER,
+    "evaluator": AIComponentType.OTHER,
+    "framework_core": AIComponentType.OTHER,
 }
+
+# Concepts the CLI will surface. Derived from the mapping above so a new
+# concept only has to be added in one place.
+ALLOWED_CONCEPTS: frozenset[str] = frozenset(_CONCEPT_TO_TYPE)
 
 # KB id path segments that override or suppress the raw concept.
 # Checked in order; first match wins.  ``None`` means "exclude this entry".
@@ -93,27 +120,29 @@ _ID_PATH_OVERRIDES: list[tuple[str, AIComponentType | None]] = [
 ]
 
 
-_EXCLUDED_CLASS_NAMES: frozenset[str] = frozenset({
-    "RecursiveCharacterTextSplitter",
-    "CharacterTextSplitter",
-    "TokenTextSplitter",
-    "TextSplitter",
-    "SentenceTransformersTokenTextSplitter",
-    "SpacyTextSplitter",
-    "NLTKTextSplitter",
-    "TextLoader",
-    "DirectoryLoader",
-    "WebBaseLoader",
-    "PyPDFLoader",
-    "CSVLoader",
-    "UnstructuredFileLoader",
-    "LLMChain",
-    "RetrievalQA",
-    "ConversationalRetrievalChain",
-    "SequentialChain",
-    "SimpleSequentialChain",
-    "ConversationChain",
-})
+_EXCLUDED_CLASS_NAMES: frozenset[str] = frozenset(
+    {
+        "RecursiveCharacterTextSplitter",
+        "CharacterTextSplitter",
+        "TokenTextSplitter",
+        "TextSplitter",
+        "SentenceTransformersTokenTextSplitter",
+        "SpacyTextSplitter",
+        "NLTKTextSplitter",
+        "TextLoader",
+        "DirectoryLoader",
+        "WebBaseLoader",
+        "PyPDFLoader",
+        "CSVLoader",
+        "UnstructuredFileLoader",
+        "LLMChain",
+        "RetrievalQA",
+        "ConversationalRetrievalChain",
+        "SequentialChain",
+        "SimpleSequentialChain",
+        "ConversationChain",
+    }
+)
 
 
 def _refine_type_from_kb_id(
@@ -133,42 +162,48 @@ def _refine_type_from_kb_id(
     return concept_type
 
 
-_AGENT_CREATION_PATTERNS: frozenset[str] = frozenset({
-    "initialize_agent",
-    "AgentExecutor",
-    "create_react_agent",
-    "create_openai_functions_agent",
-    "create_openai_tools_agent",
-    "create_structured_chat_agent",
-    "create_tool_calling_agent",
-    "create_json_chat_agent",
-    "create_xml_agent",
-    "Agent",
-    "Crew",
-    "AssistantAgent",
-    "UserProxyAgent",
-    "GroupChat",
-    "GroupChatManager",
-})
+_AGENT_CREATION_PATTERNS: frozenset[str] = frozenset(
+    {
+        "initialize_agent",
+        "AgentExecutor",
+        "create_react_agent",
+        "create_openai_functions_agent",
+        "create_openai_tools_agent",
+        "create_structured_chat_agent",
+        "create_tool_calling_agent",
+        "create_json_chat_agent",
+        "create_xml_agent",
+        "Agent",
+        "Crew",
+        "AssistantAgent",
+        "UserProxyAgent",
+        "GroupChat",
+        "GroupChatManager",
+    }
+)
 
-_AGENT_FRAMEWORK_PREFIXES: frozenset[str] = frozenset({
-    "langchain",
-    "crewai",
-    "autogen",
-    # Strands Agents (https://strandsagents.com/) uses module-level
-    # ``from strands import Agent`` followed by ``agent = Agent(...)``
-    # (no class wrapper). Without ``strands`` here, the call-pattern
-    # gate below rejects the call and the agent is never emitted, which
-    # matches the symptom observed on published open-source Strands
-    # sample repositories.
-    "strands",
-})
+_AGENT_FRAMEWORK_PREFIXES: frozenset[str] = frozenset(
+    {
+        "langchain",
+        "crewai",
+        "autogen",
+        # Strands Agents (https://strandsagents.com/) uses module-level
+        # ``from strands import Agent`` followed by ``agent = Agent(...)``
+        # (no class wrapper). Without ``strands`` here, the call-pattern
+        # gate below rejects the call and the agent is never emitted, which
+        # matches the symptom observed on published open-source Strands
+        # sample repositories.
+        "strands",
+    }
+)
 
 
 def _is_agent_creation_call(qualified_name: str, imports: list) -> bool:
     """Return True if *qualified_name* is a known agent creation pattern
     from a recognized framework."""
-    short = qualified_name.rsplit(".", 1)[-1] if "." in qualified_name else qualified_name
+    short = (
+        qualified_name.rsplit(".", 1)[-1] if "." in qualified_name else qualified_name
+    )
     if short not in _AGENT_CREATION_PATTERNS:
         return False
     prefix = qualified_name.split(".")[0].split("_")[0]
@@ -183,19 +218,33 @@ def _is_agent_creation_call(qualified_name: str, imports: list) -> bool:
     return False
 
 
-_STATIC_TOOL_PATTERNS: frozenset[str] = frozenset({
-    "Tool", "StructuredTool",
-})
-_STATIC_MEMORY_PATTERNS: frozenset[str] = frozenset({
-    "ConversationBufferMemory", "ConversationSummaryMemory",
-    "ConversationBufferWindowMemory", "ConversationKGMemory",
-    "ConversationEntityMemory", "ConversationTokenBufferMemory",
-    "VectorStoreRetrieverMemory", "ReadOnlySharedMemory",
-})
-_STATIC_PROMPT_PATTERNS: frozenset[str] = frozenset({
-    "PromptTemplate", "ChatPromptTemplate",
-    "FewShotPromptTemplate", "FewShotChatMessagePromptTemplate",
-})
+_STATIC_TOOL_PATTERNS: frozenset[str] = frozenset(
+    {
+        "Tool",
+        "StructuredTool",
+    }
+)
+_STATIC_MEMORY_PATTERNS: frozenset[str] = frozenset(
+    {
+        "ConversationBufferMemory",
+        "ConversationSummaryMemory",
+        "ConversationBufferWindowMemory",
+        "ConversationKGMemory",
+        "ConversationEntityMemory",
+        "ConversationTokenBufferMemory",
+        "VectorStoreRetrieverMemory",
+        "ReadOnlySharedMemory",
+    }
+)
+_STATIC_PROMPT_PATTERNS: frozenset[str] = frozenset(
+    {
+        "PromptTemplate",
+        "ChatPromptTemplate",
+        "FewShotPromptTemplate",
+        "FewShotChatMessagePromptTemplate",
+    }
+)
+
 
 @dataclass(frozen=True, slots=True)
 class _MatchResult:
@@ -215,18 +264,51 @@ class _MatchResult:
         return self.entry is None and self.partial_kb_id is not None
 
 
-_AI_SUGGESTIVE_DIR_SEGMENTS: frozenset[str] = frozenset({
-    "models", "agents", "tools", "prompts", "embeddings", "llm",
-    "inference", "ai", "ml", "vectorstores", "vector_stores",
-    "retrievers", "memory", "chains", "chatbots",
-})
+_AI_SUGGESTIVE_DIR_SEGMENTS: frozenset[str] = frozenset(
+    {
+        "models",
+        "agents",
+        "tools",
+        "prompts",
+        "embeddings",
+        "llm",
+        "inference",
+        "ai",
+        "ml",
+        "vectorstores",
+        "vector_stores",
+        "retrievers",
+        "memory",
+        "chains",
+        "chatbots",
+    }
+)
 
-_AI_SUGGESTIVE_IMPORT_SEGMENTS: frozenset[str] = frozenset({
-    "llm", "openai", "anthropic", "embedding", "vector", "agent",
-    "model", "inference", "chat", "completion", "bedrock", "vertex",
-    "huggingface", "transformers", "torch", "tensorflow", "keras",
-    "ollama", "cohere", "mistral", "gemini",
-})
+_AI_SUGGESTIVE_IMPORT_SEGMENTS: frozenset[str] = frozenset(
+    {
+        "llm",
+        "openai",
+        "anthropic",
+        "embedding",
+        "vector",
+        "agent",
+        "model",
+        "inference",
+        "chat",
+        "completion",
+        "bedrock",
+        "vertex",
+        "huggingface",
+        "transformers",
+        "torch",
+        "tensorflow",
+        "keras",
+        "ollama",
+        "cohere",
+        "mistral",
+        "gemini",
+    }
+)
 
 _AI_INDICATIVE_CLASS_RE: re.Pattern[str] = re.compile(
     r"(LLM|Model|Agent|Embed(?:ding|der)|Vector|Chain|Tool|Prompt|Memory|Chat|"
@@ -238,7 +320,10 @@ _AI_INDICATIVE_CLASS_RE: re.Pattern[str] = re.compile(
 
 _CLASS_NAME_TYPE_MAP: list[tuple[re.Pattern[str], AIComponentType]] = [
     (re.compile(r"Embed(?:ding|der)", re.IGNORECASE), AIComponentType.EMBEDDING),
-    (re.compile(r"Guard(?:rail)?|Inspector|Rails", re.IGNORECASE), AIComponentType.GUARDRAIL),
+    (
+        re.compile(r"Guard(?:rail)?|Inspector|Rails", re.IGNORECASE),
+        AIComponentType.GUARDRAIL,
+    ),
     (re.compile(r"MCPClient", re.IGNORECASE), AIComponentType.MCP_CLIENT),
     (re.compile(r"Traceloop", re.IGNORECASE), AIComponentType.OBSERVABILITY),
     (re.compile(r"Agent"), AIComponentType.AGENT),
@@ -250,6 +335,7 @@ _CLASS_NAME_TYPE_MAP: list[tuple[re.Pattern[str], AIComponentType]] = [
     (re.compile(r"Retriever", re.IGNORECASE), AIComponentType.RETRIEVER),
     (re.compile(r"Vector(?:Store|DB|Database)"), AIComponentType.VECTOR_STORE),
 ]
+
 
 @dataclass(frozen=True)
 class PlatformEntry:
@@ -269,86 +355,116 @@ _REG = AIComponentType.MODEL_REGISTRY
 
 _IMPORT_MODULE_TYPE_MAP: dict[str, PlatformEntry] = {
     # Pure observability
-    "traceloop":    PlatformEntry(_OBS),
-    "openllmetry":  PlatformEntry(_OBS),
-    "langsmith":    PlatformEntry(_OBS),
-    "langfuse":     PlatformEntry(_OBS),
-    "arize":        PlatformEntry(_OBS),
-    "phoenix":      PlatformEntry(_OBS),
-    "opik":         PlatformEntry(_OBS),
-    "helicone":     PlatformEntry(_OBS),
-    "freeplay":     PlatformEntry(_OBS),
-    "tracia":       PlatformEntry(_OBS),
-    "llmetry":      PlatformEntry(_OBS),
-    "galileo":      PlatformEntry(_OBS),
-    "honeyhive":    PlatformEntry(_OBS),
-    "promptlayer":  PlatformEntry(_OBS),
-    "humanloop":    PlatformEntry(_OBS),
-    "braintrust":   PlatformEntry(_OBS),
-    "whylabs":      PlatformEntry(_OBS),
+    "traceloop": PlatformEntry(_OBS),
+    "openllmetry": PlatformEntry(_OBS),
+    "langsmith": PlatformEntry(_OBS),
+    "langfuse": PlatformEntry(_OBS),
+    "arize": PlatformEntry(_OBS),
+    "phoenix": PlatformEntry(_OBS),
+    "opik": PlatformEntry(_OBS),
+    "helicone": PlatformEntry(_OBS),
+    "freeplay": PlatformEntry(_OBS),
+    "tracia": PlatformEntry(_OBS),
+    "llmetry": PlatformEntry(_OBS),
+    "galileo": PlatformEntry(_OBS),
+    "honeyhive": PlatformEntry(_OBS),
+    "promptlayer": PlatformEntry(_OBS),
+    "humanloop": PlatformEntry(_OBS),
+    "braintrust": PlatformEntry(_OBS),
+    "whylabs": PlatformEntry(_OBS),
     # Observability + model registry
-    "wandb":            PlatformEntry(_OBS, frozenset({_REG})),
-    "weights_biases":   PlatformEntry(_OBS, frozenset({_REG})),
-    "mlflow":           PlatformEntry(_OBS, frozenset({_REG})),
-    "neptune":          PlatformEntry(_OBS, frozenset({_REG})),
-    "comet":            PlatformEntry(_OBS, frozenset({_REG})),
-    "deepchecks":       PlatformEntry(_OBS),
+    "wandb": PlatformEntry(_OBS, frozenset({_REG})),
+    "weights_biases": PlatformEntry(_OBS, frozenset({_REG})),
+    "mlflow": PlatformEntry(_OBS, frozenset({_REG})),
+    "neptune": PlatformEntry(_OBS, frozenset({_REG})),
+    "comet": PlatformEntry(_OBS, frozenset({_REG})),
+    "deepchecks": PlatformEntry(_OBS),
     # Guardrails
-    "nemoguardrails":   PlatformEntry(_GRD),
-    "guardrails":       PlatformEntry(_GRD),
-    "llm_guard":        PlatformEntry(_GRD),
-    "lakera_guard":     PlatformEntry(_GRD),
-    "rebuff":           PlatformEntry(_GRD),
+    "nemoguardrails": PlatformEntry(_GRD),
+    "guardrails": PlatformEntry(_GRD),
+    "llm_guard": PlatformEntry(_GRD),
+    "lakera_guard": PlatformEntry(_GRD),
+    "rebuff": PlatformEntry(_GRD),
 }
 
 OBSERVABILITY_PLATFORM_TOKENS: frozenset[str] = frozenset(
-    k for k, entry in _IMPORT_MODULE_TYPE_MAP.items()
-    if _OBS in entry.all_types
+    k for k, entry in _IMPORT_MODULE_TYPE_MAP.items() if _OBS in entry.all_types
 )
 
 
 _NON_AI_CLASS_SUFFIXES: tuple[str, ...] = (
-    "Response", "Request", "Schema", "Config", "Spec", "Params",
-    "DTO", "DML", "DDL", "Enum", "Type", "Base", "Abstract",
-    "Interface", "Mixin", "Factory", "Builder", "Validator",
-    "Serializer", "Deserializer", "Mapper", "Converter",
-    "Exception", "Error", "Test", "Mock", "Stub", "Fake",
-    "Code", "Status", "Flag",
+    "Response",
+    "Request",
+    "Schema",
+    "Config",
+    "Spec",
+    "Params",
+    "DTO",
+    "DML",
+    "DDL",
+    "Enum",
+    "Type",
+    "Base",
+    "Abstract",
+    "Interface",
+    "Mixin",
+    "Factory",
+    "Builder",
+    "Validator",
+    "Serializer",
+    "Deserializer",
+    "Mapper",
+    "Converter",
+    "Exception",
+    "Error",
+    "Test",
+    "Mock",
+    "Stub",
+    "Fake",
+    "Code",
+    "Status",
+    "Flag",
 )
 
-_AMBIGUOUS_NAME_TYPES: frozenset[AIComponentType] = frozenset({
-    AIComponentType.EMBEDDING,
-    AIComponentType.MEMORY,
-    AIComponentType.TOOL,
-    AIComponentType.AGENT,
-    AIComponentType.VECTOR_STORE,
-    AIComponentType.RETRIEVER,
-    AIComponentType.PROMPT,
-    AIComponentType.GUARDRAIL,
-})
+_AMBIGUOUS_NAME_TYPES: frozenset[AIComponentType] = frozenset(
+    {
+        AIComponentType.EMBEDDING,
+        AIComponentType.MEMORY,
+        AIComponentType.TOOL,
+        AIComponentType.AGENT,
+        AIComponentType.VECTOR_STORE,
+        AIComponentType.RETRIEVER,
+        AIComponentType.PROMPT,
+        AIComponentType.GUARDRAIL,
+    }
+)
 
-_EMBEDDING_IMPORT_SIGNALS: frozenset[str] = frozenset({
-    "embedding",
-    "embedder",
-    "embedders",
-    "openai",
-    "langchain",
-    "haystack",
-    "llama_index",
-    "sentence_transformers",
-    "transformers",
-    "chromadb",
-})
+_EMBEDDING_IMPORT_SIGNALS: frozenset[str] = frozenset(
+    {
+        "embedding",
+        "embedder",
+        "embedders",
+        "openai",
+        "langchain",
+        "haystack",
+        "llama_index",
+        "sentence_transformers",
+        "transformers",
+        "chromadb",
+    }
+)
 
-_EMBEDDING_CALL_SIGNALS: frozenset[str] = frozenset({
-    "model=",
-    "model_name=",
-    "deployment=",
-    "deployment_name=",
-    "api_key=",
-    "client=",
-    "embedding_function=",
-})
+_EMBEDDING_CALL_SIGNALS: frozenset[str] = frozenset(
+    {
+        "model=",
+        "model_name=",
+        "deployment=",
+        "deployment_name=",
+        "api_key=",
+        "client=",
+        "embedding_function=",
+    }
+)
 
 
 def _is_data_class_name(name: str) -> bool:
@@ -376,10 +492,9 @@ def _has_embedding_import_evidence(text: str) -> bool:
 
 def _has_embedding_call_evidence(line: str, source: str) -> bool:
     lower_line = line.lower()
-    return (
-        any(signal in lower_line for signal in _EMBEDDING_CALL_SIGNALS)
-        or _has_embedding_import_evidence(source)
-    )
+    return any(
+        signal in lower_line for signal in _EMBEDDING_CALL_SIGNALS
+    ) or _has_embedding_import_evidence(source)
 
 
 def _infer_type_from_name(name: str) -> tuple[AIComponentType, bool]:
@@ -397,26 +512,88 @@ def _infer_type_from_name(name: str) -> tuple[AIComponentType, bool]:
     return AIComponentType.MODEL, False
 
 
-_GENERIC_CLASS_NAMES: frozenset[str] = frozenset({
-    "ABC", "Any", "Dict", "List", "Optional", "Tuple", "Set", "Type",
-    "Union", "Callable", "Generator", "AsyncGenerator", "Iterator",
-    "Sequence", "Mapping", "MutableMapping", "Annotated", "ClassVar",
-    "Protocol", "BaseModel", "Field", "PrivateAttr", "ConfigDict",
-    "Awaitable", "AsyncIterator", "Path", "Formatter", "ErrorCode",
-})
+_GENERIC_CLASS_NAMES: frozenset[str] = frozenset(
+    {
+        "ABC",
+        "Any",
+        "Dict",
+        "List",
+        "Optional",
+        "Tuple",
+        "Set",
+        "Type",
+        "Union",
+        "Callable",
+        "Generator",
+        "AsyncGenerator",
+        "Iterator",
+        "Sequence",
+        "Mapping",
+        "MutableMapping",
+        "Annotated",
+        "ClassVar",
+        "Protocol",
+        "BaseModel",
+        "Field",
+        "PrivateAttr",
+        "ConfigDict",
+        "Awaitable",
+        "AsyncIterator",
+        "Path",
+        "Formatter",
+        "ErrorCode",
+    }
+)
 
-_NON_AI_PACKAGES: frozenset[str] = frozenset({
-    "more_itertools", "itertools", "functools", "collections",
-    "dataclasses", "typing_extensions", "pydantic", "attrs",
-    "pytest", "unittest", "mock", "faker",
-})
+_NON_AI_PACKAGES: frozenset[str] = frozenset(
+    {
+        "more_itertools",
+        "itertools",
+        "functools",
+        "collections",
+        "dataclasses",
+        "typing_extensions",
+        "pydantic",
+        "attrs",
+        "pytest",
+        "unittest",
+        "mock",
+        "faker",
+    }
+)
 
 _DATA_CLASS_SUFFIXES: tuple[str, ...] = (
-    "Action", "Step", "Finish", "Message", "Output", "Input", "Schema",
-    "Config", "Event", "Error", "Exception", "Result", "Response",
-    "Request", "Callback", "Handler", "Parser", "Serializer",
-    "Kwargs", "Meta", "State", "Log", "Mixin", "Interface", "Value",
-    "Wrapper", "Item", "Record", "Encoder", "Decoder", "Triple",
+    "Action",
+    "Step",
+    "Finish",
+    "Message",
+    "Output",
+    "Input",
+    "Schema",
+    "Config",
+    "Event",
+    "Error",
+    "Exception",
+    "Result",
+    "Response",
+    "Request",
+    "Callback",
+    "Handler",
+    "Parser",
+    "Serializer",
+    "Kwargs",
+    "Meta",
+    "State",
+    "Log",
+    "Mixin",
+    "Interface",
+    "Value",
+    "Wrapper",
+    "Item",
+    "Record",
+    "Encoder",
+    "Decoder",
+    "Triple",
 )
 
 
@@ -446,9 +623,16 @@ def _build_kb_patterns(
     that can be matched in ``call`` observations.  Falls back to
     static lists when the KB yields nothing for a category.
     """
-    _PATH_CONCEPT_MAP: list[tuple[str, tuple[str, ...], AIComponentType, frozenset[str]]] = [
+    _PATH_CONCEPT_MAP: list[
+        tuple[str, tuple[str, ...], AIComponentType, frozenset[str]]
+    ] = [
         (".tools.", ("tool",), AIComponentType.TOOL, _STATIC_TOOL_PATTERNS),
-        (".memory.", ("memory", "datastore"), AIComponentType.MEMORY, _STATIC_MEMORY_PATTERNS),
+        (
+            ".memory.",
+            ("memory", "datastore"),
+            AIComponentType.MEMORY,
+            _STATIC_MEMORY_PATTERNS,
+        ),
         (".prompts.", ("prompt",), AIComponentType.PROMPT, _STATIC_PROMPT_PATTERNS),
         (".agents.", ("agent",), AIComponentType.AGENT, _AGENT_CREATION_PATTERNS),
     ]
@@ -515,7 +699,9 @@ def _is_known_call(
 ) -> bool:
     """Return True if *qualified_name* matches a known creation pattern
     from a recognized framework."""
-    short = qualified_name.rsplit(".", 1)[-1] if "." in qualified_name else qualified_name
+    short = (
+        qualified_name.rsplit(".", 1)[-1] if "." in qualified_name else qualified_name
+    )
     if short not in patterns:
         return False
     prefix = qualified_name.split(".")[0].split("_")[0]
@@ -551,7 +737,9 @@ def _resolve_kb_path(context: ScanContext) -> Optional[Path]:
     return None
 
 
-def _extract_frameworks_from_imports(imports: list[str] | list[tuple[int, str]]) -> set[str]:
+def _extract_frameworks_from_imports(
+    imports: list[str] | list[tuple[int, str]],
+) -> set[str]:
     """Derive top-level package names from import statements.
 
     e.g. ``"from langchain_openai import ChatOpenAI"`` → ``{"langchain_openai"}``
@@ -604,21 +792,28 @@ class KBEnrichmentScanner(BaseScanner):
                     len(BUILTIN_CATALOG_ENTRIES),
                 )
             except Exception:  # noqa: BLE001
-                _LOGGER.debug("KB enrichment: built-in catalog load failed", exc_info=True)
+                _LOGGER.debug(
+                    "KB enrichment: built-in catalog load failed", exc_info=True
+                )
 
             custom_cfg = context.config.get("custom_catalog")
             if custom_cfg is not None:
                 try:
                     from ..custom_catalog import CustomCatalogConfig
 
-                    if isinstance(custom_cfg, CustomCatalogConfig) and not custom_cfg.is_empty:
+                    if (
+                        isinstance(custom_cfg, CustomCatalogConfig)
+                        and not custom_cfg.is_empty
+                    ):
                         db.add_custom_entries(
                             [c.to_catalog_dict() for c in custom_cfg.components]
                         )
                         if custom_cfg.excludes:
                             db.add_excludes(custom_cfg.excludes)
                 except Exception:  # noqa: BLE001
-                    _LOGGER.debug("KB enrichment: custom catalog load failed", exc_info=True)
+                    _LOGGER.debug(
+                        "KB enrichment: custom catalog load failed", exc_info=True
+                    )
 
             kb_patterns = _build_kb_patterns(db)
             kb_fw_prefixes = _build_kb_framework_prefixes(db)
@@ -650,7 +845,8 @@ class KBEnrichmentScanner(BaseScanner):
             _LOGGER.debug(
                 "KB enrichment: %d Tier 1 (framework import), "
                 "%d suggestive (wrapper), %d skipped of %d total",
-                len(tier1_files), len(suggestive_files),
+                len(tier1_files),
+                len(suggestive_files),
                 len(all_py_files) - len(tier1_files) - len(suggestive_files),
                 len(all_py_files),
             )
@@ -664,14 +860,19 @@ class KBEnrichmentScanner(BaseScanner):
                     parsed_results.append(result)
                     _collect_symbols(result, all_symbols)
                 except Exception:  # noqa: BLE001
-                    _LOGGER.debug("KB enrichment: failed to parse %s", py_file, exc_info=True)
+                    _LOGGER.debug(
+                        "KB enrichment: failed to parse %s", py_file, exc_info=True
+                    )
 
             kb_entries = _batch_kb_lookup(db, all_symbols) if all_symbols else {}
 
             for result in parsed_results:
                 components.extend(
                     _process_file_with_cache(
-                        result, kb_entries, kb_patterns, kb_fw_prefixes,
+                        result,
+                        kb_entries,
+                        kb_patterns,
+                        kb_fw_prefixes,
                     )
                 )
 
@@ -682,16 +883,13 @@ class KBEnrichmentScanner(BaseScanner):
                 components.extend(_detect_import_based_assets(result))
 
             for py_file, source in suggestive_files:
-                components.extend(
-                    _emit_suggestive_candidates(py_file, source)
-                )
+                components.extend(_emit_suggestive_candidates(py_file, source))
 
-            components.extend(
-                _detect_cache_ai_co_occurrence(tier1_files)
-            )
+            components.extend(_detect_cache_ai_co_occurrence(tier1_files))
 
         components = [
-            c for c in components
+            c
+            for c in components
             if c.name.lower().replace("-", "_") not in _NON_AI_PACKAGES
         ]
 
@@ -721,9 +919,18 @@ def _build_kb_framework_names(db: CatalogDB) -> frozenset[str]:
     return frozenset(names)
 
 
-_AMBIGUOUS_TOP_LEVEL = frozenset({
-    "google", "aws", "azure", "microsoft", "com", "org", "io", "ai",
-})
+_AMBIGUOUS_TOP_LEVEL = frozenset(
+    {
+        "google",
+        "aws",
+        "azure",
+        "microsoft",
+        "com",
+        "org",
+        "io",
+        "ai",
+    }
+)
 
 
 def _import_matches_framework(dotted_path: str, kb_frameworks: frozenset[str]) -> bool:
@@ -763,7 +970,8 @@ def _import_matches_framework(dotted_path: str, kb_frameworks: frozenset[str]) -
 
 
 def _file_has_kb_framework_import(
-    source: str, kb_frameworks: frozenset[str],
+    source: str,
+    kb_frameworks: frozenset[str],
 ) -> bool:
     """Return True if *source* contains an ``import`` or ``from`` statement
     referencing any framework known to the KB.
@@ -812,7 +1020,8 @@ def _has_suggestive_signal(py_file: Path, source: str) -> bool:
 
 
 def _emit_suggestive_candidates(
-    py_file: Path, source: str,
+    py_file: Path,
+    source: str,
 ) -> list[AIComponent]:
     """Emit low-confidence agentic candidates for AI-indicative class names.
 
@@ -826,7 +1035,8 @@ def _emit_suggestive_candidates(
         if not stripped or stripped.startswith("#"):
             continue
         assign_match = re.match(
-            r"(\w+)\s*=\s*([A-Z]\w+)\s*\(", stripped,
+            r"(\w+)\s*=\s*([A-Z]\w+)\s*\(",
+            stripped,
         )
         if not assign_match:
             continue
@@ -896,7 +1106,14 @@ def _detect_cache_ai_co_occurrence(
             continue
         seen.add(file_key)
         cache_lib = "unknown"
-        for lib in ("redis", "memcache", "pymemcache", "cachetools", "diskcache", "aiocache"):
+        for lib in (
+            "redis",
+            "memcache",
+            "pymemcache",
+            "cachetools",
+            "diskcache",
+            "aiocache",
+        ):
             if re.search(rf"(?:^|\n)\s*(?:from|import)\s+{lib}\b", source):
                 cache_lib = lib
                 break
@@ -961,7 +1178,7 @@ def _detect_import_based_assets(
             tokens = imp_line.split()
             try:
                 import_idx = tokens.index("import")
-                symbols = tokens[import_idx + 1:]
+                symbols = tokens[import_idx + 1 :]
             except ValueError:
                 symbols = tokens
             for part in symbols:
@@ -1032,36 +1249,72 @@ def _detect_import_based_assets(
     return candidates
 
 
-_TOOL_KWARG_NAMES: frozenset[str] = frozenset({
-    "tools", "functions", "tool_choice",
-})
+_TOOL_KWARG_NAMES: frozenset[str] = frozenset(
+    {
+        "tools",
+        "functions",
+        "tool_choice",
+    }
+)
 
-_TOOL_DECORATOR_NAMES: frozenset[str] = frozenset({
-    "tool", "register_tool",
-})
+_TOOL_DECORATOR_NAMES: frozenset[str] = frozenset(
+    {
+        "tool",
+        "register_tool",
+    }
+)
 
-_TOOL_DECORATOR_FRAMEWORKS: frozenset[str] = frozenset({
-    "langchain", "langchain_core", "crewai", "smolagents", "pydantic_ai",
-    "autogen", "deepagents", "llama_index", "agno", "phidata", "strands",
-})
+_TOOL_DECORATOR_FRAMEWORKS: frozenset[str] = frozenset(
+    {
+        "langchain",
+        "langchain_core",
+        "crewai",
+        "smolagents",
+        "pydantic_ai",
+        "autogen",
+        "deepagents",
+        "llama_index",
+        "agno",
+        "phidata",
+        "strands",
+    }
+)
 
-_TOOL_CONVERSION_CALLS: frozenset[str] = frozenset({
-    "function_to_schema",
-    "convert_to_openai_tool",
-    "convert_to_openai_function",
-    "format_tool_to_openai_function",
-    "tool_to_function_definition",
-})
+_TOOL_CONVERSION_CALLS: frozenset[str] = frozenset(
+    {
+        "function_to_schema",
+        "convert_to_openai_tool",
+        "convert_to_openai_function",
+        "format_tool_to_openai_function",
+        "tool_to_function_definition",
+    }
+)
 
-_AI_CLIENT_CALLS: frozenset[str] = frozenset({
-    "create", "chat", "completions", "invoke", "ainvoke",
-    "bind_tools", "with_structured_output",
-})
+_AI_CLIENT_CALLS: frozenset[str] = frozenset(
+    {
+        "create",
+        "chat",
+        "completions",
+        "invoke",
+        "ainvoke",
+        "bind_tools",
+        "with_structured_output",
+    }
+)
 
-_PROMPT_KWARG_NAMES: frozenset[str] = frozenset({
-    "system_prompt", "system_message", "system", "instructions",
-    "prompt", "template", "messages", "few_shot_examples", "examples",
-})
+_PROMPT_KWARG_NAMES: frozenset[str] = frozenset(
+    {
+        "system_prompt",
+        "system_message",
+        "system",
+        "instructions",
+        "prompt",
+        "template",
+        "messages",
+        "few_shot_examples",
+        "examples",
+    }
+)
 
 
 def _detect_tool_schemas(result: "CodeAnalysisResult") -> list[AIComponent]:
@@ -1212,29 +1465,66 @@ def _variable_name(val: Any) -> str | None:
     return None
 
 
-_MODEL_KWARG_NAMES: frozenset[str] = frozenset({
-    "model", "model_name", "model_id", "deployment_name", "engine",
-})
+_MODEL_KWARG_NAMES: frozenset[str] = frozenset(
+    {
+        "model",
+        "model_name",
+        "model_id",
+        "deployment_name",
+        "engine",
+    }
+)
 
-_ENDPOINT_KWARG_NAMES: frozenset[str] = frozenset({
-    "base_url", "azure_endpoint", "api_base", "endpoint_url",
-})
+_ENDPOINT_KWARG_NAMES: frozenset[str] = frozenset(
+    {
+        "base_url",
+        "azure_endpoint",
+        "api_base",
+        "endpoint_url",
+    }
+)
 
-_KNOWN_AI_CLIENT_CLASSES: frozenset[str] = frozenset({
-    "ChatOpenAI", "ChatAnthropic", "ChatGoogleGenerativeAI", "AzureChatOpenAI",
-    "OpenAI", "Anthropic", "GenerativeModel", "AnthropicBedrock",
-    "ChatBedrock", "BedrockChat", "ChatVertexAI", "ChatCohere",
-    "ChatMistralAI", "ChatOllama", "ChatLiteLLM", "ChatFireworks",
-    "ChatGroq", "ChatTogether", "VLLMOpenAI", "AzureOpenAI",
-    # Strands built-in model provider classes (``strands.models.*``). Each
-    # accepts a ``model_id=`` kwarg at construction time and is the primary
-    # way to wire a Strands ``Agent`` to a provider. Covering these here
-    # lets ``_detect_model_kwargs`` surface both the concrete model ID and,
-    # when the constructor is bare, a needs-agentic bare-client component.
-    "BedrockModel", "AnthropicModel", "OpenAIModel", "OllamaModel",
-    "LiteLLMModel", "GeminiModel", "MistralModel", "SageMakerModel",
-    "LlamaAPIModel", "WriterModel", "LlamaCppModel", "CohereModel",
-})
+_KNOWN_AI_CLIENT_CLASSES: frozenset[str] = frozenset(
+    {
+        "ChatOpenAI",
+        "ChatAnthropic",
+        "ChatGoogleGenerativeAI",
+        "AzureChatOpenAI",
+        "OpenAI",
+        "Anthropic",
+        "GenerativeModel",
+        "AnthropicBedrock",
+        "ChatBedrock",
+        "BedrockChat",
+        "ChatVertexAI",
+        "ChatCohere",
+        "ChatMistralAI",
+        "ChatOllama",
+        "ChatLiteLLM",
+        "ChatFireworks",
+        "ChatGroq",
+        "ChatTogether",
+        "VLLMOpenAI",
+        "AzureOpenAI",
+        # Strands built-in model provider classes (``strands.models.*``). Each
+        # accepts a ``model_id=`` kwarg at construction time and is the primary
+        # way to wire a Strands ``Agent`` to a provider. Covering these here
+        # lets ``_detect_model_kwargs`` surface both the concrete model ID and,
+        # when the constructor is bare, a needs-agentic bare-client component.
+        "BedrockModel",
+        "AnthropicModel",
+        "OpenAIModel",
+        "OllamaModel",
+        "LiteLLMModel",
+        "GeminiModel",
+        "MistralModel",
+        "SageMakerModel",
+        "LlamaAPIModel",
+        "WriterModel",
+        "LlamaCppModel",
+        "CohereModel",
+    }
+)
 
 _BARE_CLIENT_HINTS: dict[str, str] = {
     "AnthropicBedrock": "Resolve model ID from .messages.create(model=...) calls. Remove if no model ID found.",
@@ -1311,7 +1601,9 @@ def _detect_model_kwargs(result: "CodeAnalysisResult") -> list[AIComponent]:
         endpoint_url: str | None = None
         for ek in _ENDPOINT_KWARG_NAMES:
             raw = call_obs.arguments.get(ek)
-            if isinstance(raw, str) and not raw.startswith(("VARIABLE:", "ATTRIBUTE:", "COMPLEX_TYPE:")):
+            if isinstance(raw, str) and not raw.startswith(
+                ("VARIABLE:", "ATTRIBUTE:", "COMPLEX_TYPE:")
+            ):
                 cleaned = raw.strip().strip("'\"")
                 if cleaned.startswith(("http://", "https://")):
                     endpoint_url = cleaned
@@ -1403,7 +1695,9 @@ def _detect_prompt_kwargs(result: "CodeAnalysisResult") -> list[AIComponent]:
 
     for assignment in result.assignments:
         if assignment.target_qualified_name and assignment.call.qualified_name:
-            variable_map[assignment.target_qualified_name] = assignment.call.qualified_name
+            variable_map[assignment.target_qualified_name] = (
+                assignment.call.qualified_name
+            )
 
     all_calls = [(c, c.line_number) for c in result.calls]
     all_calls += [(a.call, a.line_number) for a in result.assignments]
@@ -1421,7 +1715,9 @@ def _detect_prompt_kwargs(result: "CodeAnalysisResult") -> list[AIComponent]:
             if key in seen:
                 continue
 
-            if isinstance(val, str) and not val.startswith(("VARIABLE:", "ATTRIBUTE:", "COMPLEX_TYPE:")):
+            if isinstance(val, str) and not val.startswith(
+                ("VARIABLE:", "ATTRIBUTE:", "COMPLEX_TYPE:")
+            ):
                 seen.add(key)
                 display = val[:80] + "..." if len(val) > 80 else val
                 components.append(
@@ -1486,7 +1782,9 @@ def _collect_symbols(result: CodeAnalysisResult, symbols: set[str]) -> None:
     variable_map: dict[str, str] = {}
     for assignment in result.assignments:
         if assignment.target_qualified_name and assignment.call.qualified_name:
-            variable_map[assignment.target_qualified_name] = assignment.call.qualified_name
+            variable_map[assignment.target_qualified_name] = (
+                assignment.call.qualified_name
+            )
 
     for assignment in result.assignments:
         name = _resolve_chain(assignment.call.qualified_name, variable_map)
@@ -1505,7 +1803,8 @@ def _collect_symbols(result: CodeAnalysisResult, symbols: set[str]) -> None:
 
 
 def _batch_kb_lookup(
-    db: CatalogDB, symbols: set[str],
+    db: CatalogDB,
+    symbols: set[str],
 ) -> dict[str, dict[str, Any]]:
     """Query DuckDB for symbols via the token-based hash-join index.
 
@@ -1544,7 +1843,9 @@ def _process_file_with_cache(
     variable_map: dict[str, str] = {}
     for assignment in result.assignments:
         if assignment.target_qualified_name and assignment.call.qualified_name:
-            variable_map[assignment.target_qualified_name] = assignment.call.qualified_name
+            variable_map[assignment.target_qualified_name] = (
+                assignment.call.qualified_name
+            )
 
     observations: list[dict[str, Any]] = []
     components: list[AIComponent] = []
@@ -1553,9 +1854,14 @@ def _process_file_with_cache(
     for assignment in result.assignments:
         name = _resolve_chain(assignment.call.qualified_name, variable_map)
         observations.append(
-            _obs(name, result.file_path, assignment.line_number, "assignment",
-                 args=assignment.call.arguments,
-                 assigned_target=assignment.target_qualified_name)
+            _obs(
+                name,
+                result.file_path,
+                assignment.line_number,
+                "assignment",
+                args=assignment.call.arguments,
+                assigned_target=assignment.target_qualified_name,
+            )
         )
 
     for dec in result.decorators:
@@ -1566,8 +1872,13 @@ def _process_file_with_cache(
             name = f"{base}.{attr}"
         name = _resolve_chain(name, variable_map)
         observations.append(
-            _obs(name, result.file_path, dec.line_number, "decorator",
-                 decorated=dec.decorated_function_name)
+            _obs(
+                name,
+                result.file_path,
+                dec.line_number,
+                "decorator",
+                decorated=dec.decorated_function_name,
+            )
         )
 
     for ctx in result.context_managers:
@@ -1583,10 +1894,26 @@ def _process_file_with_cache(
     fw_prefixes = kb_fw_prefixes or _AGENT_FRAMEWORK_PREFIXES
     pat = kb_patterns or {}
     _call_pattern_map: list[tuple[frozenset[str], frozenset[str], AIComponentType]] = [
-        (pat.get(AIComponentType.AGENT, _AGENT_CREATION_PATTERNS), fw_prefixes, AIComponentType.AGENT),
-        (pat.get(AIComponentType.TOOL, _STATIC_TOOL_PATTERNS), fw_prefixes, AIComponentType.TOOL),
-        (pat.get(AIComponentType.MEMORY, _STATIC_MEMORY_PATTERNS), fw_prefixes, AIComponentType.MEMORY),
-        (pat.get(AIComponentType.PROMPT, _STATIC_PROMPT_PATTERNS), fw_prefixes, AIComponentType.PROMPT),
+        (
+            pat.get(AIComponentType.AGENT, _AGENT_CREATION_PATTERNS),
+            fw_prefixes,
+            AIComponentType.AGENT,
+        ),
+        (
+            pat.get(AIComponentType.TOOL, _STATIC_TOOL_PATTERNS),
+            fw_prefixes,
+            AIComponentType.TOOL,
+        ),
+        (
+            pat.get(AIComponentType.MEMORY, _STATIC_MEMORY_PATTERNS),
+            fw_prefixes,
+            AIComponentType.MEMORY,
+        ),
+        (
+            pat.get(AIComponentType.PROMPT, _STATIC_PROMPT_PATTERNS),
+            fw_prefixes,
+            AIComponentType.PROMPT,
+        ),
     ]
 
     for call_obs in result.calls:
@@ -1641,7 +1968,10 @@ def _process_file_with_cache(
             continue
 
         match = _match_observation_rich(
-            obs_data["name"], kb_by_id, imported_frameworks, suffix_idx,
+            obs_data["name"],
+            kb_by_id,
+            imported_frameworks,
+            suffix_idx,
         )
 
         if match.is_confirmed:
@@ -1750,7 +2080,9 @@ def _process_file(
     variable_map: dict[str, str] = {}
     for assignment in result.assignments:
         if assignment.target_qualified_name and assignment.call.qualified_name:
-            variable_map[assignment.target_qualified_name] = assignment.call.qualified_name
+            variable_map[assignment.target_qualified_name] = (
+                assignment.call.qualified_name
+            )
 
     observations: list[dict[str, Any]] = []
     symbols: set[str] = set()
@@ -1760,9 +2092,14 @@ def _process_file(
     for assignment in result.assignments:
         name = _resolve_chain(assignment.call.qualified_name, variable_map)
         observations.append(
-            _obs(name, result.file_path, assignment.line_number, "assignment",
-                 args=assignment.call.arguments,
-                 assigned_target=assignment.target_qualified_name)
+            _obs(
+                name,
+                result.file_path,
+                assignment.line_number,
+                "assignment",
+                args=assignment.call.arguments,
+                assigned_target=assignment.target_qualified_name,
+            )
         )
         symbols.add(name)
 
@@ -1774,8 +2111,13 @@ def _process_file(
             name = f"{base}.{attr}"
         name = _resolve_chain(name, variable_map)
         observations.append(
-            _obs(name, result.file_path, dec.line_number, "decorator",
-                 decorated=dec.decorated_function_name)
+            _obs(
+                name,
+                result.file_path,
+                dec.line_number,
+                "decorator",
+                decorated=dec.decorated_function_name,
+            )
         )
         symbols.add(name)
 
@@ -1793,10 +2135,26 @@ def _process_file(
     fw_prefixes = kb_fw_prefixes or _AGENT_FRAMEWORK_PREFIXES
     pat = kb_patterns or {}
     _call_pattern_map: list[tuple[frozenset[str], frozenset[str], AIComponentType]] = [
-        (pat.get(AIComponentType.AGENT, _AGENT_CREATION_PATTERNS), fw_prefixes, AIComponentType.AGENT),
-        (pat.get(AIComponentType.TOOL, _STATIC_TOOL_PATTERNS), fw_prefixes, AIComponentType.TOOL),
-        (pat.get(AIComponentType.MEMORY, _STATIC_MEMORY_PATTERNS), fw_prefixes, AIComponentType.MEMORY),
-        (pat.get(AIComponentType.PROMPT, _STATIC_PROMPT_PATTERNS), fw_prefixes, AIComponentType.PROMPT),
+        (
+            pat.get(AIComponentType.AGENT, _AGENT_CREATION_PATTERNS),
+            fw_prefixes,
+            AIComponentType.AGENT,
+        ),
+        (
+            pat.get(AIComponentType.TOOL, _STATIC_TOOL_PATTERNS),
+            fw_prefixes,
+            AIComponentType.TOOL,
+        ),
+        (
+            pat.get(AIComponentType.MEMORY, _STATIC_MEMORY_PATTERNS),
+            fw_prefixes,
+            AIComponentType.MEMORY,
+        ),
+        (
+            pat.get(AIComponentType.PROMPT, _STATIC_PROMPT_PATTERNS),
+            fw_prefixes,
+            AIComponentType.PROMPT,
+        ),
     ]
 
     for call_obs in result.calls:
@@ -1872,7 +2230,9 @@ def _process_file(
         if key in seen:
             continue
 
-        match = _match_observation_rich(obs_data["name"], kb_by_id, imported_frameworks, suffix_idx)
+        match = _match_observation_rich(
+            obs_data["name"], kb_by_id, imported_frameworks, suffix_idx
+        )
 
         if match.is_confirmed:
             kb_entry = match.entry
@@ -2042,11 +2402,14 @@ def _match_observation_rich(
     if suffix_index is not None:
         all_candidates = suffix_index.get(obs_name, [])
         fw_candidates = [
-            e for e in all_candidates
+            e
+            for e in all_candidates
             if not obs_module or _frameworks_related(obs_module, e.get("framework", ""))
         ]
         if fw_candidates:
-            return _MatchResult(entry=_pick_best(fw_candidates, imported_frameworks, obs_module))
+            return _MatchResult(
+                entry=_pick_best(fw_candidates, imported_frameworks, obs_module)
+            )
 
         if all_candidates and obs_module:
             best = _pick_best(all_candidates, imported_frameworks, obs_module)
@@ -2061,7 +2424,9 @@ def _match_observation_rich(
             all_cls_candidates = suffix_index.get(class_name, [])
             if all_cls_candidates:
                 best = _pick_best(all_cls_candidates, imported_frameworks, obs_module)
-                if not obs_module or _frameworks_related(obs_module, best.get("framework", "")):
+                if not obs_module or _frameworks_related(
+                    obs_module, best.get("framework", "")
+                ):
                     return _MatchResult(entry=best)
                 return _MatchResult(
                     partial_kb_id=best.get("id", ""),
@@ -2075,11 +2440,15 @@ def _match_observation_rich(
     for kb_id, entry in kb_by_id.items():
         if kb_id.endswith("." + obs_name):
             all_suffix_candidates.append(entry)
-            if not obs_module or _frameworks_related(obs_module, entry.get("framework", "")):
+            if not obs_module or _frameworks_related(
+                obs_module, entry.get("framework", "")
+            ):
                 candidates.append(entry)
 
     if candidates:
-        return _MatchResult(entry=_pick_best(candidates, imported_frameworks, obs_module))
+        return _MatchResult(
+            entry=_pick_best(candidates, imported_frameworks, obs_module)
+        )
     if all_suffix_candidates and obs_module:
         best = _pick_best(all_suffix_candidates, imported_frameworks, obs_module)
         return _MatchResult(

--- a/aibom/src/aibom/scanners/kb_enrichment_scanner.py
+++ b/aibom/src/aibom/scanners/kb_enrichment_scanner.py
@@ -389,8 +389,13 @@ _IMPORT_MODULE_TYPE_MAP: dict[str, PlatformEntry] = {
     "nemoguardrails": PlatformEntry(_GRD),
     "guardrails": PlatformEntry(_GRD),
     "llm_guard": PlatformEntry(_GRD),
+    "llm_guardrails": PlatformEntry(_GRD),
     "lakera_guard": PlatformEntry(_GRD),
     "rebuff": PlatformEntry(_GRD),
+    "guardrails_ai": PlatformEntry(_GRD),
+    # Cisco AI Defense runtime protection (agentsec).
+    "aidefense": PlatformEntry(_GRD),
+    "agentsec": PlatformEntry(_GRD),
 }
 
 OBSERVABILITY_PLATFORM_TOKENS: frozenset[str] = frozenset(
@@ -887,6 +892,7 @@ class KBEnrichmentScanner(BaseScanner):
                 components.extend(_detect_prompt_kwargs(result))
                 components.extend(_detect_model_kwargs(result))
                 components.extend(_detect_import_based_assets(result))
+                components.extend(_detect_guardrail_calls(result))
 
             for py_file, source in suggestive_files:
                 components.extend(_emit_suggestive_candidates(py_file, source))
@@ -1253,6 +1259,76 @@ def _detect_import_based_assets(
             )
 
     return candidates
+
+
+# Guardrail protection call sites. These are unambiguous: a call to one of
+# these qualified names installs runtime safety/guardrail protection over LLM
+# or MCP traffic, so the call site itself is a guardrail component. Keyed on
+# the ``module.method`` tail so e.g. ``agentsec.protect(...)`` matches whether
+# imported as ``from aidefense.runtime import agentsec`` or ``import agentsec``.
+_GUARDRAIL_CALL_PATTERNS: frozenset[str] = frozenset(
+    {
+        "agentsec.protect",
+        "RailsConfig.from_path",  # NeMo Guardrails
+        "LLMRails",  # NeMo Guardrails
+        "Guard.for_string",  # Guardrails AI
+        "Guard.for_pydantic",  # Guardrails AI
+    }
+)
+
+
+def _detect_guardrail_calls(result: "CodeAnalysisResult") -> list[AIComponent]:
+    """Detect guardrail components from protection call sites.
+
+    The clearest guardrail signal is a call that installs runtime protection,
+    e.g. Cisco AI Defense's ``agentsec.protect(...)`` or a NeMo Guardrails /
+    Guardrails AI entry point. Import-based detection alone misses these when
+    the protection is wired through a call rather than a class import, and the
+    call site carries the precise file/line evidence.
+    """
+    from ..structures import CodeAnalysisResult as _CAR  # noqa: F811
+
+    if not isinstance(result, _CAR):
+        return []
+
+    components: list[AIComponent] = []
+    seen: set[tuple[str, int]] = set()
+
+    all_calls = [(c.qualified_name or "", c.line_number) for c in result.calls]
+    all_calls += [
+        (a.call.qualified_name or "", a.line_number) for a in result.assignments
+    ]
+
+    for qn, line in all_calls:
+        if not qn:
+            continue
+        # Match either the full ``module.method`` tail or a bare class name.
+        tail2 = ".".join(qn.split(".")[-2:]) if "." in qn else qn
+        short = qn.rsplit(".", 1)[-1] if "." in qn else qn
+        if tail2 not in _GUARDRAIL_CALL_PATTERNS and short not in (
+            _GUARDRAIL_CALL_PATTERNS
+        ):
+            continue
+
+        key = (result.file_path, line)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        framework = qn.split(".")[0] if "." in qn else qn
+        components.append(
+            AIComponent(
+                name=tail2 if tail2 in _GUARDRAIL_CALL_PATTERNS else short,
+                component_type=AIComponentType.GUARDRAIL,
+                file_path=result.file_path,
+                line_number=line,
+                framework=framework,
+                detection_source=DetectionSource.CODE_ANALYSIS,
+                metadata={"call_pattern": qn, "guardrail_protection": True},
+            )
+        )
+
+    return components
 
 
 _TOOL_KWARG_NAMES: frozenset[str] = frozenset(

--- a/aibom/src/aibom/scanners/kb_enrichment_scanner.py
+++ b/aibom/src/aibom/scanners/kb_enrichment_scanner.py
@@ -185,6 +185,12 @@ _AGENT_CREATION_PATTERNS: frozenset[str] = frozenset(
 _AGENT_FRAMEWORK_PREFIXES: frozenset[str] = frozenset(
     {
         "langchain",
+        # LangGraph ships the prebuilt ReAct agent factory
+        # ``langgraph.prebuilt.create_react_agent`` (catalogued in the KB as an
+        # agent). The call-pattern gate derives the prefix from the qualified
+        # name's first segment, so ``langgraph`` must be listed here for those
+        # module-level factory calls to be emitted as agents.
+        "langgraph",
         "crewai",
         "autogen",
         # Strands Agents (https://strandsagents.com/) uses module-level

--- a/aibom/src/aibom/scanners/mcp_detector.py
+++ b/aibom/src/aibom/scanners/mcp_detector.py
@@ -57,6 +57,19 @@ _RE_MULTI_MCP_CLIENT = re.compile(r"\bMultiServerMCPClient\s*\(")
 _RE_LANGCHAIN_MCP_ADAPTERS = re.compile(r"from\s+langchain_mcp_adapters\b")
 _RE_CLIENT_SESSION = re.compile(r"\bClientSession\s*\(")
 _RE_MCP_CLIENT_MODULE = re.compile(r"\bmcp\.client\b")
+# MCP Python SDK transport factories. The modern SDK idiom opens a connection
+# with one of these and then wraps the streams in a ClientSession, e.g.
+# ``async with streamablehttp_client(url) as (r, w, _): ClientSession(r, w)``.
+_RE_STREAMABLEHTTP_CLIENT = re.compile(r"\bstreamablehttp_client\s*\(")
+_RE_SSE_CLIENT = re.compile(r"\bsse_client\s*\(")
+_RE_STDIO_CLIENT = re.compile(r"\bstdio_client\s*\(")
+# Google ADK MCP integration: ``McpToolset(connection_params=...)`` with a
+# ``StreamableHTTPConnectionParams`` / ``SseConnectionParams`` / stdio params.
+_RE_ADK_MCP_TOOLSET = re.compile(r"\bMcpToolset\s*\(")
+_RE_ADK_MCP_CONN_PARAMS = re.compile(
+    r"\b(?:StreamableHTTPConnectionParams|SseConnectionParams|"
+    r"StdioConnectionParams|StdioServerParameters)\s*\("
+)
 
 
 def _is_mcp_config_path(path: Path) -> bool:
@@ -72,9 +85,7 @@ def _load_exclude_spec(patterns: list[str]) -> Optional[PathSpec]:
     return PathSpec.from_lines("gitwildmatch", patterns)
 
 
-def _is_excluded(
-    file_path: Path, root: Path, spec: Optional[PathSpec]
-) -> bool:
+def _is_excluded(file_path: Path, root: Path, spec: Optional[PathSpec]) -> bool:
     if not spec:
         return False
     try:
@@ -221,9 +232,7 @@ def _components_from_python(path: Path) -> list[AIComponent]:
         constructor_hits.append(("FastMCP", _first_match_line(_RE_FASTMCP, text)))
 
     m_srv_call = _RE_SERVER_CALL.search(text)
-    if m_srv_call and (
-        _RE_FROM_MCP_SERVER_IMPORT.search(text) or "mcp.server" in text
-    ):
+    if m_srv_call and (_RE_FROM_MCP_SERVER_IMPORT.search(text) or "mcp.server" in text):
         if not constructor_name:
             m_srv_name = _RE_SERVER_CALL_NAME.search(text)
             if m_srv_name:
@@ -286,6 +295,11 @@ def _components_from_python(path: Path) -> list[AIComponent]:
     for label, pat in (
         ("MCPClient", _RE_MCP_CLIENT),
         ("MultiServerMCPClient", _RE_MULTI_MCP_CLIENT),
+        ("streamablehttp_client", _RE_STREAMABLEHTTP_CLIENT),
+        ("sse_client", _RE_SSE_CLIENT),
+        ("stdio_client", _RE_STDIO_CLIENT),
+        ("McpToolset", _RE_ADK_MCP_TOOLSET),
+        ("mcp_connection_params", _RE_ADK_MCP_CONN_PARAMS),
     ):
         m = pat.search(text)
         if m:
@@ -295,8 +309,17 @@ def _components_from_python(path: Path) -> list[AIComponent]:
         client_hits.append(
             ("langchain_mcp_adapters", _line_for_match(text, m_lc.start()))
         )
+    # ``ClientSession`` is a generic name, so it only counts as an MCP client
+    # when the file also references the MCP client module *or* opens one of the
+    # MCP SDK transport clients above (the modern Streamable-HTTP idiom imports
+    # ``ClientSession`` from ``mcp`` rather than touching ``mcp.client``).
     m_cs = _RE_CLIENT_SESSION.search(text)
-    if m_cs and _RE_MCP_CLIENT_MODULE.search(text):
+    has_mcp_transport = bool(
+        _RE_STREAMABLEHTTP_CLIENT.search(text)
+        or _RE_SSE_CLIENT.search(text)
+        or _RE_STDIO_CLIENT.search(text)
+    )
+    if m_cs and (_RE_MCP_CLIENT_MODULE.search(text) or m_imp or has_mcp_transport):
         client_hits.append(("ClientSession", _line_for_match(text, m_cs.start())))
     if client_hits:
         client_hits.sort(key=lambda x: x[1])
@@ -331,9 +354,7 @@ def _run_optional_yara_on_configs(config_paths: list[str]) -> None:
                     analyzers=[AnalyzerEnum.YARA],
                 )
             except Exception:
-                _LOGGER.debug(
-                    "mcpscanner YARA scan failed for %s", cfg, exc_info=True
-                )
+                _LOGGER.debug("mcpscanner YARA scan failed for %s", cfg, exc_info=True)
 
     try:
         asyncio.run(_scan_all())

--- a/aibom/src/aibom/source_attribution.py
+++ b/aibom/src/aibom/source_attribution.py
@@ -36,6 +36,7 @@ in the loop, so the CLI is the source of truth.
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -46,6 +47,11 @@ SOURCE_KIND_CONTAINER_IMAGE = "container_image"
 SOURCE_KIND_LOCAL_PATH = "local-path"
 
 _GIT_TIMEOUT_S = 5
+
+# scp-style git remote, e.g. ``git@github.com:org/repo.git``.
+_SCP_LIKE_RE = re.compile(r"^[^/@]+@([^:/]+):(.+)$")
+# ``scheme://[user[:pass]@]host[:port]/path`` for git remotes.
+_URL_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*://(?P<rest>.*)$")
 
 
 def _is_git_working_tree(path: Path) -> bool:
@@ -87,3 +93,112 @@ def detect_source_kind(
         return SOURCE_KIND_GIT
 
     return SOURCE_KIND_LOCAL_PATH
+
+
+def canonicalize_git_remote(remote_url: str) -> str:
+    """Canonicalize a git remote URL to one stable ``host/path`` string.
+
+    The same repository can be expressed many ways
+    (``git@github.com:org/repo.git``, ``https://github.com/org/repo``, with or
+    without a trailing ``.git``, mixed host casing, embedded credentials, a
+    trailing slash). A downstream backend derives a deterministic asset
+    identity from this string, so every equivalent spelling must collapse to a
+    single canonical form.
+
+    Canonicalization: drop the scheme, strip any ``user[:pass]@`` credentials,
+    lowercase the host, drop a ``:port``, normalize path separators to ``/``,
+    remove a trailing ``.git``, and drop a trailing slash. The result is
+    ``host/path`` lowercased on the host only (paths stay case-sensitive).
+    """
+    if not remote_url:
+        return ""
+
+    raw = remote_url.strip()
+    host = ""
+    path = ""
+
+    scp = _SCP_LIKE_RE.match(raw)
+    url = _URL_RE.match(raw)
+    if scp:
+        host = scp.group(1)
+        path = scp.group(2)
+    elif url:
+        rest = url.group("rest")
+        # Strip credentials.
+        if "@" in rest:
+            rest = rest.rsplit("@", 1)[1]
+        if "/" in rest:
+            authority, path = rest.split("/", 1)
+        else:
+            authority, path = rest, ""
+        host = authority
+    else:
+        # Bare ``host:path`` or ``host/path`` (no scheme, not scp/user form).
+        if ":" in raw and "/" not in raw.split(":", 1)[0]:
+            host, path = raw.split(":", 1)
+        elif "/" in raw:
+            host, path = raw.split("/", 1)
+        else:
+            host, path = raw, ""
+
+    # Drop a :port from the host.
+    if ":" in host:
+        host = host.split(":", 1)[0]
+    host = host.lower()
+
+    path = path.replace("\\", "/").strip("/")
+    if path.endswith(".git"):
+        path = path[: -len(".git")]
+
+    return f"{host}/{path}" if path else host
+
+
+def canonicalize_image_ref(image_ref: str) -> str:
+    """Canonicalize a container image reference to a stable registry path.
+
+    Strips a digest (``@sha256:...``) and a tag (``:tag``), normalizes the
+    registry host to lowercase, and applies Docker Hub defaults
+    (``library/`` for single-segment official images; an implicit
+    ``docker.io`` registry). The version (tag/digest) is captured separately as
+    ``source_ref_version`` and intentionally not part of the canonical ref.
+    """
+    if not image_ref:
+        return ""
+
+    ref = image_ref.strip()
+
+    # Drop digest.
+    if "@" in ref:
+        ref = ref.split("@", 1)[0]
+
+    # Split off an optional registry host (first segment containing '.' or
+    # ':' or equal to 'localhost').
+    first, sep, remainder = ref.partition("/")
+    if sep and ("." in first or ":" in first or first == "localhost"):
+        registry = first.lower()
+        repo = remainder
+    else:
+        registry = "docker.io"
+        repo = ref
+
+    # Drop a tag from the final path segment (but not from a registry port).
+    if ":" in repo:
+        repo_head, _, repo_tag = repo.rpartition(":")
+        # A ':' that is part of the path (tag) has no '/' after it.
+        if "/" not in repo_tag:
+            repo = repo_head
+
+    repo = repo.replace("\\", "/").strip("/")
+
+    # Docker Hub official images get the implicit ``library/`` namespace.
+    if registry == "docker.io" and "/" not in repo and repo:
+        repo = f"library/{repo}"
+
+    return f"{registry}/{repo}" if repo else registry
+
+
+def canonicalize_source_ref(source_ref: str, source_kind: str) -> str:
+    """Canonicalize a source reference according to its ``source_kind``."""
+    if source_kind == SOURCE_KIND_CONTAINER_IMAGE:
+        return canonicalize_image_ref(source_ref)
+    return canonicalize_git_remote(source_ref)

--- a/aibom/src/aibom/source_attribution.py
+++ b/aibom/src/aibom/source_attribution.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Source-attribution capture for the AI BOM.
+
+When the CLI scans a repository or container image, a downstream backend
+ingests the resulting BOM and projects each discovered component as an
+inventory asset. To keep an asset stable across re-scans, the backend derives a
+deterministic identity from three source-attribution fields the CLI emits on
+every BOM:
+
+* ``source_kind`` — ``git`` for a git working tree, ``container_image`` for an
+  OCI image, or ``local-path`` for a plain directory that is not a checkout.
+* ``source_ref_canonical`` — a single canonical string per source (normalized
+  git remote URL or registry path) so the same source spelled different ways
+  resolves to one identity.
+* ``source_ref_version`` — a point-in-time version stamp (git commit SHA or
+  image manifest digest).
+
+All three are produced deterministically at scan time; the customer's CI is not
+in the loop, so the CLI is the source of truth.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+# Source-kind values.
+SOURCE_KIND_GIT = "git"
+SOURCE_KIND_CONTAINER_IMAGE = "container_image"
+SOURCE_KIND_LOCAL_PATH = "local-path"
+
+_GIT_TIMEOUT_S = 5
+
+
+def _is_git_working_tree(path: Path) -> bool:
+    """Return True when *path* resolves inside a git working tree."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--is-inside-work-tree"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def detect_source_kind(
+    source: str, *, is_container_image: Optional[bool] = None
+) -> str:
+    """Detect the ``source_kind`` for a scan target.
+
+    Args:
+        source: The scan target — a filesystem path (git working tree or plain
+            directory) or an OCI image reference.
+        is_container_image: When the caller already knows the target is an OCI
+            image (e.g. the CLI resolved it via the container-extraction path),
+            pass ``True`` to short-circuit detection. ``None`` means "decide
+            from the path".
+
+    Returns:
+        ``"git"`` if the target is a git working tree, ``"container_image"`` if
+        it is an OCI image, otherwise ``"local-path"``.
+    """
+    if is_container_image:
+        return SOURCE_KIND_CONTAINER_IMAGE
+
+    path = Path(source)
+    if path.exists() and _is_git_working_tree(path):
+        return SOURCE_KIND_GIT
+
+    return SOURCE_KIND_LOCAL_PATH

--- a/aibom/src/aibom/source_attribution.py
+++ b/aibom/src/aibom/source_attribution.py
@@ -202,3 +202,68 @@ def canonicalize_source_ref(source_ref: str, source_kind: str) -> str:
     if source_kind == SOURCE_KIND_CONTAINER_IMAGE:
         return canonicalize_image_ref(source_ref)
     return canonicalize_git_remote(source_ref)
+
+
+def capture_git_remote(path: str) -> Optional[str]:
+    """Return the ``origin`` remote URL for the git working tree at *path*.
+
+    Returns ``None`` when the path is not a git tree or has no ``origin``
+    remote. The raw URL is returned as-is; canonicalization is the caller's
+    responsibility via :func:`canonicalize_source_ref`.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    return url or None
+
+
+def capture_git_head_sha(path: str) -> Optional[str]:
+    """Return the full commit SHA of ``HEAD`` for the git tree at *path*.
+
+    Returns ``None`` when the path is not a git tree or ``HEAD`` cannot be
+    resolved (e.g. a freshly initialized repo with no commits).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+def capture_source_ref_version(
+    source: str,
+    source_kind: str,
+    *,
+    image_digest: Optional[str] = None,
+) -> Optional[str]:
+    """Capture the point-in-time ``source_ref_version`` for a scan target.
+
+    For a git source this is the full ``HEAD`` commit SHA; for a container
+    image it is the manifest digest supplied by the caller (the
+    container-extraction path already resolves it). Returns ``None`` when no
+    version can be determined — the field is a best-effort version stamp, not
+    part of the stable identity hash.
+    """
+    if source_kind == SOURCE_KIND_CONTAINER_IMAGE:
+        digest = (image_digest or "").strip()
+        return digest or None
+    if source_kind == SOURCE_KIND_GIT:
+        return capture_git_head_sha(source)
+    return None

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -76,7 +76,9 @@ class TestBuildContextMessage:
             model_name="gpt-4o",
         )
         msg = _build_context_message(
-            [batch_comp], [], ["/tmp"],
+            [batch_comp],
+            [],
+            ["/tmp"],
             all_components=[batch_comp, other_comp],
         )
         json_start = msg.index("```json\n") + 8
@@ -109,7 +111,9 @@ class TestBuildContextMessage:
 
     def test_includes_code_context_for_real_file(self, tmp_path):
         src = tmp_path / "example.py"
-        src.write_text("import openai\nclient = openai.OpenAI()\nresult = client.chat.completions.create(model='gpt-4o')\n")
+        src.write_text(
+            "import openai\nclient = openai.OpenAI()\nresult = client.chat.completions.create(model='gpt-4o')\n"
+        )
         comps = [
             AIComponent(
                 name="gpt-4o",
@@ -168,31 +172,31 @@ class TestExtractStructuredResponse:
 class TestLazyImport:
     def test_aibom_import_does_not_import_deepagents(self):
         """Importing aibom.agentic should NOT trigger deepagents import."""
-        import sys
         import importlib
+        import sys
 
         mods_before = set(sys.modules.keys())
         importlib.import_module("aibom.agentic")
         mods_after = set(sys.modules.keys())
         new_mods = mods_after - mods_before
         deepagent_mods = [m for m in new_mods if "deepagent" in m.lower()]
-        assert deepagent_mods == [], (
-            f"Importing aibom.agentic pulled in deepagents: {deepagent_mods}"
-        )
+        assert (
+            deepagent_mods == []
+        ), f"Importing aibom.agentic pulled in deepagents: {deepagent_mods}"
 
     def test_aibom_import_does_not_import_langchain(self):
         """Importing aibom.agentic should NOT trigger langchain import."""
-        import sys
         import importlib
+        import sys
 
         mods_before = set(sys.modules.keys())
         importlib.import_module("aibom.agentic")
         mods_after = set(sys.modules.keys())
         new_mods = mods_after - mods_before
         langchain_mods = [m for m in new_mods if "langchain" in m.lower()]
-        assert langchain_mods == [], (
-            f"Importing aibom.agentic pulled in langchain: {langchain_mods}"
-        )
+        assert (
+            langchain_mods == []
+        ), f"Importing aibom.agentic pulled in langchain: {langchain_mods}"
 
 
 class TestRunAgenticEnrichment:
@@ -229,24 +233,28 @@ class TestRunAgenticEnrichment:
     @patch("aibom.agentic.agent._close_model_clients")
     @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
     @patch("aibom.agentic.agent.create_aibom_agent")
-    def test_merges_agent_output_into_components(self, mock_create, _mock_build, _mock_close):
+    def test_merges_agent_output_into_components(
+        self, mock_create, _mock_build, _mock_close
+    ):
         from aibom.agentic.agent import run_agentic_enrichment
 
-        agent_response = json.dumps({
-            "enriched_components": [],
-            "new_components": [
-                {
-                    "name": "agent-found-model",
-                    "component_type": "model",
-                    "file_path": "new.py",
-                    "line_number": 1,
-                    "framework": "openai",
-                    "model_name": "gpt-5",
-                }
-            ],
-            "new_relationships": [],
-            "risk_findings": [],
-        })
+        agent_response = json.dumps(
+            {
+                "enriched_components": [],
+                "new_components": [
+                    {
+                        "name": "agent-found-model",
+                        "component_type": "model",
+                        "file_path": "new.py",
+                        "line_number": 1,
+                        "framework": "openai",
+                        "model_name": "gpt-5",
+                    }
+                ],
+                "new_relationships": [],
+                "risk_findings": [],
+            }
+        )
 
         mock_agent = MagicMock()
         mock_msg = MagicMock()
@@ -276,24 +284,28 @@ class TestRunAgenticEnrichment:
     @patch("aibom.agentic.agent._close_model_clients")
     @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
     @patch("aibom.agentic.agent.create_aibom_agent")
-    def test_cached_rerun_replays_new_components(self, mock_create, _mock_build, _mock_close, tmp_path):
+    def test_cached_rerun_replays_new_components(
+        self, mock_create, _mock_build, _mock_close, tmp_path
+    ):
         from aibom.agentic.agent import run_agentic_enrichment
 
-        agent_response = json.dumps({
-            "enriched_components": [],
-            "new_components": [
-                {
-                    "name": "agent-found-model",
-                    "component_type": "model",
-                    "file_path": "new.py",
-                    "line_number": 1,
-                    "framework": "openai",
-                    "model_name": "gpt-5",
-                }
-            ],
-            "new_relationships": [],
-            "risk_findings": [],
-        })
+        agent_response = json.dumps(
+            {
+                "enriched_components": [],
+                "new_components": [
+                    {
+                        "name": "agent-found-model",
+                        "component_type": "model",
+                        "file_path": "new.py",
+                        "line_number": 1,
+                        "framework": "openai",
+                        "model_name": "gpt-5",
+                    }
+                ],
+                "new_relationships": [],
+                "risk_findings": [],
+            }
+        )
 
         mock_agent = MagicMock()
         mock_msg = MagicMock()
@@ -340,42 +352,46 @@ class TestRunAgenticEnrichment:
         from aibom.agentic.agent import run_agentic_enrichment
 
         first_msg = MagicMock()
-        first_msg.content = json.dumps({
-            "enriched_components": [],
-            "new_components": [
-                {
-                    "name": "agent-found-model",
-                    "component_type": "model",
-                    "file_path": "new.py",
-                    "line_number": 1,
-                    "framework": "openai",
-                    "model_name": "gpt-5",
-                }
-            ],
-            "new_relationships": [
-                {
-                    "source_name": "existing-a",
-                    "target_name": "existing-b",
-                    "relationship_type": "USES_MODEL",
-                }
-            ],
-            "risk_findings": [
-                {
-                    "flag": "cache_replayed",
-                    "description": "cached finding",
-                    "file_path": "app_a.py",
-                    "line_number": 1,
-                    "severity": "low",
-                }
-            ],
-        })
+        first_msg.content = json.dumps(
+            {
+                "enriched_components": [],
+                "new_components": [
+                    {
+                        "name": "agent-found-model",
+                        "component_type": "model",
+                        "file_path": "new.py",
+                        "line_number": 1,
+                        "framework": "openai",
+                        "model_name": "gpt-5",
+                    }
+                ],
+                "new_relationships": [
+                    {
+                        "source_name": "existing-a",
+                        "target_name": "existing-b",
+                        "relationship_type": "USES_MODEL",
+                    }
+                ],
+                "risk_findings": [
+                    {
+                        "flag": "cache_replayed",
+                        "description": "cached finding",
+                        "file_path": "app_a.py",
+                        "line_number": 1,
+                        "severity": "low",
+                    }
+                ],
+            }
+        )
         second_msg = MagicMock()
-        second_msg.content = json.dumps({
-            "enriched_components": [],
-            "new_components": [],
-            "new_relationships": [],
-            "risk_findings": [],
-        })
+        second_msg.content = json.dumps(
+            {
+                "enriched_components": [],
+                "new_components": [],
+                "new_relationships": [],
+                "risk_findings": [],
+            }
+        )
         mock_agent = MagicMock()
         mock_agent.invoke.side_effect = [
             {"messages": [first_msg]},
@@ -423,10 +439,15 @@ class TestRunAgenticEnrichment:
         )
 
         assert {c.name for c in fresh_components} == {
-            "existing-a", "existing-b", "agent-found-model",
+            "existing-a",
+            "existing-b",
+            "agent-found-model",
         }
         assert {c.name for c in cached_components} == {
-            "existing-a", "existing-b", "existing-c", "agent-found-model",
+            "existing-a",
+            "existing-b",
+            "existing-c",
+            "agent-found-model",
         }
         assert sum(c.name == "agent-found-model" for c in cached_components) == 1
         assert len(cached_rels) == 1
@@ -449,22 +470,24 @@ class TestRunAgenticEnrichment:
         from aibom.agentic.agent import run_cross_repo_coordination
 
         mock_msg = MagicMock()
-        mock_msg.content = json.dumps({
-            "new_relationships": [
-                {
-                    "source_name": "repo-a-model",
-                    "target_name": "repo-b-endpoint",
-                    "relationship_type": "USES_MODEL",
-                }
-            ],
-            "risk_findings": [
-                {
-                    "flag": "cross_repo_env_var_mismatch",
-                    "description": "backend mismatch",
-                    "severity": "medium",
-                }
-            ],
-        })
+        mock_msg.content = json.dumps(
+            {
+                "new_relationships": [
+                    {
+                        "source_name": "repo-a-model",
+                        "target_name": "repo-b-endpoint",
+                        "relationship_type": "USES_MODEL",
+                    }
+                ],
+                "risk_findings": [
+                    {
+                        "flag": "cross_repo_env_var_mismatch",
+                        "description": "backend mismatch",
+                        "severity": "medium",
+                    }
+                ],
+            }
+        )
         mock_agent = MagicMock()
         mock_agent.invoke.return_value = {"messages": [mock_msg]}
         mock_create.return_value = mock_agent
@@ -538,7 +561,9 @@ class TestRunAgenticEnrichment:
     @patch("aibom.agentic.agent._close_model_clients")
     @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
     @patch("aibom.agentic.agent.create_aibom_agent")
-    def test_handles_agent_failure_gracefully(self, mock_create, _mock_build, _mock_close):
+    def test_handles_agent_failure_gracefully(
+        self, mock_create, _mock_build, _mock_close
+    ):
         from aibom.agentic.agent import run_agentic_enrichment
 
         mock_create.return_value = MagicMock(
@@ -568,12 +593,14 @@ class TestRunAgenticEnrichment:
 
         mock_agent = MagicMock()
         mock_msg = MagicMock()
-        mock_msg.content = json.dumps({
-            "enriched_components": [],
-            "new_components": [],
-            "new_relationships": [],
-            "risk_findings": [],
-        })
+        mock_msg.content = json.dumps(
+            {
+                "enriched_components": [],
+                "new_components": [],
+                "new_relationships": [],
+                "risk_findings": [],
+            }
+        )
         mock_agent.invoke.return_value = {"messages": [mock_msg]}
         mock_agent.ainvoke = AsyncMock(return_value={"messages": [mock_msg]})
         mock_create.return_value = mock_agent
@@ -607,12 +634,14 @@ class TestRunAgenticEnrichment:
 
         mock_agent = MagicMock()
         mock_msg = MagicMock()
-        mock_msg.content = json.dumps({
-            "enriched_components": [],
-            "new_components": [],
-            "new_relationships": [],
-            "risk_findings": [],
-        })
+        mock_msg.content = json.dumps(
+            {
+                "enriched_components": [],
+                "new_components": [],
+                "new_relationships": [],
+                "risk_findings": [],
+            }
+        )
         mock_agent.invoke.return_value = {"messages": [mock_msg]}
         mock_create.return_value = mock_agent
 
@@ -637,17 +666,21 @@ class TestRunAgenticEnrichment:
     @patch("aibom.agentic.agent._close_model_clients")
     @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
     @patch("aibom.agentic.agent.create_aibom_agent")
-    def test_tiered_model_uses_fast_for_simple(self, mock_create, mock_build, _mock_close):
+    def test_tiered_model_uses_fast_for_simple(
+        self, mock_create, mock_build, _mock_close
+    ):
         from aibom.agentic.agent import run_agentic_enrichment
 
         mock_agent = MagicMock()
         mock_msg = MagicMock()
-        mock_msg.content = json.dumps({
-            "enriched_components": [],
-            "new_components": [],
-            "new_relationships": [],
-            "risk_findings": [],
-        })
+        mock_msg.content = json.dumps(
+            {
+                "enriched_components": [],
+                "new_components": [],
+                "new_relationships": [],
+                "risk_findings": [],
+            }
+        )
         mock_agent.invoke.return_value = {"messages": [mock_msg]}
         mock_create.return_value = mock_agent
 
@@ -678,7 +711,11 @@ class TestRunAgenticEnrichment:
 
 class TestToolStats:
     def test_tool_stats_isolated_per_reset(self):
-        from aibom.agentic.tools import _reset_tool_stats, get_tool_stats, _get_stats_dict
+        from aibom.agentic.tools import (
+            _get_stats_dict,
+            _reset_tool_stats,
+            get_tool_stats,
+        )
 
         _reset_tool_stats()
         assert get_tool_stats() == {}
@@ -690,7 +727,7 @@ class TestToolStats:
         assert get_tool_stats() == {}
 
     def test_track_tool_decorator(self):
-        from aibom.agentic.tools import _reset_tool_stats, get_tool_stats, _track_tool
+        from aibom.agentic.tools import _reset_tool_stats, _track_tool, get_tool_stats
 
         _reset_tool_stats()
 
@@ -712,10 +749,30 @@ class TestLocalityAwareBatching:
         from aibom.agentic.agent import _locality_aware_batches
 
         comps = [
-            AIComponent(name="a", component_type=AIComponentType.MODEL, file_path="/repo/dir1/a.py", line_number=1),
-            AIComponent(name="b", component_type=AIComponentType.MODEL, file_path="/repo/dir1/b.py", line_number=2),
-            AIComponent(name="c", component_type=AIComponentType.MODEL, file_path="/repo/dir2/c.py", line_number=1),
-            AIComponent(name="d", component_type=AIComponentType.MODEL, file_path="/repo/dir2/d.py", line_number=2),
+            AIComponent(
+                name="a",
+                component_type=AIComponentType.MODEL,
+                file_path="/repo/dir1/a.py",
+                line_number=1,
+            ),
+            AIComponent(
+                name="b",
+                component_type=AIComponentType.MODEL,
+                file_path="/repo/dir1/b.py",
+                line_number=2,
+            ),
+            AIComponent(
+                name="c",
+                component_type=AIComponentType.MODEL,
+                file_path="/repo/dir2/c.py",
+                line_number=1,
+            ),
+            AIComponent(
+                name="d",
+                component_type=AIComponentType.MODEL,
+                file_path="/repo/dir2/d.py",
+                line_number=2,
+            ),
         ]
         batches = _locality_aware_batches(comps, batch_size=3)
         assert len(batches) == 2
@@ -726,7 +783,12 @@ class TestLocalityAwareBatching:
         from aibom.agentic.agent import _locality_aware_batches
 
         comps = [
-            AIComponent(name=f"m{i}", component_type=AIComponentType.MODEL, file_path=f"/repo/pkg/{i}.py", line_number=i)
+            AIComponent(
+                name=f"m{i}",
+                component_type=AIComponentType.MODEL,
+                file_path=f"/repo/pkg/{i}.py",
+                line_number=i,
+            )
             for i in range(4)
         ]
         batches = _locality_aware_batches(comps, batch_size=5)
@@ -737,7 +799,12 @@ class TestLocalityAwareBatching:
         from aibom.agentic.agent import _locality_aware_batches
 
         comps = [
-            AIComponent(name=f"m{i}", component_type=AIComponentType.MODEL, file_path=f"/repo/pkg/{i}.py", line_number=i)
+            AIComponent(
+                name=f"m{i}",
+                component_type=AIComponentType.MODEL,
+                file_path=f"/repo/pkg/{i}.py",
+                line_number=i,
+            )
             for i in range(7)
         ]
         batches = _locality_aware_batches(comps, batch_size=3)
@@ -753,8 +820,11 @@ class TestAgenticResultCache:
 
         cache = _AgenticResultCache(tmp_path / "cache")
         comp = AIComponent(
-            name="gpt-4o", component_type=AIComponentType.MODEL,
-            file_path="a.py", line_number=1, model_name="gpt-4o",
+            name="gpt-4o",
+            component_type=AIComponentType.MODEL,
+            file_path="a.py",
+            line_number=1,
+            model_name="gpt-4o",
         )
         key = _component_cache_key(comp)
         assert cache.get(key) is None
@@ -766,8 +836,20 @@ class TestAgenticResultCache:
         from aibom.agentic.agent import _AgenticResultCache, _component_cache_key
 
         cache = _AgenticResultCache(tmp_path / "cache")
-        c1 = AIComponent(name="a", component_type=AIComponentType.MODEL, file_path="a.py", line_number=1, model_name="gpt-4o")
-        c2 = AIComponent(name="b", component_type=AIComponentType.MODEL, file_path="b.py", line_number=1, model_name="gpt-5")
+        c1 = AIComponent(
+            name="a",
+            component_type=AIComponentType.MODEL,
+            file_path="a.py",
+            line_number=1,
+            model_name="gpt-4o",
+        )
+        c2 = AIComponent(
+            name="b",
+            component_type=AIComponentType.MODEL,
+            file_path="b.py",
+            line_number=1,
+            model_name="gpt-5",
+        )
         cache.put(_component_cache_key(c1), {"enriched_components": []})
 
         cached, uncached = cache.partition([c1, c2])
@@ -781,7 +863,12 @@ class TestAgenticResultCache:
 
         cache_dir = tmp_path / "cache"
         cache1 = _AgenticResultCache(cache_dir)
-        comp = AIComponent(name="x", component_type=AIComponentType.MODEL, file_path="x.py", line_number=1)
+        comp = AIComponent(
+            name="x",
+            component_type=AIComponentType.MODEL,
+            file_path="x.py",
+            line_number=1,
+        )
         key = _component_cache_key(comp)
         cache1.put(key, {"enriched_components": [], "test": True})
 
@@ -805,26 +892,33 @@ class TestAgenticResultCache:
             heuristic_confidence=0.2,
             agentic_hint="stale_hint",
         )
-        after = before.model_copy(update={
-            "component_type": AIComponentType.MODEL_ENDPOINT,
-            "description": "",
-            "framework": "openai",
-            "metadata": {"verified": True},
-            "heuristic_confidence": 0.97,
-            "agentic_hint": "",
-            "needs_agentic": False,
-        })
-        cache.put(_component_cache_key(before), {
-            "cached_component": after.model_dump(mode="json"),
-            "enriched_components": [],
-            "new_components": [],
-            "remove_components": [],
-            "reclassify_components": [],
-            "new_relationships": [],
-            "risk_findings": [],
-        })
+        after = before.model_copy(
+            update={
+                "component_type": AIComponentType.MODEL_ENDPOINT,
+                "description": "",
+                "framework": "openai",
+                "metadata": {"verified": True},
+                "heuristic_confidence": 0.97,
+                "agentic_hint": "",
+                "needs_agentic": False,
+            }
+        )
+        cache.put(
+            _component_cache_key(before),
+            {
+                "cached_component": after.model_dump(mode="json"),
+                "enriched_components": [],
+                "new_components": [],
+                "remove_components": [],
+                "reclassify_components": [],
+                "new_relationships": [],
+                "risk_findings": [],
+            },
+        )
 
-        enriched, new, rels, flags = cache.apply_cached([before], AIBOMScannerMiddleware())
+        enriched, new, rels, flags = cache.apply_cached(
+            [before], AIBOMScannerMiddleware()
+        )
 
         assert new == []
         assert rels == []
@@ -844,9 +938,7 @@ class TestAgenticResultCache:
 
         source = tmp_path / "service.py"
         source.write_text(
-            "setup()\n"
-            "agent = RouterAgent()\n"
-            "agent.run(task)\n",
+            "setup()\n" "agent = RouterAgent()\n" "agent.run(task)\n",
             encoding="utf-8",
         )
 
@@ -907,8 +999,8 @@ class TestRunTier:
     def test_tier_cache_hit_populates_memo(self, tmp_path):
         from aibom.agentic.agent import (
             _AgenticResultCache,
-            _DecisionMemo,
             _build_tier_cache_payload,
+            _DecisionMemo,
             _run_tier,
             _tier_cache_key,
         )
@@ -921,9 +1013,13 @@ class TestRunTier:
             line_number=1,
             model_name="gpt-4o",
         )
-        cached = comp.model_copy(update={"heuristic_confidence": 0.99, "needs_agentic": False})
+        cached = comp.model_copy(
+            update={"heuristic_confidence": 0.99, "needs_agentic": False}
+        )
         cache = _AgenticResultCache(tmp_path / "cache")
-        cache.put(_tier_cache_key([comp]), _build_tier_cache_payload([cached], [], [], []))
+        cache.put(
+            _tier_cache_key([comp]), _build_tier_cache_payload([cached], [], [], [])
+        )
 
         memo = _DecisionMemo()
         agent = MagicMock()
@@ -949,7 +1045,12 @@ class TestRunTier:
         assert memo.lookup(comp) == {"action": "keep", "heuristic_confidence": 0.99}
 
     def test_cache_only_fast_path_populates_memo(self, tmp_path):
-        from aibom.agentic.agent import _AgenticResultCache, _DecisionMemo, _component_cache_key, _run_tier
+        from aibom.agentic.agent import (
+            _AgenticResultCache,
+            _component_cache_key,
+            _DecisionMemo,
+            _run_tier,
+        )
         from aibom.agentic.middleware import AIBOMScannerMiddleware
 
         comp = AIComponent(
@@ -958,21 +1059,26 @@ class TestRunTier:
             file_path="cfg.yaml",
             line_number=7,
         )
-        cached = comp.model_copy(update={
-            "component_type": AIComponentType.MODEL_ENDPOINT,
-            "heuristic_confidence": 0.91,
-            "needs_agentic": False,
-        })
+        cached = comp.model_copy(
+            update={
+                "component_type": AIComponentType.MODEL_ENDPOINT,
+                "heuristic_confidence": 0.91,
+                "needs_agentic": False,
+            }
+        )
         cache = _AgenticResultCache(tmp_path / "cache")
-        cache.put(_component_cache_key(comp), {
-            "cached_component": cached.model_dump(mode="json"),
-            "enriched_components": [],
-            "new_components": [],
-            "remove_components": [],
-            "reclassify_components": [],
-            "new_relationships": [],
-            "risk_findings": [],
-        })
+        cache.put(
+            _component_cache_key(comp),
+            {
+                "cached_component": cached.model_dump(mode="json"),
+                "enriched_components": [],
+                "new_components": [],
+                "remove_components": [],
+                "reclassify_components": [],
+                "new_relationships": [],
+                "risk_findings": [],
+            },
+        )
 
         memo = _DecisionMemo()
         agent = MagicMock()
@@ -1010,10 +1116,31 @@ class TestDecisionMemo:
         from aibom.agentic.agent import _DecisionMemo
 
         memo = _DecisionMemo()
-        dep = AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="req.txt", line_number=1)
-        model = AIComponent(name="gpt-4o", component_type=AIComponentType.MODEL, file_path="a.py", line_number=1, model_name="gpt-4o")
-        emb = AIComponent(name="ada-002", component_type=AIComponentType.EMBEDDING, file_path="b.py", line_number=1)
-        artifact = AIComponent(name="model.onnx", component_type=AIComponentType.MODEL_ARTIFACT, file_path="c.py", line_number=1)
+        dep = AIComponent(
+            name="torch",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="req.txt",
+            line_number=1,
+        )
+        model = AIComponent(
+            name="gpt-4o",
+            component_type=AIComponentType.MODEL,
+            file_path="a.py",
+            line_number=1,
+            model_name="gpt-4o",
+        )
+        emb = AIComponent(
+            name="ada-002",
+            component_type=AIComponentType.EMBEDDING,
+            file_path="b.py",
+            line_number=1,
+        )
+        artifact = AIComponent(
+            name="model.onnx",
+            component_type=AIComponentType.MODEL_ARTIFACT,
+            file_path="c.py",
+            line_number=1,
+        )
 
         assert memo._key(dep) is not None
         assert memo._key(model) is not None
@@ -1024,9 +1151,24 @@ class TestDecisionMemo:
         from aibom.agentic.agent import _DecisionMemo
 
         memo = _DecisionMemo()
-        endpoint = AIComponent(name="env:ENDPOINT", component_type=AIComponentType.LLM_ENDPOINT, file_path="v.yaml", line_number=5)
-        prompt = AIComponent(name="my-prompt", component_type=AIComponentType.PROMPT, file_path="p.py", line_number=1)
-        secret = AIComponent(name="api-key", component_type=AIComponentType.SECRET, file_path="s.py", line_number=1)
+        endpoint = AIComponent(
+            name="env:ENDPOINT",
+            component_type=AIComponentType.LLM_ENDPOINT,
+            file_path="v.yaml",
+            line_number=5,
+        )
+        prompt = AIComponent(
+            name="my-prompt",
+            component_type=AIComponentType.PROMPT,
+            file_path="p.py",
+            line_number=1,
+        )
+        secret = AIComponent(
+            name="api-key",
+            component_type=AIComponentType.SECRET,
+            file_path="s.py",
+            line_number=1,
+        )
 
         assert memo._key(endpoint) is None
         assert memo._key(prompt) is None
@@ -1036,8 +1178,15 @@ class TestDecisionMemo:
         from aibom.agentic.agent import _DecisionMemo
 
         memo = _DecisionMemo()
-        before = AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="req.txt", line_number=1)
-        after = before.model_copy(update={"heuristic_confidence": 0.95, "needs_agentic": False})
+        before = AIComponent(
+            name="torch",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="req.txt",
+            line_number=1,
+        )
+        after = before.model_copy(
+            update={"heuristic_confidence": 0.95, "needs_agentic": False}
+        )
 
         memo.record(before, after)
         verdict = memo.lookup(before)
@@ -1049,7 +1198,12 @@ class TestDecisionMemo:
         from aibom.agentic.agent import _DecisionMemo
 
         memo = _DecisionMemo()
-        before = AIComponent(name="requests", component_type=AIComponentType.DEPENDENCY, file_path="req.txt", line_number=5)
+        before = AIComponent(
+            name="requests",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="req.txt",
+            line_number=5,
+        )
 
         memo.record(before, None)
         verdict = memo.lookup(before)
@@ -1060,8 +1214,18 @@ class TestDecisionMemo:
         from aibom.agentic.agent import _DecisionMemo
 
         memo = _DecisionMemo()
-        before = AIComponent(name="ada-ep", component_type=AIComponentType.EMBEDDING, file_path="cfg.yaml", line_number=3)
-        after = before.model_copy(update={"component_type": AIComponentType.MODEL_ENDPOINT, "heuristic_confidence": 0.9})
+        before = AIComponent(
+            name="ada-ep",
+            component_type=AIComponentType.EMBEDDING,
+            file_path="cfg.yaml",
+            line_number=3,
+        )
+        after = before.model_copy(
+            update={
+                "component_type": AIComponentType.MODEL_ENDPOINT,
+                "heuristic_confidence": 0.9,
+            }
+        )
 
         memo.record(before, after)
         verdict = memo.lookup(before)
@@ -1074,11 +1238,29 @@ class TestDecisionMemo:
         from aibom.agentic.agent import _DecisionMemo
 
         memo = _DecisionMemo()
-        c1 = AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="a.txt", line_number=1)
-        memo.record(c1, c1.model_copy(update={"heuristic_confidence": 0.9, "needs_agentic": False}))
+        c1 = AIComponent(
+            name="torch",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="a.txt",
+            line_number=1,
+        )
+        memo.record(
+            c1,
+            c1.model_copy(update={"heuristic_confidence": 0.9, "needs_agentic": False}),
+        )
 
-        c1_dup = AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="c.txt", line_number=3)
-        c2 = AIComponent(name="flask", component_type=AIComponentType.DEPENDENCY, file_path="b.txt", line_number=2)
+        c1_dup = AIComponent(
+            name="torch",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="c.txt",
+            line_number=3,
+        )
+        c2 = AIComponent(
+            name="flask",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="b.txt",
+            line_number=2,
+        )
         hits, misses = memo.partition([c1_dup, c2])
         assert len(hits) == 1
         assert hits[0].name == "torch"
@@ -1089,7 +1271,12 @@ class TestDecisionMemo:
         from aibom.agentic.agent import _DecisionMemo
 
         memo = _DecisionMemo()
-        c = AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="r.txt", line_number=1)
+        c = AIComponent(
+            name="torch",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="r.txt",
+            line_number=1,
+        )
         memo.record(c, c.model_copy(update={"heuristic_confidence": 0.95}))
 
         result = memo.apply([c])
@@ -1101,7 +1288,12 @@ class TestDecisionMemo:
         from aibom.agentic.agent import _DecisionMemo
 
         memo = _DecisionMemo()
-        c = AIComponent(name="requests", component_type=AIComponentType.DEPENDENCY, file_path="r.txt", line_number=1)
+        c = AIComponent(
+            name="requests",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="r.txt",
+            line_number=1,
+        )
         memo.record(c, None)
 
         result = memo.apply([c])
@@ -1111,11 +1303,26 @@ class TestDecisionMemo:
         from aibom.agentic.agent import _DecisionMemo
 
         memo = _DecisionMemo()
-        before = AIComponent(name="ada-ep", component_type=AIComponentType.EMBEDDING, file_path="x.yaml", line_number=1)
-        after = before.model_copy(update={"component_type": AIComponentType.MODEL_ENDPOINT, "heuristic_confidence": 0.85})
+        before = AIComponent(
+            name="ada-ep",
+            component_type=AIComponentType.EMBEDDING,
+            file_path="x.yaml",
+            line_number=1,
+        )
+        after = before.model_copy(
+            update={
+                "component_type": AIComponentType.MODEL_ENDPOINT,
+                "heuristic_confidence": 0.85,
+            }
+        )
         memo.record(before, after)
 
-        dup = AIComponent(name="ada-ep", component_type=AIComponentType.EMBEDDING, file_path="y.yaml", line_number=5)
+        dup = AIComponent(
+            name="ada-ep",
+            component_type=AIComponentType.EMBEDDING,
+            file_path="y.yaml",
+            line_number=5,
+        )
         result = memo.apply([dup])
         assert len(result) == 1
         assert result[0].component_type == AIComponentType.MODEL_ENDPOINT
@@ -1126,8 +1333,15 @@ class TestDecisionMemo:
         from aibom.agentic.agent import _DecisionMemo
 
         memo = _DecisionMemo()
-        ep = AIComponent(name="env:WEAVIATE_EP", component_type=AIComponentType.LLM_ENDPOINT, file_path="v.yaml", line_number=1)
-        memo.record(ep, ep.model_copy(update={"component_type": AIComponentType.VECTOR_STORE}))
+        ep = AIComponent(
+            name="env:WEAVIATE_EP",
+            component_type=AIComponentType.LLM_ENDPOINT,
+            file_path="v.yaml",
+            line_number=1,
+        )
+        memo.record(
+            ep, ep.model_copy(update={"component_type": AIComponentType.VECTOR_STORE})
+        )
 
         assert memo.lookup(ep) is None
         assert len(memo) == 0
@@ -1137,7 +1351,12 @@ class TestDecisionMemo:
 
         memo = _DecisionMemo()
         assert len(memo) == 0
-        c = AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="r.txt", line_number=1)
+        c = AIComponent(
+            name="torch",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="r.txt",
+            line_number=1,
+        )
         memo.record(c, c.model_copy(update={"heuristic_confidence": 0.9}))
         assert len(memo) == 1
 
@@ -1149,9 +1368,24 @@ class TestSubAgentGrouping:
         from aibom.agentic.agent import _group_by_top_dir
 
         comps = [
-            AIComponent(name="a", component_type=AIComponentType.MODEL, file_path="/repo1/src/a.py", line_number=1),
-            AIComponent(name="b", component_type=AIComponentType.MODEL, file_path="/repo1/src/b.py", line_number=2),
-            AIComponent(name="c", component_type=AIComponentType.MODEL, file_path="/repo2/lib/c.py", line_number=1),
+            AIComponent(
+                name="a",
+                component_type=AIComponentType.MODEL,
+                file_path="/repo1/src/a.py",
+                line_number=1,
+            ),
+            AIComponent(
+                name="b",
+                component_type=AIComponentType.MODEL,
+                file_path="/repo1/src/b.py",
+                line_number=2,
+            ),
+            AIComponent(
+                name="c",
+                component_type=AIComponentType.MODEL,
+                file_path="/repo2/lib/c.py",
+                line_number=1,
+            ),
         ]
         groups = _group_by_top_dir(comps, scan_paths=["/repo1", "/repo2"])
         assert len(groups) == 2
@@ -1160,7 +1394,12 @@ class TestSubAgentGrouping:
         from aibom.agentic.agent import _group_by_top_dir
 
         comps = [
-            AIComponent(name=f"m{i}", component_type=AIComponentType.MODEL, file_path=f"/repo/d{i}/f.py", line_number=i)
+            AIComponent(
+                name=f"m{i}",
+                component_type=AIComponentType.MODEL,
+                file_path=f"/repo/d{i}/f.py",
+                line_number=i,
+            )
             for i in range(5)
         ]
         groups = _group_by_top_dir(comps, scan_paths=["/repo"])
@@ -1272,7 +1511,11 @@ class TestAgentEvidenceOnClassifications:
         )
         resp = AgentResponse(
             reclassify_components=[
-                {"instance_id": "a", "new_type": "agent", "agent_evidence": ev.model_dump()},
+                {
+                    "instance_id": "a",
+                    "new_type": "agent",
+                    "agent_evidence": ev.model_dump(),
+                },
             ],
         )
         assert resp.reclassify_components[0].agent_evidence == ev
@@ -1298,5 +1541,75 @@ class TestA2ARelationshipTypes:
     def test_a2a_types_round_trip_via_string(self):
         from aibom.models import RelationshipType
 
-        assert RelationshipType("INVOKES_A2A_AGENT") is RelationshipType.INVOKES_A2A_AGENT
-        assert RelationshipType("EXPOSES_A2A_AGENT") is RelationshipType.EXPOSES_A2A_AGENT
+        assert (
+            RelationshipType("INVOKES_A2A_AGENT") is RelationshipType.INVOKES_A2A_AGENT
+        )
+        assert (
+            RelationshipType("EXPOSES_A2A_AGENT") is RelationshipType.EXPOSES_A2A_AGENT
+        )
+
+
+class TestAgenticResultCacheAtomicWrite:
+    """``_AgenticResultCache`` must write cache entries atomically so an
+    interrupted run never leaves a half-written ``.json`` that a later resume
+    reads as a partial/corrupt entry."""
+
+    def test_successful_put_writes_complete_json_only(self, tmp_path: Path):
+        from aibom.agentic.agent import _AgenticResultCache
+
+        cache = _AgenticResultCache(cache_dir=tmp_path)
+        cache.put("k1", {"a": 1, "b": [1, 2, 3]})
+
+        # The committed entry is complete and parseable JSON.
+        files = list(tmp_path.glob("*.json"))
+        assert [f.name for f in files] == ["k1.json"]
+        assert json.loads(files[0].read_text(encoding="utf-8")) == {
+            "a": 1,
+            "b": [1, 2, 3],
+        }
+        # No temp/partial artifacts left behind.
+        assert list(tmp_path.glob("*.tmp")) == []
+        assert list(tmp_path.glob("*.json.*")) == []
+
+    def test_write_is_atomic_via_temp_then_rename(self, tmp_path: Path, monkeypatch):
+        """``put`` must stage to a temp file and atomically rename into place,
+        so a crash during the commit never leaves a partial ``key.json``. We
+        intercept ``os.replace`` (the atomic commit) to fail; the target file
+        must not exist afterwards (only a leftover temp at worst)."""
+        import os as _os
+
+        from aibom.agentic.agent import _AgenticResultCache
+
+        cache = _AgenticResultCache(cache_dir=tmp_path)
+
+        calls: dict[str, int] = {"replace": 0}
+
+        def failing_replace(src, dst):
+            calls["replace"] += 1
+            raise OSError("simulated crash during atomic commit")
+
+        monkeypatch.setattr(_os, "replace", failing_replace)
+
+        # put() swallows OSError today; the contract we assert is that the
+        # atomic commit was attempted and no corrupt target file remains.
+        cache.put("k1", {"a": 1})
+
+        assert (
+            calls["replace"] == 1
+        ), "put() must commit via os.replace (atomic temp-file rename)"
+        assert not (
+            tmp_path / "k1.json"
+        ).exists(), "a failed commit must not leave a partial/corrupt k1.json"
+
+    def test_resume_skips_truncated_cache_entry(self, tmp_path: Path):
+        from aibom.agentic.agent import _AgenticResultCache
+
+        # Simulate a killed run that left a truncated (invalid) JSON file.
+        (tmp_path / "good.json").write_text('{"ok": true}', encoding="utf-8")
+        (tmp_path / "partial.json").write_text('{"ok": tr', encoding="utf-8")
+
+        cache = _AgenticResultCache(cache_dir=tmp_path)
+
+        # Good entry loads; truncated entry is skipped (cache miss), not fatal.
+        assert cache.get("good") == {"ok": True}
+        assert cache.get("partial") is None

--- a/aibom/tests/test_agentic_timeout.py
+++ b/aibom/tests/test_agentic_timeout.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import threading
 import time
 from unittest.mock import MagicMock, patch
 
@@ -25,7 +26,9 @@ class TestAgenticTimeout:
     @patch("aibom.agentic.agent._close_model_clients")
     @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
     @patch("aibom.agentic.agent.create_aibom_agent")
-    def test_timeout_marks_components_not_agentic(self, mock_create: MagicMock, _mb: MagicMock, _mc: MagicMock) -> None:
+    def test_timeout_marks_components_not_agentic(
+        self, mock_create: MagicMock, _mb: MagicMock, _mc: MagicMock
+    ) -> None:
         from aibom.agentic.agent import run_agentic_enrichment
 
         mock_agent = MagicMock()
@@ -54,13 +57,147 @@ class TestAgenticTimeout:
         assert comps[0].needs_agentic is False
         assert comps[0].agentic_hint == "batch_timeout"
 
+    @patch("aibom.agentic.agent._RETRY_COOLDOWN_S", 0)
+    @patch("aibom.agentic.agent._close_model_clients")
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_never_returning_invoke_does_not_hang(
+        self, mock_create: MagicMock, _mb: MagicMock, _mc: MagicMock
+    ) -> None:
+        """A truly hung LLM call (invoke that never returns) must NOT wedge the
+        scan: the batch must time out and fail open within a bounded wall-clock,
+        even though the worker thread cannot be cancelled.
+
+        Regression for the executor-shutdown hang: the previous implementation
+        wrapped the blocking call in ``asyncio.run(asyncio.wait_for(
+        asyncio.to_thread(...)))``; ``wait_for`` raised TimeoutError but
+        ``asyncio.run`` then blocked forever joining the orphaned executor
+        thread on loop shutdown.
+        """
+        never = threading.Event()  # never set -> invoke blocks forever
+
+        def hung_invoke(*_a: object, **_k: object) -> dict[str, object]:
+            never.wait()  # blocks until process exit
+            return {"messages": []}
+
+        mock_agent = MagicMock()
+        mock_agent.invoke.side_effect = hung_invoke
+        mock_create.return_value = mock_agent
+
+        comp = AIComponent(
+            name="x",
+            component_type=AIComponentType.AGENT,
+            file_path="b.py",
+            line_number=1,
+        )
+
+        from aibom.agentic.agent import run_agentic_enrichment
+
+        start = time.monotonic()
+        comps, _, _, _ = run_agentic_enrichment(
+            model_string="m",
+            deterministic_components=[comp],
+            deterministic_relationships=[],
+            scan_paths=["/tmp"],
+            timeout_s=1,
+        )
+        elapsed = time.monotonic() - start
+
+        # Must return shortly after the 1s timeout, not hang on the stuck thread.
+        assert (
+            elapsed < 20
+        ), f"batch hung for {elapsed:.1f}s on a never-returning invoke"
+        assert len(comps) == 1
+        assert comps[0].needs_agentic is False
+        assert comps[0].agentic_hint == "batch_timeout"
+
+
+class TestAgenticAsyncTimeout:
+    @patch("aibom.agentic.agent._RETRY_COOLDOWN_S", 0)
+    @patch("aibom.agentic.agent._close_model_clients")
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_parallel_path_stalled_ainvoke_does_not_hang(
+        self, mock_create: MagicMock, _mb: MagicMock, _mc: MagicMock
+    ) -> None:
+        """The async/parallel batch path (max_concurrent>1, >1 batch) must bound
+        a stalled provider call and let the scan complete + the process exit.
+
+        Models a real native-async provider call that never returns (e.g. a
+        wedged streaming response): ``ainvoke`` awaits a never-set event.
+        ``asyncio.timeout`` cancels it at the coroutine level; the batch fails
+        open as ``batch_timeout``. The old ``asyncio.run`` orchestration could
+        wedge on ``loop.shutdown_default_executor()``; ``_run_async_bounded``
+        runs the loop in a daemon thread and abandons its executor, so the scan
+        returns within the timeout and the process exits cleanly.
+
+        Note: a provider that offloads a *blocking* sync call to the loop's
+        default executor (``run_in_executor``) cannot be hard-cancelled — that
+        is a Python limitation (you cannot kill a thread stuck in a syscall),
+        independent of this fix. The fix still lets the scan complete; only the
+        orphaned worker lingers until process exit.
+        """
+        import asyncio
+
+        sync_never = threading.Event()  # for the sequential retry (sync) pass
+
+        async def stalled_ainvoke(*_a: object, **_k: object) -> dict[str, object]:
+            # Native-async stall: awaitable + cancellable, like a wedged
+            # httpx.AsyncClient streaming read.
+            await asyncio.Event().wait()
+            return {"messages": []}
+
+        def hung_invoke(*_a: object, **_k: object) -> dict[str, object]:
+            # The sequential retry pass uses the sync path; keep it hung too so
+            # both passes fail open via timeout rather than on a junk mock.
+            sync_never.wait()
+            return {"messages": []}
+
+        mock_agent = MagicMock()
+        mock_agent.ainvoke = stalled_ainvoke
+        mock_agent.invoke.side_effect = hung_invoke
+        mock_create.return_value = mock_agent
+
+        comps = [
+            AIComponent(
+                name=f"c{i}",
+                component_type=AIComponentType.AGENT,
+                file_path=f"f{i}.py",
+                line_number=i,
+            )
+            for i in range(2)
+        ]
+
+        from aibom.agentic.agent import run_agentic_enrichment
+
+        start = time.monotonic()
+        out, _, _, _ = run_agentic_enrichment(
+            model_string="m",
+            deterministic_components=comps,
+            deterministic_relationships=[],
+            scan_paths=["/tmp"],
+            batch_size=1,  # 2 batches -> parallel/async path
+            max_concurrent=2,
+            timeout_s=1,
+        )
+        elapsed = time.monotonic() - start
+
+        assert (
+            elapsed < 25
+        ), f"parallel path hung for {elapsed:.1f}s on a never-returning ainvoke"
+        assert len(out) == 2
+        assert all(c.needs_agentic is False for c in out)
+        assert all(c.agentic_hint == "batch_timeout" for c in out)
+
 
 class TestAgenticCircuitBreaker:
     @patch("aibom.agentic.agent._RETRY_COOLDOWN_S", 0)
     @patch("aibom.agentic.agent._close_model_clients")
     @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
     @patch("aibom.agentic.agent.create_aibom_agent")
-    def test_skips_after_three_consecutive_failures(self, mock_create: MagicMock, _mb: MagicMock, _mc: MagicMock) -> None:
+    def test_skips_after_three_consecutive_failures(
+        self, mock_create: MagicMock, _mb: MagicMock, _mc: MagicMock
+    ) -> None:
         from aibom.agentic.agent import run_agentic_enrichment
 
         mock_agent = MagicMock()
@@ -95,15 +232,19 @@ class TestAgenticCircuitBreaker:
     @patch("aibom.agentic.agent._close_model_clients")
     @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
     @patch("aibom.agentic.agent.create_aibom_agent")
-    def test_non_consecutive_failures_do_not_trip(self, mock_create: MagicMock, _mb: MagicMock, _mc: MagicMock) -> None:
+    def test_non_consecutive_failures_do_not_trip(
+        self, mock_create: MagicMock, _mb: MagicMock, _mc: MagicMock
+    ) -> None:
         from aibom.agentic.agent import run_agentic_enrichment
 
-        ok = json.dumps({
-            "enriched_components": [],
-            "new_components": [],
-            "new_relationships": [],
-            "risk_findings": [],
-        })
+        ok = json.dumps(
+            {
+                "enriched_components": [],
+                "new_components": [],
+                "new_relationships": [],
+                "risk_findings": [],
+            }
+        )
         mock_msg = MagicMock()
         mock_msg.content = ok
 

--- a/aibom/tests/test_agentic_timeout.py
+++ b/aibom/tests/test_agentic_timeout.py
@@ -190,6 +190,192 @@ class TestAgenticAsyncTimeout:
         assert all(c.agentic_hint == "batch_timeout" for c in out)
 
 
+class TestInvokeAgentBounded:
+    """Unit tests for the shared daemon-thread deadline helper used by every
+    synchronous ``agent.invoke`` site."""
+
+    def test_returns_result_on_success(self) -> None:
+        from aibom.agentic.agent import _invoke_agent_bounded
+
+        agent = MagicMock()
+        agent.invoke.return_value = {"messages": ["ok"]}
+        result = _invoke_agent_bounded(agent, "hello", timeout_s=5)
+        assert result == {"messages": ["ok"]}
+
+    def test_propagates_worker_exception(self) -> None:
+        from aibom.agentic.agent import _invoke_agent_bounded
+
+        agent = MagicMock()
+        agent.invoke.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError, match="boom"):
+            _invoke_agent_bounded(agent, "hello", timeout_s=5)
+
+    def test_times_out_on_never_returning_invoke(self) -> None:
+        from aibom.agentic.agent import _invoke_agent_bounded, _InvokeTimeout
+
+        never = threading.Event()  # never set -> invoke blocks forever
+
+        def hung_invoke(*_a: object, **_k: object) -> object:
+            never.wait()
+            return {"messages": []}
+
+        agent = MagicMock()
+        agent.invoke.side_effect = hung_invoke
+
+        start = time.monotonic()
+        with pytest.raises(_InvokeTimeout):
+            _invoke_agent_bounded(agent, "hello", timeout_s=1)
+        elapsed = time.monotonic() - start
+        # Must abandon the hung daemon thread promptly, not block on it.
+        assert elapsed < 10, f"helper hung for {elapsed:.1f}s"
+
+    def test_omits_config_when_recursion_limit_none(self) -> None:
+        from aibom.agentic.agent import _invoke_agent_bounded
+
+        agent = MagicMock()
+        agent.invoke.return_value = {"messages": []}
+        _invoke_agent_bounded(agent, "hi", timeout_s=5)
+        _, kwargs = agent.invoke.call_args
+        assert "config" not in kwargs
+
+    def test_passes_recursion_limit_when_set(self) -> None:
+        from aibom.agentic.agent import _invoke_agent_bounded
+
+        agent = MagicMock()
+        agent.invoke.return_value = {"messages": []}
+        _invoke_agent_bounded(agent, "hi", timeout_s=5, recursion_limit=25)
+        _, kwargs = agent.invoke.call_args
+        assert kwargs["config"] == {"recursion_limit": 25}
+
+    def test_message_shape(self) -> None:
+        from aibom.agentic.agent import _invoke_agent_bounded
+
+        agent = MagicMock()
+        agent.invoke.return_value = {"messages": []}
+        _invoke_agent_bounded(agent, "the-prompt", timeout_s=5)
+        args, _ = agent.invoke.call_args
+        assert args[0] == {"messages": [{"role": "user", "content": "the-prompt"}]}
+
+
+class TestCrossRepoCoordinationTimeout:
+    """run_cross_repo_coordination must bound a hung coordinator call and fail
+    open (return no relationships/flags) without wedging the scan."""
+
+    @patch("aibom.agentic.agent._DEFAULT_AGENTIC_TIMEOUT_S", 1)
+    @patch("aibom.agentic.agent._close_model_clients")
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_hung_coordinator_fails_open(self, mock_create, _mb, _mc, tmp_path) -> None:
+        from types import SimpleNamespace
+
+        from aibom.agentic.agent import run_cross_repo_coordination
+
+        never = threading.Event()
+
+        def hung_invoke(*_a: object, **_k: object) -> object:
+            never.wait()
+            return {"messages": []}
+
+        mock_agent = MagicMock()
+        mock_agent.invoke.side_effect = hung_invoke
+        mock_create.return_value = mock_agent
+
+        per_repo_results = {
+            "/repo-a": {
+                "components": [
+                    AIComponent(
+                        name="repo-a-model",
+                        component_type=AIComponentType.MODEL,
+                        file_path="/repo-a/app.py",
+                        line_number=10,
+                        model_name="gpt-4o-mini",
+                    )
+                ],
+                "_unresolved_env_vars": [],
+            },
+            "/repo-b": {
+                "components": [
+                    AIComponent(
+                        name="repo-b-endpoint",
+                        component_type=AIComponentType.LLM_ENDPOINT,
+                        file_path="/repo-b/values.yaml",
+                        line_number=20,
+                    )
+                ],
+                "_unresolved_env_vars": [],
+            },
+        }
+
+        with (
+            patch(
+                "aibom.agentic.cross_repo.cross_repo_summary_tool",
+                return_value=json.dumps(
+                    {
+                        "shared_env_vars": [],
+                        "shared_packages": [],
+                        "unresolved_env_var_refs": [],
+                    }
+                ),
+            ),
+            patch(
+                "aibom.agentic.cross_repo.build_cross_repo_tools",
+                return_value=[MagicMock()],
+            ),
+            patch(
+                "aibom.cross_ref.build_env_index",
+                return_value=SimpleNamespace(env={}),
+            ),
+        ):
+            start = time.monotonic()
+            rels, flags = run_cross_repo_coordination(
+                model_string="test-model",
+                per_repo_results=per_repo_results,
+                cache_dir=tmp_path / "agentic-cache",
+            )
+            elapsed = time.monotonic() - start
+
+        assert elapsed < 15, f"coordination hung for {elapsed:.1f}s"
+        assert rels == []
+        assert flags == []
+
+
+class TestContainerLayoutTimeout:
+    """resolve_container_layout must bound a hung layout call and fall back to
+    the deterministic candidate directories."""
+
+    @patch("aibom.agentic.agent._close_model_clients")
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_hung_layout_agent_falls_back_to_candidates(
+        self, mock_create, _mb, _mc
+    ) -> None:
+        from aibom.agentic.agent import resolve_container_layout
+
+        never = threading.Event()
+
+        def hung_invoke(*_a: object, **_k: object) -> object:
+            never.wait()
+            return {"messages": []}
+
+        mock_agent = MagicMock()
+        mock_agent.invoke.side_effect = hung_invoke
+        mock_create.return_value = mock_agent
+
+        candidates = ["/app", "/srv/app"]
+        start = time.monotonic()
+        result = resolve_container_layout(
+            model_string="test-model",
+            image_config={"workdir": "/app", "entrypoint": [], "cmd": [], "env": {}},
+            candidate_dirs=candidates,
+            file_listing=["/app/main.py"],
+            timeout_s=1,
+        )
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 15, f"layout agent hung for {elapsed:.1f}s"
+        assert result == candidates
+
+
 class TestAgenticCircuitBreaker:
     @patch("aibom.agentic.agent._RETRY_COOLDOWN_S", 0)
     @patch("aibom.agentic.agent._close_model_clients")

--- a/aibom/tests/test_agentic_timeout.py
+++ b/aibom/tests/test_agentic_timeout.py
@@ -345,10 +345,7 @@ class TestContainerLayoutTimeout:
 
     @patch("aibom.agentic.agent._close_model_clients")
     @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
-    @patch("aibom.agentic.agent.create_aibom_agent")
-    def test_hung_layout_agent_falls_back_to_candidates(
-        self, mock_create, _mb, _mc
-    ) -> None:
+    def test_hung_layout_agent_falls_back_to_candidates(self, _mb, _mc) -> None:
         from aibom.agentic.agent import resolve_container_layout
 
         never = threading.Event()
@@ -359,18 +356,29 @@ class TestContainerLayoutTimeout:
 
         mock_agent = MagicMock()
         mock_agent.invoke.side_effect = hung_invoke
-        mock_create.return_value = mock_agent
+
+        # resolve_container_layout calls ``from deepagents import
+        # create_deep_agent`` directly (not via create_aibom_agent), so inject a
+        # fake module — the agentic extra is not installed in CI's base env.
+        fake_deepagents = MagicMock()
+        fake_deepagents.create_deep_agent.return_value = mock_agent
 
         candidates = ["/app", "/srv/app"]
-        start = time.monotonic()
-        result = resolve_container_layout(
-            model_string="test-model",
-            image_config={"workdir": "/app", "entrypoint": [], "cmd": [], "env": {}},
-            candidate_dirs=candidates,
-            file_listing=["/app/main.py"],
-            timeout_s=1,
-        )
-        elapsed = time.monotonic() - start
+        with patch.dict("sys.modules", {"deepagents": fake_deepagents}):
+            start = time.monotonic()
+            result = resolve_container_layout(
+                model_string="test-model",
+                image_config={
+                    "workdir": "/app",
+                    "entrypoint": [],
+                    "cmd": [],
+                    "env": {},
+                },
+                candidate_dirs=candidates,
+                file_listing=["/app/main.py"],
+                timeout_s=1,
+            )
+            elapsed = time.monotonic() - start
 
         assert elapsed < 15, f"layout agent hung for {elapsed:.1f}s"
         assert result == candidates

--- a/aibom/tests/test_categorizer.py
+++ b/aibom/tests/test_categorizer.py
@@ -15,21 +15,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from unittest.mock import MagicMock, patch
 from collections import namedtuple
+from unittest.mock import MagicMock, patch
 
 from aibom.categorizer import (
-    categorize_symbols,
     _is_symbol_match,
     _reconstruct_code_snippet,
+    categorize_symbols,
 )
 from aibom.structures import (
-    CodeAnalysisResult,
     AssignmentObservation,
     CallObservation,
+    CodeAnalysisResult,
     DecoratorObservation,
 )
-from aibom.workflow_analyzer import WorkflowIndex, FunctionNode
+from aibom.workflow_analyzer import FunctionNode, WorkflowIndex
 
 
 class TestCategorizer(unittest.TestCase):
@@ -106,13 +106,20 @@ class TestCategorizer(unittest.TestCase):
         ]
 
         self.mock_connector.find_components_by_suffixes.return_value = [
-            {"id": "langchain.chat_models.init_chat_model", "concept": "model", "label": "init_chat_model"}
+            {
+                "id": "langchain.chat_models.init_chat_model",
+                "concept": "model",
+                "label": "init_chat_model",
+            }
         ]
 
         result = categorize_symbols(analysis_results, self.mock_connector)
         self.assertIn("model", result.components)
         self.assertEqual(len(result.components["model"]), 1)
-        self.assertEqual(result.components["model"][0]["name"], "langchain.chat_models.init_chat_model")
+        self.assertEqual(
+            result.components["model"][0]["name"],
+            "langchain.chat_models.init_chat_model",
+        )
 
     def test_memory_relationship_detected(self):
         """Improvement 3: USES_MEMORY relationship derived from agent args."""
@@ -145,8 +152,16 @@ class TestCategorizer(unittest.TestCase):
         ]
 
         self.mock_connector.find_components_by_suffixes.return_value = [
-            {"id": "langgraph.checkpoint.memory.MemorySaver", "concept": "memory", "label": "MemorySaver"},
-            {"id": "langgraph.prebuilt.create_react_agent", "concept": "agent", "label": "create_react_agent"},
+            {
+                "id": "langgraph.checkpoint.memory.MemorySaver",
+                "concept": "memory",
+                "label": "MemorySaver",
+            },
+            {
+                "id": "langgraph.prebuilt.create_react_agent",
+                "concept": "agent",
+                "label": "create_react_agent",
+            },
         ]
 
         result = categorize_symbols(analysis_results, self.mock_connector)
@@ -183,8 +198,16 @@ class TestCategorizer(unittest.TestCase):
         ]
 
         self.mock_connector.find_components_by_suffixes.return_value = [
-            {"id": "langchain_core.retrievers.BaseRetriever", "concept": "retriever", "label": "BaseRetriever"},
-            {"id": "langgraph.prebuilt.create_react_agent", "concept": "agent", "label": "create_react_agent"},
+            {
+                "id": "langchain_core.retrievers.BaseRetriever",
+                "concept": "retriever",
+                "label": "BaseRetriever",
+            },
+            {
+                "id": "langgraph.prebuilt.create_react_agent",
+                "concept": "agent",
+                "label": "create_react_agent",
+            },
         ]
 
         result = categorize_symbols(analysis_results, self.mock_connector)
@@ -221,18 +244,116 @@ class TestCategorizer(unittest.TestCase):
         ]
 
         self.mock_connector.find_components_by_suffixes.return_value = [
-            {"id": "langchain_openai.OpenAIEmbeddings", "concept": "embedding", "label": "OpenAIEmbeddings"},
-            {"id": "langgraph.prebuilt.create_react_agent", "concept": "agent", "label": "create_react_agent"},
+            {
+                "id": "langchain_openai.OpenAIEmbeddings",
+                "concept": "embedding",
+                "label": "OpenAIEmbeddings",
+            },
+            {
+                "id": "langgraph.prebuilt.create_react_agent",
+                "concept": "agent",
+                "label": "create_react_agent",
+            },
         ]
 
         result = categorize_symbols(analysis_results, self.mock_connector)
         self.assertTrue(any(r.label == "USES_EMBEDDING" for r in result.relationships))
 
+    def test_agent_to_agent_relationship_detected(self):
+        """USES_AGENT: a supervisor agent delegating to a sub-agent."""
+        analysis_results = [
+            CodeAnalysisResult(
+                file_path="/test/crew.py",
+                assignments=[
+                    AssignmentObservation(
+                        target_qualified_name="worker",
+                        call=CallObservation(
+                            qualified_name="crewai.Agent",
+                            arguments={},
+                            line_number=5,
+                        ),
+                        line_number=5,
+                    ),
+                    AssignmentObservation(
+                        target_qualified_name="supervisor",
+                        call=CallObservation(
+                            qualified_name="crewai.Agent",
+                            arguments={"sub_agents": "VARIABLE:worker"},
+                            line_number=10,
+                        ),
+                        line_number=10,
+                    ),
+                ],
+                decorators=[],
+                imports=[],
+            )
+        ]
+
+        self.mock_connector.find_components_by_suffixes.return_value = [
+            {"id": "crewai.Agent", "concept": "agent", "label": "Agent"},
+        ]
+
+        result = categorize_symbols(analysis_results, self.mock_connector)
+        agent_edges = [r for r in result.relationships if r.label == "USES_AGENT"]
+        self.assertTrue(agent_edges, "expected a USES_AGENT edge")
+        # No self-edge: source and target must differ.
+        for r in agent_edges:
+            self.assertNotEqual(r.source_instance_id, r.target_instance_id)
+
+    def test_agent_to_skill_relationship_detected(self):
+        """USES_SKILL: an agent using a skill plugin."""
+        analysis_results = [
+            CodeAnalysisResult(
+                file_path="/test/sk.py",
+                assignments=[
+                    AssignmentObservation(
+                        target_qualified_name="my_skill",
+                        call=CallObservation(
+                            qualified_name="semantic_kernel.MathSkill",
+                            arguments={},
+                            line_number=5,
+                        ),
+                        line_number=5,
+                    ),
+                    AssignmentObservation(
+                        target_qualified_name="agent",
+                        call=CallObservation(
+                            qualified_name="crewai.Agent",
+                            arguments={"skills": "VARIABLE:my_skill"},
+                            line_number=10,
+                        ),
+                        line_number=10,
+                    ),
+                ],
+                decorators=[],
+                imports=[],
+            )
+        ]
+
+        self.mock_connector.find_components_by_suffixes.return_value = [
+            {
+                "id": "semantic_kernel.MathSkill",
+                "concept": "skill",
+                "label": "MathSkill",
+            },
+            {"id": "crewai.Agent", "concept": "agent", "label": "Agent"},
+        ]
+
+        result = categorize_symbols(analysis_results, self.mock_connector)
+        self.assertTrue(
+            any(r.label == "USES_SKILL" for r in result.relationships),
+            "expected a USES_SKILL edge",
+        )
+
+    def test_uses_agent_and_uses_skill_enum_members_exist(self):
+        from aibom.models.enums import RelationshipType
+
+        assert RelationshipType("USES_AGENT") is RelationshipType.USES_AGENT
+        assert RelationshipType("USES_SKILL") is RelationshipType.USES_SKILL
+
     def test_is_symbol_match(self):
         self.assertTrue(_is_symbol_match("a.b.c", "a.b.c", []))
-        self.assertFalse(
-            _is_symbol_match("a.b.c", "x.y.a.b.c", ["import a.b"])
-        )
+        self.assertFalse(_is_symbol_match("a.b.c", "x.y.a.b.c", ["import a.b"]))
         self.assertFalse(_is_symbol_match("a.b.c", "d.e.f", []))
 
     def test_reconstruct_code_snippet(self):
@@ -296,7 +417,11 @@ class TestCategorizer(unittest.TestCase):
         ]
 
         self.mock_connector.find_components_by_suffixes.return_value = [
-            {"id": "langchain.PromptTemplate", "concept": "prompt", "label": "PromptTemplate"}
+            {
+                "id": "langchain.PromptTemplate",
+                "concept": "prompt",
+                "label": "PromptTemplate",
+            }
         ]
 
         result = categorize_symbols(analysis_results, self.mock_connector)
@@ -359,9 +484,13 @@ class TestCategorizer(unittest.TestCase):
         self.assertEqual(len(result.relationships), 2)
         labels = {rel.label for rel in result.relationships}
         self.assertSetEqual(labels, {"USES_TOOL", "USES_LLM"})
-        tool_relationship = next(rel for rel in result.relationships if rel.label == "USES_TOOL")
+        tool_relationship = next(
+            rel for rel in result.relationships if rel.label == "USES_TOOL"
+        )
         self.assertEqual(tool_relationship.target_name, "my_library.SearchTool")
-        llm_relationship = next(rel for rel in result.relationships if rel.label == "USES_LLM")
+        llm_relationship = next(
+            rel for rel in result.relationships if rel.label == "USES_LLM"
+        )
         self.assertEqual(llm_relationship.target_name, "my_library.AsyncLLM")
 
     def test_categorize_symbols_with_no_concept(self):
@@ -372,14 +501,13 @@ class TestCategorizer(unittest.TestCase):
                     AssignmentObservation(
                         target_qualified_name="unknown_obj",
                         call=CallObservation(
-                            qualified_name="unknown.Library",
-                            arguments={}
+                            qualified_name="unknown.Library", arguments={}
                         ),
-                        line_number=25
+                        line_number=25,
                     )
                 ],
                 decorators=[],
-                imports=[]
+                imports=[],
             )
         ]
 
@@ -407,14 +535,13 @@ class TestCategorizer(unittest.TestCase):
                     AssignmentObservation(
                         target_qualified_name="no_match",
                         call=CallObservation(
-                            qualified_name="nonexistent.Class",
-                            arguments={}
+                            qualified_name="nonexistent.Class", arguments={}
                         ),
-                        line_number=30
+                        line_number=30,
                     )
                 ],
                 decorators=[],
-                imports=[]
+                imports=[],
             )
         ]
 
@@ -434,13 +561,13 @@ class TestCategorizer(unittest.TestCase):
                         call=CallObservation(
                             qualified_name="openai.OpenAI",
                             arguments={"model": "gpt-4"},
-                            raw_code='OpenAI(model="gpt-4")'
+                            raw_code='OpenAI(model="gpt-4")',
                         ),
-                        line_number=35
+                        line_number=35,
                     )
                 ],
                 decorators=[],
-                imports=['from openai import OpenAI']
+                imports=["from openai import OpenAI"],
             )
         ]
 
@@ -455,7 +582,9 @@ class TestCategorizer(unittest.TestCase):
             mock_llm_instance.extract_model_name.return_value = "gpt-4"
             mock_llm_class.return_value = mock_llm_instance
 
-            result = categorize_symbols(analysis_results, self.mock_connector, mock_llm_config)
+            result = categorize_symbols(
+                analysis_results, self.mock_connector, mock_llm_config
+            )
 
         components = result.components
         self.assertIn("model", components)
@@ -476,10 +605,7 @@ class TestCategorizer(unittest.TestCase):
         result = _reconstruct_code_snippet(empty_obs)
         self.assertIn("()", result)
 
-        no_args_obs = {
-            "parser_name": "module.Class",
-            "arguments": {}
-        }
+        no_args_obs = {"parser_name": "module.Class", "arguments": {}}
         result = _reconstruct_code_snippet(no_args_obs)
         self.assertEqual(result, "Class()")
 
@@ -489,8 +615,8 @@ class TestCategorizer(unittest.TestCase):
                 "list_arg": [1, 2, 3],
                 "dict_arg": {"key": "value"},
                 "none_arg": None,
-                "bool_arg": True
-            }
+                "bool_arg": True,
+            },
         }
         result = _reconstruct_code_snippet(complex_obs)
         self.assertIn("Class(", result)
@@ -508,8 +634,8 @@ class TestPrecedenceAndExcludes(unittest.TestCase):
 
     def test_inline_annotation_overrides_catalog_concept(self):
         """DuckDB says concept='model', inline says concept='tool' -> appears once as 'tool'."""
-        from aibom.structures import ClassDefObservation
         from aibom.custom_catalog import CustomCatalogConfig
+        from aibom.structures import ClassDefObservation
 
         # The DuckDB catalog would match this symbol as 'model'
         self.mock_connector.find_components_by_suffixes.return_value = [
@@ -549,16 +675,15 @@ class TestPrecedenceAndExcludes(unittest.TestCase):
         # The inline annotation should win: appears in 'tool', NOT in 'model'
         tool_names = [c["name"] for c in result.components.get("tool", [])]
         model_at_line_10 = [
-            c for c in result.components.get("model", [])
-            if c.get("line_number") == 10
+            c for c in result.components.get("model", []) if c.get("line_number") == 10
         ]
         self.assertIn("MyClass", tool_names)
         self.assertEqual(len(model_at_line_10), 0)
 
     def test_excludes_filter_inline_annotations(self):
         """Symbol excluded in config, detected via # aibom: -> does NOT appear."""
-        from aibom.structures import ClassDefObservation
         from aibom.custom_catalog import CustomCatalogConfig
+        from aibom.structures import ClassDefObservation
 
         self.mock_connector.find_components_by_suffixes.return_value = []
 
@@ -588,8 +713,8 @@ class TestPrecedenceAndExcludes(unittest.TestCase):
 
     def test_excludes_filter_base_class_detections(self):
         """Symbol excluded in config, detected via base-class rule -> does NOT appear."""
+        from aibom.custom_catalog import BaseClassRule, CustomCatalogConfig
         from aibom.structures import ClassDefObservation
-        from aibom.custom_catalog import CustomCatalogConfig, BaseClassRule
 
         self.mock_connector.find_components_by_suffixes.return_value = []
 
@@ -665,8 +790,8 @@ class TestPrecedenceAndExcludes(unittest.TestCase):
 
     def test_base_class_skipped_when_catalog_detected(self):
         """Symbol detected by DuckDB at same location as base-class rule -> appears once with DuckDB data."""
+        from aibom.custom_catalog import BaseClassRule, CustomCatalogConfig
         from aibom.structures import ClassDefObservation
-        from aibom.custom_catalog import CustomCatalogConfig, BaseClassRule
 
         self.mock_connector.find_components_by_suffixes.return_value = [
             {"id": "mylib.Agent", "concept": "agent", "label": "Agent"}

--- a/aibom/tests/test_kb_enrichment_scanner.py
+++ b/aibom/tests/test_kb_enrichment_scanner.py
@@ -897,3 +897,50 @@ class TestStrandsAgentFrameworkPrefix:
             f"stray Agent() call from unknown framework should NOT be "
             f"promoted; got {[(c.name, c.framework) for c in agents]}"
         )
+
+
+class TestLangGraphAgentFrameworkPrefix:
+    """``create_react_agent(...)`` from LangGraph must become an AGENT.
+
+    LangGraph's prebuilt ReAct factory is catalogued in the KB as an agent,
+    but the call-pattern gate (``_AGENT_FRAMEWORK_PREFIXES``) derives the
+    framework prefix from the qualified name's first segment. Without
+    ``"langgraph"`` in the set, ``langgraph.prebuilt.create_react_agent(...)``
+    was rejected and the agent was never emitted — observed on published
+    open-source LangGraph sample repositories.
+    """
+
+    def test_langgraph_is_registered_framework_prefix(self) -> None:
+        assert "langgraph" in _AGENT_FRAMEWORK_PREFIXES, (
+            "langgraph must be a recognised agent framework prefix so that "
+            "create_react_agent(...) calls are classified."
+        )
+
+    def test_create_react_agent_call_is_detected(self, tmp_path: Path) -> None:
+        src = tmp_path / "agent.py"
+        src.write_text(
+            "from langgraph.prebuilt import create_react_agent\n"
+            "\n"
+            "agent = create_react_agent(model=llm, tools=tools)\n"
+        )
+        result = parse_source_code(str(src), src.read_text())
+        comps = _process_file_with_cache(result, kb_by_id={})
+        agents = [c for c in comps if c.component_type == AIComponentType.AGENT]
+        assert len(agents) == 1, (
+            f"expected exactly one LangGraph agent; got: "
+            f"{[(c.name, c.component_type) for c in comps]}"
+        )
+        call_pattern = agents[0].metadata.get("call_pattern", "")
+        assert call_pattern.endswith("create_react_agent"), call_pattern
+
+
+class TestLangGraphDependencyAllowlist:
+    """LangGraph and sibling agent-framework packages are AI dependencies."""
+
+    def test_agent_framework_packages_are_known_ai(self) -> None:
+        from aibom.scanners.dependency_scanner import is_known_ai_package
+
+        for pkg in ("langgraph", "ag2", "autogen-ext", "google-adk"):
+            assert is_known_ai_package(
+                "pypi", pkg
+            ), f"{pkg} should be recognised as an AI dependency"

--- a/aibom/tests/test_kb_enrichment_scanner.py
+++ b/aibom/tests/test_kb_enrichment_scanner.py
@@ -33,12 +33,12 @@ import pytest
 from aibom.cst_parser import parse_source_code
 from aibom.models import AIComponentType, DetectionSource, ScanContext
 from aibom.scanners.kb_enrichment_scanner import (
-    ALLOWED_CONCEPTS,
-    KBEnrichmentScanner,
     _AGENT_FRAMEWORK_PREFIXES,
     _BARE_CLIENT_HINTS,
+    _CONCEPT_TO_TYPE,
     _KNOWN_AI_CLIENT_CLASSES,
-    _MatchResult,
+    ALLOWED_CONCEPTS,
+    KBEnrichmentScanner,
     _build_kb_patterns,
     _detect_model_kwargs,
     _emit_suggestive_candidates,
@@ -47,10 +47,10 @@ from aibom.scanners.kb_enrichment_scanner import (
     _frameworks_related,
     _has_suggestive_signal,
     _match_observation_rich,
+    _MatchResult,
     _process_file_with_cache,
     _resolve_kb_path,
 )
-
 
 # ---------------------------------------------------------------------------
 # Unit tests for helper functions
@@ -62,10 +62,15 @@ class TestExtractClassSegment:
         assert _extract_class_segment("langchain_openai.ChatOpenAI") == "ChatOpenAI"
 
     def test_factory_method(self):
-        assert _extract_class_segment("langchain_community.vectorstores.FAISS.from_texts") == "FAISS"
+        assert (
+            _extract_class_segment("langchain_community.vectorstores.FAISS.from_texts")
+            == "FAISS"
+        )
 
     def test_deep_method_chain(self):
-        assert _extract_class_segment("openai.OpenAI.chat.completions.create") == "OpenAI"
+        assert (
+            _extract_class_segment("openai.OpenAI.chat.completions.create") == "OpenAI"
+        )
 
     def test_single_name(self):
         assert _extract_class_segment("ChatOpenAI") is None
@@ -185,15 +190,14 @@ class TestMethodLabelFiltering:
         }
 
         comps = _process_file_with_cache(result, kb_entries)
-        assert [c for c in comps if c.component_type == AIComponentType.VECTOR_STORE] == []
+        assert [
+            c for c in comps if c.component_type == AIComponentType.VECTOR_STORE
+        ] == []
 
     def test_kb_class_match_still_emits_vector_store_asset(self, tmp_path: Path):
         helper = tmp_path / "store.py"
         helper.write_text(
-            "class FakeVectorStore:\n"
-            "    pass\n"
-            "\n"
-            "store = FakeVectorStore()\n"
+            "class FakeVectorStore:\n" "    pass\n" "\n" "store = FakeVectorStore()\n"
         )
 
         result = parse_source_code(str(helper), helper.read_text())
@@ -221,7 +225,9 @@ class TestMethodLabelFiltering:
             },
         }
         result = _match_observation_rich(
-            "models.llm.openai.ChatOpenAI.invoke", kb, set(),
+            "models.llm.openai.ChatOpenAI.invoke",
+            kb,
+            set(),
         )
         assert result.is_partial
         assert "ChatOpenAI" in (result.partial_kb_id or "")
@@ -234,7 +240,9 @@ class TestMethodLabelFiltering:
                 "framework": "langchain_openai",
             },
         }
-        result = _match_observation_rich("langchain_openai.ChatOpenAI", kb, {"langchain_openai"})
+        result = _match_observation_rich(
+            "langchain_openai.ChatOpenAI", kb, {"langchain_openai"}
+        )
         assert result.is_confirmed
 
     def test_tier3_lowercase_short_name_skipped(self):
@@ -264,12 +272,17 @@ class TestExtractLeafClass:
 
     def test_valid_deep_class(self):
         assert (
-            _extract_leaf_class("langchain_community.tools.ddg_search.tool.DuckDuckGoSearchRun")
+            _extract_leaf_class(
+                "langchain_community.tools.ddg_search.tool.DuckDuckGoSearchRun"
+            )
             == "DuckDuckGoSearchRun"
         )
 
     def test_rejects_lowercase_leaf(self):
-        assert _extract_leaf_class("langchain.tools.render.format_tool_to_openai_function") is None
+        assert (
+            _extract_leaf_class("langchain.tools.render.format_tool_to_openai_function")
+            is None
+        )
 
     def test_rejects_all_uppercase(self):
         assert _extract_leaf_class("langchain.constants.API") is None
@@ -290,7 +303,12 @@ class TestExtractLeafClass:
         assert _extract_leaf_class("Tool") is None
 
     def test_excluded_class_blocked(self):
-        assert _extract_leaf_class("langchain.text_splitter.RecursiveCharacterTextSplitter") is None
+        assert (
+            _extract_leaf_class(
+                "langchain.text_splitter.RecursiveCharacterTextSplitter"
+            )
+            is None
+        )
 
 
 @pytest.mark.skipif(not _kb_available(), reason="No KB DuckDB installed")
@@ -378,6 +396,41 @@ class TestAllowedConcepts:
     def test_other_excluded(self):
         assert "other" not in ALLOWED_CONCEPTS
 
+    def test_expanded_vocabulary_concepts_accepted(self):
+        # Operational + MCP concepts must be surfaced, not dropped.
+        for concept in (
+            "guardrail",
+            "mcp_server",
+            "mcp_client",
+            "skill",
+            "observability",
+            "vector_store",
+            "dataset",
+            "training_run",
+            "model_artifact",
+        ):
+            assert concept in ALLOWED_CONCEPTS
+
+    def test_allowed_concepts_derived_from_mapping(self):
+        # ALLOWED_CONCEPTS must stay in lockstep with the type mapping so the
+        # two never drift.
+        assert ALLOWED_CONCEPTS == frozenset(_CONCEPT_TO_TYPE)
+
+    def test_concepts_map_to_expected_types(self):
+        assert _CONCEPT_TO_TYPE["guardrail"] is AIComponentType.GUARDRAIL
+        assert _CONCEPT_TO_TYPE["mcp_server"] is AIComponentType.MCP_SERVER
+        assert _CONCEPT_TO_TYPE["mcp_client"] is AIComponentType.MCP_CLIENT
+        assert _CONCEPT_TO_TYPE["skill"] is AIComponentType.SKILL
+        assert _CONCEPT_TO_TYPE["observability"] is AIComponentType.OBSERVABILITY
+        assert _CONCEPT_TO_TYPE["vector_store"] is AIComponentType.VECTOR_STORE
+
+    def test_typeless_concepts_map_to_other_not_dropped(self):
+        # Concepts without a dedicated type are kept as OTHER so the evidence
+        # is not silently discarded.
+        for concept in ("reranker", "evaluator", "framework_core"):
+            assert _CONCEPT_TO_TYPE[concept] is AIComponentType.OTHER
+            assert concept in ALLOWED_CONCEPTS
+
 
 # ---------------------------------------------------------------------------
 # Scanner-level tests (KB presence required)
@@ -425,8 +478,7 @@ class TestKBEnrichmentScannerIntegration:
 
     def test_detects_agent(self, tmp_path: Path):
         (tmp_path / "graph.py").write_text(
-            "from langgraph.graph import StateGraph\n"
-            "graph = StateGraph()\n"
+            "from langgraph.graph import StateGraph\n" "graph = StateGraph()\n"
         )
         ctx = ScanContext(paths=[str(tmp_path)])
         comps, _ = KBEnrichmentScanner().scan(ctx)
@@ -457,8 +509,7 @@ class TestKBEnrichmentScannerIntegration:
 
     def test_filters_other_concept(self, tmp_path: Path):
         (tmp_path / "client.py").write_text(
-            "import openai\n"
-            "client = openai.OpenAI()\n"
+            "import openai\n" "client = openai.OpenAI()\n"
         )
         ctx = ScanContext(paths=[str(tmp_path)])
         comps, _ = KBEnrichmentScanner().scan(ctx)
@@ -479,8 +530,7 @@ class TestKBEnrichmentScannerIntegration:
 
     def test_dedup_same_line(self, tmp_path: Path):
         (tmp_path / "app.py").write_text(
-            "from crewai import Agent\n"
-            "a = Agent(role='r')\n"
+            "from crewai import Agent\n" "a = Agent(role='r')\n"
         )
         ctx = ScanContext(paths=[str(tmp_path)])
         comps, _ = KBEnrichmentScanner().scan(ctx)
@@ -495,12 +545,10 @@ class TestKBEnrichmentScannerIntegration:
 
     def test_multiple_files(self, tmp_path: Path):
         (tmp_path / "a.py").write_text(
-            "from crewai import Agent\n"
-            "a = Agent(role='r')\n"
+            "from crewai import Agent\n" "a = Agent(role='r')\n"
         )
         (tmp_path / "b.py").write_text(
-            "from langgraph.graph import StateGraph\n"
-            "g = StateGraph()\n"
+            "from langgraph.graph import StateGraph\n" "g = StateGraph()\n"
         )
         ctx = ScanContext(paths=[str(tmp_path)])
         comps, _ = KBEnrichmentScanner().scan(ctx)
@@ -580,8 +628,7 @@ class TestEmitSuggestiveCandidates:
         f = tmp_path / "agents" / "multi.py"
         f.parent.mkdir()
         source = (
-            "router = RouterAgent(api_key='x')\n"
-            "search = SearchTool(name='docs')\n"
+            "router = RouterAgent(api_key='x')\n" "search = SearchTool(name='docs')\n"
         )
         f.write_text(source)
         candidates = _emit_suggestive_candidates(f, source)
@@ -661,15 +708,11 @@ class TestAgentSpecificHint:
 
     def test_non_agent_hint_unchanged(self, tmp_path: Path):
         (tmp_path / "app.py").write_text(
-            "from stores.vector_store import VectorStore\n"
-            "vs = VectorStore()\n"
+            "from stores.vector_store import VectorStore\n" "vs = VectorStore()\n"
         )
         ctx = ScanContext(paths=[str(tmp_path)])
         comps, _ = KBEnrichmentScanner().scan(ctx)
-        stores = [
-            c for c in comps
-            if c.component_type == AIComponentType.VECTOR_STORE
-        ]
+        stores = [c for c in comps if c.component_type == AIComponentType.VECTOR_STORE]
         if stores:
             hint = stores[0].agentic_hint
             assert "REMOVE unless surrounding code proves" in hint
@@ -708,19 +751,19 @@ class TestStrandsProviderClassCoverage:
 
     @pytest.mark.parametrize("class_name", _STRANDS_MODEL_CLASSES)
     def test_strands_class_is_registered(self, class_name: str) -> None:
-        assert class_name in _KNOWN_AI_CLIENT_CLASSES, (
-            f"{class_name} missing from _KNOWN_AI_CLIENT_CLASSES"
-        )
+        assert (
+            class_name in _KNOWN_AI_CLIENT_CLASSES
+        ), f"{class_name} missing from _KNOWN_AI_CLIENT_CLASSES"
 
     @pytest.mark.parametrize("class_name", _STRANDS_MODEL_CLASSES)
     def test_strands_class_has_bare_client_hint(self, class_name: str) -> None:
-        assert class_name in _BARE_CLIENT_HINTS, (
-            f"{class_name} missing from _BARE_CLIENT_HINTS"
-        )
+        assert (
+            class_name in _BARE_CLIENT_HINTS
+        ), f"{class_name} missing from _BARE_CLIENT_HINTS"
         hint = _BARE_CLIENT_HINTS[class_name]
-        assert "Remove" in hint, (
-            f"{class_name} bare-client hint must mention removal: {hint!r}"
-        )
+        assert (
+            "Remove" in hint
+        ), f"{class_name} bare-client hint must mention removal: {hint!r}"
 
     def test_bedrock_model_resolves_model_id_kwarg(self, tmp_path: Path) -> None:
         """``BedrockModel(model_id="...")`` should yield a MODEL asset with
@@ -741,17 +784,14 @@ class TestStrandsProviderClassCoverage:
         assert models[0].heuristic_confidence == 1.0
         assert models[0].metadata["constructor"] == "BedrockModel"
         assert models[0].metadata["extracted_from_kwarg"] == "model_id"
-        assert (
-            models[0].metadata.get("detection_method") != "bare_provider_client"
-        )
+        assert models[0].metadata.get("detection_method") != "bare_provider_client"
 
     def test_bare_bedrock_model_emits_agentic_candidate(self, tmp_path: Path) -> None:
         """``BedrockModel()`` with no model_id is a bare client, so we emit a
         needs_agentic MODEL so the agentic layer can resolve or prune it."""
         src = tmp_path / "agent.py"
         src.write_text(
-            "from strands.models import BedrockModel\n"
-            "model = BedrockModel()\n"
+            "from strands.models import BedrockModel\n" "model = BedrockModel()\n"
         )
         result = parse_source_code(str(src), src.read_text())
         comps = _detect_model_kwargs(result)
@@ -834,9 +874,9 @@ class TestStrandsAgentFrameworkPrefix:
         agent = agents[0]
         assert agent.detection_source == DetectionSource.CODE_ANALYSIS
         call_pattern = agent.metadata.get("call_pattern", "")
-        assert call_pattern.endswith("Agent"), (
-            f"call_pattern should end with 'Agent', got {call_pattern!r}"
-        )
+        assert call_pattern.endswith(
+            "Agent"
+        ), f"call_pattern should end with 'Agent', got {call_pattern!r}"
 
     def test_non_strands_non_framework_call_is_not_detected(
         self, tmp_path: Path

--- a/aibom/tests/test_kb_enrichment_scanner.py
+++ b/aibom/tests/test_kb_enrichment_scanner.py
@@ -944,3 +944,47 @@ class TestLangGraphDependencyAllowlist:
             assert is_known_ai_package(
                 "pypi", pkg
             ), f"{pkg} should be recognised as an AI dependency"
+
+
+class TestGuardrailDetection:
+    """``agentsec.protect(...)`` and guardrail frameworks must be detected."""
+
+    def test_agentsec_protect_call_is_guardrail(self, tmp_path: Path) -> None:
+        from aibom.scanners.kb_enrichment_scanner import _detect_guardrail_calls
+
+        src = tmp_path / "agent.py"
+        src.write_text(
+            "from aidefense.runtime import agentsec\n"
+            "agentsec.protect(config='agentsec.yaml')\n"
+        )
+        result = parse_source_code(str(src), src.read_text())
+        comps = _detect_guardrail_calls(result)
+        guardrails = [c for c in comps if c.component_type == AIComponentType.GUARDRAIL]
+        assert len(guardrails) == 1, (
+            f"expected one guardrail from agentsec.protect(); got "
+            f"{[(c.name, c.component_type) for c in comps]}"
+        )
+        assert guardrails[0].metadata.get("guardrail_protection") is True
+        assert (
+            guardrails[0].metadata.get("call_pattern", "").endswith("agentsec.protect")
+        )
+
+    def test_non_guardrail_call_is_ignored(self, tmp_path: Path) -> None:
+        from aibom.scanners.kb_enrichment_scanner import _detect_guardrail_calls
+
+        src = tmp_path / "app.py"
+        src.write_text(
+            "import logging\n"
+            "logging.getLogger(__name__).info('protect')\n"
+            "some_obj.protect_something()\n"
+        )
+        result = parse_source_code(str(src), src.read_text())
+        comps = _detect_guardrail_calls(result)
+        assert comps == []
+
+    def test_guardrail_framework_imports_mapped(self) -> None:
+        from aibom.scanners.kb_enrichment_scanner import _IMPORT_MODULE_TYPE_MAP
+
+        for mod in ("agentsec", "aidefense", "nemoguardrails", "guardrails"):
+            assert mod in _IMPORT_MODULE_TYPE_MAP
+            assert _IMPORT_MODULE_TYPE_MAP[mod].primary is AIComponentType.GUARDRAIL

--- a/aibom/tests/test_llm_factory.py
+++ b/aibom/tests/test_llm_factory.py
@@ -21,8 +21,9 @@ from unittest.mock import MagicMock, patch
 @patch(
     "aibom.llm_factory.ensure_llm_runtime_available",
     side_effect=lambda model_string, *, provider=None: (
-        __import__("aibom.llm_factory", fromlist=["resolve_provider"])
-        .resolve_provider(model_string, provider)
+        __import__("aibom.llm_factory", fromlist=["resolve_provider"]).resolve_provider(
+            model_string, provider
+        )
     ),
 )
 class TestBuildChatModel(unittest.TestCase):
@@ -189,6 +190,62 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertEqual(kwargs["model_provider"], "bedrock")
         self.assertNotIn("base_url", kwargs)
         self.assertNotIn("azure_endpoint", kwargs)
+
+    # --- Reasoning-model parameter handling ---
+
+    @patch("aibom.llm_factory.init_chat_model")
+    def test_reasoning_model_uses_max_completion_tokens(
+        self, mock_init, _mock_preflight
+    ):
+        """Reasoning models (gpt-5.x) reject ``max_tokens`` and require
+        ``max_completion_tokens``."""
+        from aibom.llm_factory import build_chat_model
+
+        mock_init.return_value = MagicMock()
+        build_chat_model("gpt-5.5", max_tokens=256)
+        _, kwargs = mock_init.call_args
+        self.assertEqual(kwargs.get("max_completion_tokens"), 256)
+        self.assertNotIn("max_tokens", kwargs)
+
+    @patch("aibom.llm_factory.init_chat_model")
+    def test_reasoning_model_omits_temperature(self, mock_init, _mock_preflight):
+        """Reasoning models reject a non-default ``temperature``; omit it."""
+        from aibom.llm_factory import build_chat_model
+
+        mock_init.return_value = MagicMock()
+        build_chat_model("gpt-5.5", temperature=0.0)
+        _, kwargs = mock_init.call_args
+        self.assertNotIn("temperature", kwargs)
+
+    @patch("aibom.llm_factory.init_chat_model")
+    def test_reasoning_model_detected_via_provider_slash(
+        self, mock_init, _mock_preflight
+    ):
+        """Detection works on the bare model id after stripping a provider/
+        prefix (e.g. ``openai/o3-mini``)."""
+        from aibom.llm_factory import build_chat_model
+
+        mock_init.return_value = MagicMock()
+        build_chat_model("openai/o3-mini", max_tokens=128)
+        _, kwargs = mock_init.call_args
+        self.assertEqual(kwargs.get("max_completion_tokens"), 128)
+        self.assertNotIn("max_tokens", kwargs)
+        self.assertNotIn("temperature", kwargs)
+
+    @patch("aibom.llm_factory.init_chat_model")
+    def test_non_reasoning_model_keeps_max_tokens_and_temperature(
+        self, mock_init, _mock_preflight
+    ):
+        """Regression: non-reasoning models are unaffected — they keep
+        ``max_tokens`` and ``temperature``."""
+        from aibom.llm_factory import build_chat_model
+
+        mock_init.return_value = MagicMock()
+        build_chat_model("gpt-4o", max_tokens=256, temperature=0.2)
+        _, kwargs = mock_init.call_args
+        self.assertEqual(kwargs["max_tokens"], 256)
+        self.assertEqual(kwargs["temperature"], 0.2)
+        self.assertNotIn("max_completion_tokens", kwargs)
 
 
 if __name__ == "__main__":

--- a/aibom/tests/test_mcp_detector.py
+++ b/aibom/tests/test_mcp_detector.py
@@ -22,16 +22,23 @@ class TestMcpDetector:
                 "mcp.json": json.dumps(
                     {
                         "mcpServers": {
-                            "fetch": {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-fetch"]},
+                            "fetch": {
+                                "command": "npx",
+                                "args": ["-y", "@modelcontextprotocol/server-fetch"],
+                            },
                         },
                     },
                 ),
             },
         )
-        names = {c.name for c in comps if c.component_type == AIComponentType.MCP_SERVER}
+        names = {
+            c.name for c in comps if c.component_type == AIComponentType.MCP_SERVER
+        }
         assert "fetch" in names
 
-    def test_detects_mcp_server_from_claude_desktop_config(self, tmp_path: Path) -> None:
+    def test_detects_mcp_server_from_claude_desktop_config(
+        self, tmp_path: Path
+    ) -> None:
         comps, _ = run_scanner(
             McpDetector,
             tmp_path,
@@ -45,7 +52,9 @@ class TestMcpDetector:
                 ),
             },
         )
-        names = {c.name for c in comps if c.component_type == AIComponentType.MCP_SERVER}
+        names = {
+            c.name for c in comps if c.component_type == AIComponentType.MCP_SERVER
+        }
         assert "filesystem" in names
 
     def test_detects_fastmcp_in_python(self, tmp_path: Path) -> None:
@@ -75,3 +84,70 @@ class TestMcpDetector:
             {"mcp.json": "{ not valid json <<<"},
         )
         assert comps == []
+
+    def test_detects_streamablehttp_client_with_session(self, tmp_path: Path) -> None:
+        # Modern MCP SDK idiom: streamablehttp_client + ClientSession, where
+        # the file imports ClientSession from ``mcp`` (not ``mcp.client``).
+        src = (
+            "from mcp import ClientSession\n"
+            "from mcp.client.streamable_http import streamablehttp_client\n"
+            "\n"
+            "async def run(url):\n"
+            "    async with streamablehttp_client(url) as (r, w, _):\n"
+            "        async with ClientSession(r, w) as session:\n"
+            "            await session.initialize()\n"
+        )
+        comps, _ = run_scanner(McpDetector, tmp_path, {"agent.py": src})
+        clients = [c for c in comps if c.component_type == AIComponentType.MCP_CLIENT]
+        assert len(clients) == 1
+        patterns = clients[0].metadata.get("patterns", [])
+        assert "streamablehttp_client" in patterns
+        assert "ClientSession" in patterns
+
+    def test_detects_google_adk_mcp_toolset(self, tmp_path: Path) -> None:
+        src = (
+            "from google.adk.tools.mcp_tool import McpToolset\n"
+            "from google.adk.tools.mcp_tool.mcp_session_manager import (\n"
+            "    StreamableHTTPConnectionParams,\n"
+            ")\n"
+            "\n"
+            "def build(url):\n"
+            "    return McpToolset(\n"
+            "        connection_params=StreamableHTTPConnectionParams(url=url),\n"
+            "    )\n"
+        )
+        comps, _ = run_scanner(McpDetector, tmp_path, {"adk_agent.py": src})
+        clients = [c for c in comps if c.component_type == AIComponentType.MCP_CLIENT]
+        assert len(clients) == 1
+        patterns = clients[0].metadata.get("patterns", [])
+        assert "McpToolset" in patterns
+
+    def test_distinct_clients_across_files_not_collapsed(self, tmp_path: Path) -> None:
+        src = (
+            "from mcp import ClientSession\n"
+            "from mcp.client.streamable_http import streamablehttp_client\n"
+            "async def run(url):\n"
+            "    async with streamablehttp_client(url) as (r, w, _):\n"
+            "        async with ClientSession(r, w) as s:\n"
+            "            await s.initialize()\n"
+        )
+        comps, _ = run_scanner(
+            McpDetector,
+            tmp_path,
+            {"a/agent.py": src, "b/agent.py": src},
+        )
+        clients = [c for c in comps if c.component_type == AIComponentType.MCP_CLIENT]
+        assert len(clients) == 2
+
+    def test_plain_clientsession_without_mcp_not_detected(self, tmp_path: Path) -> None:
+        # A ClientSession unrelated to MCP (no mcp import / transport) must
+        # not be misdetected as an MCP client.
+        src = (
+            "from aiohttp import ClientSession\n"
+            "async def run():\n"
+            "    async with ClientSession() as s:\n"
+            "        await s.get('https://example.com')\n"
+        )
+        comps, _ = run_scanner(McpDetector, tmp_path, {"http.py": src})
+        clients = [c for c in comps if c.component_type == AIComponentType.MCP_CLIENT]
+        assert clients == []

--- a/aibom/tests/test_repo_triage.py
+++ b/aibom/tests/test_repo_triage.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -82,6 +84,66 @@ class TestTriageAgentIntegration:
         assert len(results) == 2
         assert results[0].decision == "deep-scan"
         assert results[1].decision == "skip"
+
+
+class TestTriageInvokeTimeout:
+    """A hung triage agent.invoke must be bounded by the daemon-thread deadline
+    helper and fail open to deep-scan, never wedging the scan."""
+
+    def test_invoke_with_timeout_bounds_hung_agent(self) -> None:
+        never = threading.Event()  # never set -> invoke blocks forever
+
+        def hung_invoke(*_a: object, **_k: object) -> object:
+            never.wait()
+            return {"messages": []}
+
+        agent = MagicMock()
+        agent.invoke.side_effect = hung_invoke
+
+        triager = RepoTriager()
+        with patch("aibom.repo_triage._TRIAGE_TIMEOUT_S", 1):
+            start = time.monotonic()
+            from aibom.agentic.agent import _InvokeTimeout
+
+            try:
+                triager._invoke_with_timeout(agent, "triage this repo")
+                raised = None
+            except _InvokeTimeout as exc:
+                raised = exc
+            elapsed = time.monotonic() - start
+
+        assert raised is not None, "expected _InvokeTimeout on a hung invoke"
+        assert elapsed < 10, f"triage invoke hung for {elapsed:.1f}s"
+
+    def test_hung_triage_degrades_to_deep_scan(self, tmp_path: Path) -> None:
+        repo = tmp_path / "ai-app"
+        repo.mkdir()
+
+        never = threading.Event()
+
+        def hung_invoke(*_a: object, **_k: object) -> object:
+            never.wait()
+            return {"messages": []}
+
+        agent = MagicMock()
+        agent.invoke.side_effect = hung_invoke
+        fake_deepagents = MagicMock()
+        fake_deepagents.create_deep_agent.return_value = agent
+
+        triager = RepoTriager(llm_config={"model": "test-model", "api_key": "k"})
+        with (
+            patch("aibom.repo_triage._TRIAGE_TIMEOUT_S", 1),
+            patch("aibom.llm_factory.build_chat_model", return_value=MagicMock()),
+            patch("aibom.agentic.tools.build_triage_tools", return_value=[]),
+            patch.dict("sys.modules", {"deepagents": fake_deepagents}),
+        ):
+            start = time.monotonic()
+            results = triager.triage_repos([str(repo)])
+            elapsed = time.monotonic() - start
+
+        assert elapsed < 15, f"triage hung for {elapsed:.1f}s"
+        assert results[0].decision == "deep-scan"
+        assert "failed" in results[0].reason
 
 
 class TestTriageSingleNoExtras:

--- a/aibom/tests/test_reporters.py
+++ b/aibom/tests/test_reporters.py
@@ -65,9 +65,7 @@ EXPECTED_REPORTER_NAMES = frozenset(
 )
 
 
-def _source_with_three_components(
-    path: str, name_prefix: str
-) -> SourceResult:
+def _source_with_three_components(path: str, name_prefix: str) -> SourceResult:
     model = AIComponent(
         name=f"{name_prefix}-model",
         component_type=AIComponentType.MODEL,
@@ -157,12 +155,14 @@ def test_get_reporter_unknown_returns_none():
 
 def test_friendly_source_name(tmp_path, monkeypatch):
     from unittest.mock import patch
+
     from aibom.reporters.json_reporter import _friendly_source_name
 
     def _fake_run(cmd, **_kw):
         class R:
             returncode = 0
             stdout = "git@github.com:acme-org/my-service.git\n"
+
         return R()
 
     with patch("aibom.reporters.json_reporter.subprocess.run", side_effect=_fake_run):
@@ -172,6 +172,7 @@ def test_friendly_source_name(tmp_path, monkeypatch):
         class R:
             returncode = 0
             stdout = "https://github.com/org/repo.git\n"
+
         return R()
 
     with patch("aibom.reporters.json_reporter.subprocess.run", side_effect=_fake_https):
@@ -230,7 +231,9 @@ def test_json_reporter_preserves_decision_annotations():
     )
     result = ScanResult(
         metadata={"analyzer_version": "2.0.0-test", "run_id": "run-test-annotations"},
-        sources=[SourceResult(path="/proj/src", components=[component], relationships=[])],
+        sources=[
+            SourceResult(path="/proj/src", components=[component], relationships=[])
+        ],
         risk=RiskScore(),
     )
 
@@ -244,11 +247,15 @@ def test_json_reporter_preserves_decision_annotations():
     assert rendered["decision_annotation"]["code_snippet"]["truncated"] is False
 
 
-def test_json_reporter_disambiguates_colliding_source_names(sample_scan_result: ScanResult):
+def test_json_reporter_disambiguates_colliding_source_names(
+    sample_scan_result: ScanResult,
+):
     from unittest.mock import patch
 
     buf = StringIO()
-    with patch("aibom.reporters.json_reporter._friendly_source_name", return_value="dup"):
+    with patch(
+        "aibom.reporters.json_reporter._friendly_source_name", return_value="dup"
+    ):
         get_reporter("json").render(sample_scan_result, buf)
 
     data = json.loads(buf.getvalue())
@@ -260,7 +267,52 @@ def test_json_reporter_disambiguates_colliding_source_names(sample_scan_result: 
     assert sources["dup#2"]["source_path"] == "/proj/src/beta"
 
 
-def test_json_reporter_omits_component_summary_by_default(sample_scan_result: ScanResult):
+def test_json_reporter_emits_source_attribution_block(
+    sample_scan_result: ScanResult,
+):
+    buf = StringIO()
+    JsonReporter().render(sample_scan_result, buf)
+    data = json.loads(buf.getvalue())
+
+    sources = data["aibom_analysis"]["sources"]
+    for src in sources.values():
+        meta = src["metadata"]
+        # The attribution triple is always present.
+        assert "source_kind" in meta
+        assert "source_ref_canonical" in meta
+        assert "source_ref_version" in meta
+        # Fixture paths are not real checkouts -> local-path, empty refs.
+        assert meta["source_kind"] == "local-path"
+        assert meta["source_ref_canonical"] == ""
+        assert meta["source_ref_version"] == ""
+
+
+def test_json_reporter_source_attribution_prefers_supplied_detail(
+    sample_scan_result: ScanResult,
+):
+    # Pipeline / cross-repo discovery may already know the attribution; those
+    # values must win over local-path derivation.
+    sample_scan_result.metadata["_report_source_details"] = {
+        "/proj/src/alpha": {
+            "source_kind": "git",
+            "source_ref_canonical": "github.com/org/repo",
+            "source_ref_version": "a" * 40,
+        }
+    }
+    buf = StringIO()
+    JsonReporter().render(sample_scan_result, buf)
+    data = json.loads(buf.getvalue())
+
+    alpha = data["aibom_analysis"]["sources"]["alpha"]
+    assert alpha["summary"]["source_kind"] == "git"
+    assert alpha["metadata"]["source_kind"] == "git"
+    assert alpha["metadata"]["source_ref_canonical"] == "github.com/org/repo"
+    assert alpha["metadata"]["source_ref_version"] == "a" * 40
+
+
+def test_json_reporter_omits_component_summary_by_default(
+    sample_scan_result: ScanResult,
+):
     buf = StringIO()
     JsonReporter().render(sample_scan_result, buf)
     data = json.loads(buf.getvalue())
@@ -268,7 +320,9 @@ def test_json_reporter_omits_component_summary_by_default(sample_scan_result: Sc
     assert "component_summary" not in data["aibom_analysis"]
 
 
-def test_json_reporter_emits_component_summary_when_enabled(sample_scan_result: ScanResult):
+def test_json_reporter_emits_component_summary_when_enabled(
+    sample_scan_result: ScanResult,
+):
     buf = StringIO()
     JsonReporter(include_component_summary=True).render(sample_scan_result, buf)
     data = json.loads(buf.getvalue())

--- a/aibom/tests/test_scan_pipeline.py
+++ b/aibom/tests/test_scan_pipeline.py
@@ -709,6 +709,97 @@ class TestProtectedDependencies:
         assert [c.name for c in result] == ["strands-agents"]
 
 
+class TestBackfillRelationshipInstanceIds:
+    """LLM-emitted edges with blank endpoint ids are backfilled deterministically."""
+
+    def _model(self, name: str, path: str, line: int) -> AIComponent:
+        return AIComponent(
+            name=name,
+            component_type=AIComponentType.MODEL,
+            file_path=path,
+            line_number=line,
+            model_name=name,
+        )
+
+    def _agent(self, name: str, path: str, line: int) -> AIComponent:
+        return AIComponent(
+            name=name,
+            component_type=AIComponentType.AGENT,
+            file_path=path,
+            line_number=line,
+        )
+
+    def test_unique_name_endpoints_are_resolved(self):
+        from aibom.models import ComponentRelationship, RelationshipType
+        from aibom.scan_pipeline import _backfill_relationship_instance_ids
+
+        agent = self._agent("agent", "lab/a.py", 5)
+        model = self._model("claude-3-5-haiku", "lab/a.py", 10)
+        rel = ComponentRelationship(
+            source_instance_id="",
+            target_instance_id="",
+            source_name="agent",
+            target_name="claude-3-5-haiku",
+            relationship_type=RelationshipType.USES_MODEL,
+        )
+        out = _backfill_relationship_instance_ids([rel], [agent, model])
+        assert out[0].source_instance_id == agent.instance_id
+        assert out[0].target_instance_id == model.instance_id
+
+    def test_ambiguous_name_left_blank(self):
+        from aibom.models import ComponentRelationship, RelationshipType
+        from aibom.scan_pipeline import _backfill_relationship_instance_ids
+
+        # Two agents named "agent" in different files -> ambiguous.
+        a1 = self._agent("agent", "lab/a.py", 5)
+        a2 = self._agent("agent", "lab/b.py", 5)
+        model = self._model("gpt-4o", "lab/a.py", 10)
+        rel = ComponentRelationship(
+            source_instance_id="",
+            target_instance_id="",
+            source_name="agent",
+            target_name="gpt-4o",
+            relationship_type=RelationshipType.USES_MODEL,
+        )
+        out = _backfill_relationship_instance_ids([rel], [a1, a2, model])
+        # Ambiguous source stays blank; unique target is resolved.
+        assert out[0].source_instance_id == ""
+        assert out[0].target_instance_id == model.instance_id
+
+    def test_existing_ids_preserved(self):
+        from aibom.models import ComponentRelationship, RelationshipType
+        from aibom.scan_pipeline import _backfill_relationship_instance_ids
+
+        agent = self._agent("agent", "lab/a.py", 5)
+        model = self._model("gpt-4o", "lab/a.py", 10)
+        rel = ComponentRelationship(
+            source_instance_id="preset-src",
+            target_instance_id="preset-tgt",
+            source_name="agent",
+            target_name="gpt-4o",
+            relationship_type=RelationshipType.USES_MODEL,
+        )
+        out = _backfill_relationship_instance_ids([rel], [agent, model])
+        assert out[0].source_instance_id == "preset-src"
+        assert out[0].target_instance_id == "preset-tgt"
+
+    def test_unknown_name_left_blank(self):
+        from aibom.models import ComponentRelationship, RelationshipType
+        from aibom.scan_pipeline import _backfill_relationship_instance_ids
+
+        agent = self._agent("agent", "lab/a.py", 5)
+        rel = ComponentRelationship(
+            source_instance_id="",
+            target_instance_id="",
+            source_name="agent",
+            target_name="model-that-was-pruned",
+            relationship_type=RelationshipType.USES_MODEL,
+        )
+        out = _backfill_relationship_instance_ids([rel], [agent])
+        assert out[0].source_instance_id == agent.instance_id
+        assert out[0].target_instance_id == ""
+
+
 class TestDefaultBomScope:
     def test_stage_assemble_excludes_test_only_components(self):
         component = AIComponent(

--- a/aibom/tests/test_scan_pipeline.py
+++ b/aibom/tests/test_scan_pipeline.py
@@ -1038,11 +1038,12 @@ class TestDefaultBomScope:
 
         assert [c.name for c in components] == ["gpt-4o-mini"]
 
-    def test_stage_assemble_excludes_fixture_components(self):
+    def test_stage_assemble_excludes_fixture_components_under_test_root(self):
+        # A fixtures/ dir nested under a test root is genuine test scaffolding.
         component = AIComponent(
             name="FakePrompt",
             component_type=AIComponentType.PROMPT,
-            file_path="repo/fixtures/sample_prompt.py",
+            file_path="repo/tests/fixtures/sample_prompt.py",
             line_number=4,
             heuristic_confidence=0.8,
         )
@@ -1052,6 +1053,23 @@ class TestDefaultBomScope:
 
         assert components == []
         assert agentic_count == 0
+
+    def test_stage_assemble_keeps_top_level_fixtures_production_component(self):
+        # A bare top-level fixtures/ dir with no other test signal is NOT
+        # automatically test-only — it may be a production data loader. The
+        # over-broad ``fixtures`` segment previously dropped this asset.
+        component = AIComponent(
+            name="gpt-4o-mini",
+            component_type=AIComponentType.MODEL,
+            file_path="repo/fixtures/prompt_loader.py",
+            line_number=4,
+            heuristic_confidence=0.8,
+        )
+        pipeline = ScanPipeline(scan_paths=["/tmp"])
+
+        components, _ = pipeline._stage_assemble([component])
+
+        assert [c.name for c in components] == ["gpt-4o-mini"]
 
     def test_stage_assemble_keeps_components_with_production_evidence(self):
         prod = AIComponent(
@@ -1172,6 +1190,58 @@ class TestDefaultBomScope:
 
         assert [c.name for c in result.components] == ["gpt-4o"]
         assert result.relationships == [kept_rel]
+
+
+class TestIsTestFile:
+    """``_is_test_file`` must classify genuine test files as test-only without
+    misclassifying production files that merely live under a ``spec``,
+    ``testing``, or ``fixtures`` directory."""
+
+    def _f(self, p: str) -> bool:
+        from aibom.scan_pipeline import _is_test_file
+
+        return _is_test_file(p)
+
+    # Unambiguous test markers — standalone, still test-only.
+    def test_tests_dir_is_test(self):
+        assert self._f("repo/tests/test_agent.py") is True
+
+    def test_dunder_tests_dir_is_test(self):
+        assert self._f("repo/__tests__/agent.py") is True
+
+    def test_testdata_dir_is_test(self):
+        assert self._f("repo/testdata/agent.py") is True
+        assert self._f("repo/test_data/agent.py") is True
+
+    def test_test_prefix_filename_is_test(self):
+        assert self._f("repo/src/test_router.py") is True
+
+    def test_test_suffix_filename_is_test(self):
+        assert self._f("repo/src/router_test.py") is True
+
+    # Ambiguous segments — only test-only WITH a co-located test signal.
+    def test_fixtures_under_test_root_is_test(self):
+        assert self._f("repo/tests/fixtures/sample.py") is True
+
+    def test_spec_with_test_filename_is_test(self):
+        assert self._f("repo/spec/test_contract.py") is True
+
+    def test_testing_under_test_root_is_test(self):
+        assert self._f("repo/test/testing/helpers.py") is True
+
+    # Ambiguous segments alone in a production tree — NOT test-only.
+    def test_top_level_fixtures_production_is_not_test(self):
+        assert self._f("repo/fixtures/prompt_loader.py") is False
+
+    def test_top_level_spec_production_is_not_test(self):
+        assert self._f("repo/spec/openapi_models.py") is False
+
+    def test_top_level_testing_utility_is_not_test(self):
+        assert self._f("repo/src/testing/harness.py") is False
+
+    # Regression: a production file with no test signal stays production.
+    def test_plain_production_file_is_not_test(self):
+        assert self._f("repo/src/app/service.py") is False
 
 
 class TestDependencyPolicyScope:

--- a/aibom/tests/test_scan_pipeline.py
+++ b/aibom/tests/test_scan_pipeline.py
@@ -633,6 +633,184 @@ class TestPropagateRemovals:
             f"{[(c.name, c.metadata.get('import_statement')) for c in result]}"
         )
 
+    def test_test_file_removal_does_not_kill_production_sibling(self):
+        """Regression: the LLM pruning a guardrail call-site in a *test* file
+        must NOT cascade to the production call-site that shares the same
+        canonical consolidation key.
+
+        ``agentsec.protect(...)`` appears once in production ``agent.py`` and
+        many times across ``tests/`` (mode-handling unit tests). Both are
+        call-site emissions (``call_pattern`` set), so both are "strong" under
+        the import-only rule. ``_consolidation_key`` lowercases the name and
+        ignores the file, collapsing them to ``("agentsec.protect",
+        "guardrail")``. When the agent removed a test-file instance as test
+        scaffolding, the strong removal cascaded and wiped the production
+        guardrail — observed end-to-end where the agentsec example tree
+        produced 0 guardrails while a prod-only copy produced the guardrail.
+        """
+        from aibom.scan_pipeline import _propagate_removals
+
+        prod = AIComponent(
+            name="agentsec.protect",
+            component_type=AIComponentType.GUARDRAIL,
+            file_path="langchain-agent/agent.py",
+            line_number=77,
+            metadata={"call_pattern": "aidefense.runtime.agentsec.protect"},
+        )
+        test_use = AIComponent(
+            name="agentsec.protect",
+            component_type=AIComponentType.GUARDRAIL,
+            file_path="langchain-agent/tests/unit/test_langchain_example.py",
+            line_number=210,
+            metadata={"call_pattern": "aidefense.runtime.agentsec.protect"},
+        )
+
+        result = _propagate_removals(
+            sent=[prod, test_use],
+            received=[prod],
+            pre_fanout_removed_ids={test_use.instance_id},
+        )
+
+        names = [(c.name, c.file_path) for c in result]
+        assert prod.instance_id in {c.instance_id for c in result}, (
+            "production agentsec.protect guardrail must survive when only a "
+            f"test-file sibling was removed; got kept: {names}"
+        )
+
+    def test_production_removal_still_cascades_to_test_sibling(self):
+        """A production-scope removal must still take out test-scope siblings
+        sharing the canonical key — the original cascade intent is preserved
+        for the production→all direction."""
+        from aibom.scan_pipeline import _propagate_removals
+
+        prod = AIComponent(
+            name="FakeAgent",
+            component_type=AIComponentType.AGENT,
+            file_path="src/app.py",
+            line_number=10,
+            metadata={"call_pattern": "pkg.FakeAgent"},
+        )
+        test_use = AIComponent(
+            name="FakeAgent",
+            component_type=AIComponentType.AGENT,
+            file_path="tests/test_app.py",
+            line_number=5,
+            metadata={"call_pattern": "pkg.FakeAgent"},
+        )
+
+        result = _propagate_removals(
+            sent=[prod, test_use],
+            received=[test_use],
+            pre_fanout_removed_ids={prod.instance_id},
+        )
+
+        assert result == [], (
+            "a production-scope removal must cascade to the test-scope "
+            f"sibling; got kept: {[(c.name, c.file_path) for c in result]}"
+        )
+
+    def test_test_removal_still_cascades_to_other_test_sibling(self):
+        """A test-scope removal still cascades to *other test-scope* siblings
+        (one rejection is enough for test scaffolding), just not to
+        production."""
+        from aibom.scan_pipeline import _propagate_removals
+
+        test_a = AIComponent(
+            name="agentsec.protect",
+            component_type=AIComponentType.GUARDRAIL,
+            file_path="tests/unit/test_a.py",
+            line_number=10,
+            metadata={"call_pattern": "aidefense.runtime.agentsec.protect"},
+        )
+        test_b = AIComponent(
+            name="agentsec.protect",
+            component_type=AIComponentType.GUARDRAIL,
+            file_path="tests/unit/test_b.py",
+            line_number=20,
+            metadata={"call_pattern": "aidefense.runtime.agentsec.protect"},
+        )
+
+        result = _propagate_removals(
+            sent=[test_a, test_b],
+            received=[test_b],
+            pre_fanout_removed_ids={test_a.instance_id},
+        )
+
+        assert result == [], (
+            "a test-scope removal should cascade to other test-scope "
+            f"siblings; got kept: {[(c.name, c.file_path) for c in result]}"
+        )
+
+    def test_test_file_import_only_removal_does_not_kill_production_import(self):
+        """A removed *test-file* import-only line must not cascade to a
+        *production* import-only sibling.
+
+        Removal reach is the intersection of evidence-strength (import-only →
+        only other imports) AND scope (test → only other test files). A
+        bare ``from X import Y`` pruned in a unit test is the weakest possible
+        signal and must not delete the production import of the same symbol.
+        """
+        from aibom.scan_pipeline import _propagate_removals
+
+        test_import = AIComponent(
+            name="Agent",
+            component_type=AIComponentType.AGENT,
+            file_path="tests/unit/test_app.py",
+            line_number=2,
+            metadata={"import_statement": "from strands import Agent"},
+        )
+        prod_import = AIComponent(
+            name="Agent",
+            component_type=AIComponentType.AGENT,
+            file_path="src/app.py",
+            line_number=2,
+            metadata={"import_statement": "from strands import Agent"},
+        )
+
+        result = _propagate_removals(
+            sent=[test_import, prod_import],
+            received=[prod_import],
+            pre_fanout_removed_ids={test_import.instance_id},
+        )
+
+        assert prod_import.instance_id in {c.instance_id for c in result}, (
+            "production import-only sibling must survive when only a "
+            "test-file import-only line was removed; got kept: "
+            f"{[(c.name, c.file_path) for c in result]}"
+        )
+
+    def test_production_import_only_removal_still_cascades_to_all_imports(self):
+        """Guard: a *production* import-only removal still cascades to all
+        import-only siblings (the original strands weak-cascade), test or
+        production."""
+        from aibom.scan_pipeline import _propagate_removals
+
+        prod_import = AIComponent(
+            name="Agent",
+            component_type=AIComponentType.AGENT,
+            file_path="src/a.py",
+            line_number=2,
+            metadata={"import_statement": "from strands import Agent"},
+        )
+        other_import = AIComponent(
+            name="Agent",
+            component_type=AIComponentType.AGENT,
+            file_path="src/b.py",
+            line_number=3,
+            metadata={"import_statement": "from strands import Agent"},
+        )
+
+        result = _propagate_removals(
+            sent=[prod_import, other_import],
+            received=[other_import],
+            pre_fanout_removed_ids={prod_import.instance_id},
+        )
+
+        assert result == [], (
+            "a production import-only removal should still cascade to other "
+            f"import-only siblings; got kept: {[c.file_path for c in result]}"
+        )
+
 
 class TestProtectedDependencies:
     """Recognized AI dependencies are deterministic manifest facts and must

--- a/aibom/tests/test_scan_pipeline.py
+++ b/aibom/tests/test_scan_pipeline.py
@@ -33,14 +33,10 @@ class TestScanPipeline:
         (tmp_path / "values.yaml").write_text(
             "inference:\n  model: some-custom-thing\n"
         )
-        pipeline_relaxed = ScanPipeline(
-            scan_paths=[str(tmp_path)], strict=False
-        )
+        pipeline_relaxed = ScanPipeline(scan_paths=[str(tmp_path)], strict=False)
         result_relaxed = pipeline_relaxed.run()
 
-        pipeline_strict = ScanPipeline(
-            scan_paths=[str(tmp_path)], strict=True
-        )
+        pipeline_strict = ScanPipeline(scan_paths=[str(tmp_path)], strict=True)
         result_strict = pipeline_strict.run()
 
         agentic_relaxed = [c for c in result_relaxed.components if c.needs_agentic]
@@ -53,23 +49,18 @@ class TestScanPipeline:
         """EnvVarResolver + cross-ref should wire env vars to config values."""
         (tmp_path / ".env").write_text("LLM_MODEL=gpt-4o\n")
         (tmp_path / "app.py").write_text(
-            'import os\nfrom openai import OpenAI\n'
-            'client = OpenAI()\n'
-            'resp = client.chat.completions.create(\n'
+            "import os\nfrom openai import OpenAI\n"
+            "client = OpenAI()\n"
+            "resp = client.chat.completions.create(\n"
             '    model=os.getenv("LLM_MODEL"),\n'
-            '    messages=[]\n'
-            ')\n'
+            "    messages=[]\n"
+            ")\n"
         )
         pipeline = ScanPipeline(scan_paths=[str(tmp_path)])
         result = pipeline.run()
 
-        env_comps = [
-            c for c in result.components if c.name.startswith("env:")
-        ]
-        resolved = [
-            c for c in env_comps
-            if c.model_name and c.model_name == "gpt-4o"
-        ]
+        env_comps = [c for c in result.components if c.name.startswith("env:")]
+        resolved = [c for c in env_comps if c.model_name and c.model_name == "gpt-4o"]
         if env_comps:
             assert any(
                 c.metadata.get("resolved_value") == "gpt-4o" or c.model_name == "gpt-4o"
@@ -124,7 +115,9 @@ class TestPipelineTiming:
         scan_timing = next(t for t in result.timings if t.name == "scan")
         assert "file cache" in scan_timing.detail
 
-    def test_progress_callback_receives_stage_and_scanner_events(self, tmp_path: Path) -> None:
+    def test_progress_callback_receives_stage_and_scanner_events(
+        self, tmp_path: Path
+    ) -> None:
         (tmp_path / "app.py").write_text("import openai\n")
         events: list[dict[str, object]] = []
         result = ScanPipeline(
@@ -139,9 +132,7 @@ class TestPipelineTiming:
         assert "scanner_completed" in event_names
         assert event_names[-1] == "stage_completed"
         stage_names = [
-            str(event["stage"])
-            for event in events
-            if event["event"] == "stage_started"
+            str(event["stage"]) for event in events if event["event"] == "stage_started"
         ]
         assert stage_names == ["scan", "cross_ref", "agentic", "assemble"]
 
@@ -232,15 +223,13 @@ class TestResolveComponentsProvenance:
         """Resolved env vars should carry provenance in metadata."""
         (tmp_path / ".env").write_text("MODEL_VAR=gpt-4o\n")
         (tmp_path / "main.py").write_text(
-            'import os\n'
-            'model=os.getenv("MODEL_VAR")\n'
+            "import os\n" 'model=os.getenv("MODEL_VAR")\n'
         )
         pipeline = ScanPipeline(scan_paths=[str(tmp_path)])
         result = pipeline.run()
 
         env_comps = [
-            c for c in result.components
-            if c.metadata.get("env") == "MODEL_VAR"
+            c for c in result.components if c.metadata.get("env") == "MODEL_VAR"
         ]
         for c in env_comps:
             if c.metadata.get("resolved_from"):
@@ -255,9 +244,24 @@ class TestDedupForAgentic:
         from aibom.scan_pipeline import _dedup_for_agentic
 
         comps = [
-            AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="a/req.txt", line_number=1),
-            AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="b/req.txt", line_number=1),
-            AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="c/req.txt", line_number=1),
+            AIComponent(
+                name="torch",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="a/req.txt",
+                line_number=1,
+            ),
+            AIComponent(
+                name="torch",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="b/req.txt",
+                line_number=1,
+            ),
+            AIComponent(
+                name="torch",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="c/req.txt",
+                line_number=1,
+            ),
         ]
         deduped, fanout = _dedup_for_agentic(comps)
         assert len(deduped) == 1
@@ -269,8 +273,18 @@ class TestDedupForAgentic:
         from aibom.scan_pipeline import _dedup_for_agentic
 
         comps = [
-            AIComponent(name="env:EP", component_type=AIComponentType.LLM_ENDPOINT, file_path="a.yaml", line_number=1),
-            AIComponent(name="env:EP", component_type=AIComponentType.LLM_ENDPOINT, file_path="b.yaml", line_number=5),
+            AIComponent(
+                name="env:EP",
+                component_type=AIComponentType.LLM_ENDPOINT,
+                file_path="a.yaml",
+                line_number=1,
+            ),
+            AIComponent(
+                name="env:EP",
+                component_type=AIComponentType.LLM_ENDPOINT,
+                file_path="b.yaml",
+                line_number=5,
+            ),
         ]
         deduped, fanout = _dedup_for_agentic(comps)
         assert len(deduped) == 2
@@ -280,9 +294,24 @@ class TestDedupForAgentic:
         from aibom.scan_pipeline import _dedup_for_agentic
 
         comps = [
-            AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="a/req.txt", line_number=1),
-            AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="b/req.txt", line_number=1),
-            AIComponent(name="env:EP", component_type=AIComponentType.LLM_ENDPOINT, file_path="a.yaml", line_number=1),
+            AIComponent(
+                name="torch",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="a/req.txt",
+                line_number=1,
+            ),
+            AIComponent(
+                name="torch",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="b/req.txt",
+                line_number=1,
+            ),
+            AIComponent(
+                name="env:EP",
+                component_type=AIComponentType.LLM_ENDPOINT,
+                file_path="a.yaml",
+                line_number=1,
+            ),
         ]
         deduped, fanout = _dedup_for_agentic(comps)
         assert len(deduped) == 2
@@ -291,10 +320,17 @@ class TestDedupForAgentic:
     def test_picks_richest_representative(self):
         from aibom.scan_pipeline import _dedup_for_agentic
 
-        sparse = AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="a/req.txt", line_number=1)
+        sparse = AIComponent(
+            name="torch",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="a/req.txt",
+            line_number=1,
+        )
         rich = AIComponent(
-            name="torch", component_type=AIComponentType.DEPENDENCY,
-            file_path="b/req.txt", line_number=1,
+            name="torch",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="b/req.txt",
+            line_number=1,
             description="PyTorch deep learning framework",
             metadata={"version": "2.1.0", "known_ai_package": True},
         )
@@ -306,8 +342,18 @@ class TestDedupForAgentic:
         from aibom.scan_pipeline import _dedup_for_agentic
 
         comps = [
-            AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="a.txt", line_number=1),
-            AIComponent(name="tensorflow", component_type=AIComponentType.DEPENDENCY, file_path="b.txt", line_number=1),
+            AIComponent(
+                name="torch",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="a.txt",
+                line_number=1,
+            ),
+            AIComponent(
+                name="tensorflow",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="b.txt",
+                line_number=1,
+            ),
         ]
         deduped, fanout = _dedup_for_agentic(comps)
         assert len(deduped) == 2
@@ -320,11 +366,23 @@ class TestFanoutAgenticResults:
         from aibom.scan_pipeline import _dedup_for_agentic, _fanout_agentic_results
 
         comps = [
-            AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="a/req.txt", line_number=1),
-            AIComponent(name="torch", component_type=AIComponentType.DEPENDENCY, file_path="b/req.txt", line_number=1),
+            AIComponent(
+                name="torch",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="a/req.txt",
+                line_number=1,
+            ),
+            AIComponent(
+                name="torch",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="b/req.txt",
+                line_number=1,
+            ),
         ]
         deduped, fanout = _dedup_for_agentic(comps)
-        rep = deduped[0].model_copy(update={"heuristic_confidence": 0.95, "needs_agentic": False})
+        rep = deduped[0].model_copy(
+            update={"heuristic_confidence": 0.95, "needs_agentic": False}
+        )
 
         result = _fanout_agentic_results([rep], fanout)
         assert len(result) == 2
@@ -336,8 +394,18 @@ class TestFanoutAgenticResults:
         from aibom.scan_pipeline import _dedup_for_agentic, _fanout_agentic_results
 
         comps = [
-            AIComponent(name="requests", component_type=AIComponentType.DEPENDENCY, file_path="a/req.txt", line_number=1),
-            AIComponent(name="requests", component_type=AIComponentType.DEPENDENCY, file_path="b/req.txt", line_number=1),
+            AIComponent(
+                name="requests",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="a/req.txt",
+                line_number=1,
+            ),
+            AIComponent(
+                name="requests",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="b/req.txt",
+                line_number=1,
+            ),
         ]
         _, fanout = _dedup_for_agentic(comps)
         result = _fanout_agentic_results([], fanout)
@@ -347,15 +415,27 @@ class TestFanoutAgenticResults:
         from aibom.scan_pipeline import _dedup_for_agentic, _fanout_agentic_results
 
         comps = [
-            AIComponent(name="ada-ep", component_type=AIComponentType.EMBEDDING, file_path="a.yaml", line_number=1),
-            AIComponent(name="ada-ep", component_type=AIComponentType.EMBEDDING, file_path="b.yaml", line_number=5),
+            AIComponent(
+                name="ada-ep",
+                component_type=AIComponentType.EMBEDDING,
+                file_path="a.yaml",
+                line_number=1,
+            ),
+            AIComponent(
+                name="ada-ep",
+                component_type=AIComponentType.EMBEDDING,
+                file_path="b.yaml",
+                line_number=5,
+            ),
         ]
         deduped, fanout = _dedup_for_agentic(comps)
-        rep = deduped[0].model_copy(update={
-            "component_type": AIComponentType.MODEL_ENDPOINT,
-            "heuristic_confidence": 0.9,
-            "needs_agentic": False,
-        })
+        rep = deduped[0].model_copy(
+            update={
+                "component_type": AIComponentType.MODEL_ENDPOINT,
+                "heuristic_confidence": 0.9,
+                "needs_agentic": False,
+            }
+        )
 
         result = _fanout_agentic_results([rep], fanout)
         assert len(result) == 2
@@ -366,7 +446,12 @@ class TestFanoutAgenticResults:
     def test_non_fanout_components_pass_through(self):
         from aibom.scan_pipeline import _fanout_agentic_results
 
-        ep = AIComponent(name="env:EP", component_type=AIComponentType.LLM_ENDPOINT, file_path="v.yaml", line_number=1)
+        ep = AIComponent(
+            name="env:EP",
+            component_type=AIComponentType.LLM_ENDPOINT,
+            file_path="v.yaml",
+            line_number=1,
+        )
         result = _fanout_agentic_results([ep], {})
         assert len(result) == 1
         assert result[0].instance_id == ep.instance_id
@@ -549,6 +634,81 @@ class TestPropagateRemovals:
         )
 
 
+class TestProtectedDependencies:
+    """Recognized AI dependencies are deterministic manifest facts and must
+    survive the agentic stage even if the LLM omits them from its set."""
+
+    def _dep(self, name: str, path: str) -> AIComponent:
+        return AIComponent(
+            name=name,
+            component_type=AIComponentType.DEPENDENCY,
+            file_path=path,
+            line_number=1,
+            metadata={"ecosystem": "pypi", "known_ai_package": True},
+        )
+
+    def test_protected_dependency_predicate(self):
+        from aibom.scan_pipeline import _is_protected_dependency
+
+        known = self._dep("cisco-aidefense-sdk", "a/pyproject.toml")
+        assert _is_protected_dependency(known) is True
+
+        unknown_dep = AIComponent(
+            name="some-random-lib",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="a/pyproject.toml",
+            line_number=1,
+            metadata={"ecosystem": "pypi"},
+        )
+        assert _is_protected_dependency(unknown_dep) is False
+
+        model = AIComponent(
+            name="gpt-4o",
+            component_type=AIComponentType.MODEL,
+            file_path="a.yaml",
+            line_number=1,
+        )
+        assert _is_protected_dependency(model) is False
+
+    def test_agent_omission_does_not_cascade_to_dependency(self):
+        from aibom.scan_pipeline import _propagate_removals
+
+        dep = self._dep("cisco-aidefense-sdk", "a/pyproject.toml")
+        # Agent returned nothing for the dependency (omitted from its set).
+        result = _propagate_removals(
+            sent=[dep],
+            received=[],
+            all_candidates=[dep],
+            pre_fanout_removed_ids={dep.instance_id},
+        )
+        # No strong/weak key should be formed from a protected dependency.
+        assert [c.name for c in result] == []  # received was empty here
+
+    def test_dropped_sole_representative_is_reinstated(self):
+        from aibom.scan_pipeline import _reinstate_protected_dependencies
+
+        # Two manifests declare the same package; dedup keeps one
+        # representative, which the agent then dropped — fanout restored none.
+        dep_a = self._dep("cisco-aidefense-sdk", "a/pyproject.toml")
+        dep_b = self._dep("cisco-aidefense-sdk", "b/pyproject.toml")
+        # enriched lost both instances.
+        enriched: list[AIComponent] = []
+        result = _reinstate_protected_dependencies([dep_a, dep_b], enriched)
+        names = [c.name for c in result]
+        assert names.count("cisco-aidefense-sdk") == 1, (
+            "exactly one protected dependency instance should be reinstated; "
+            f"got {names}"
+        )
+
+    def test_reinstate_noop_when_dependency_survived(self):
+        from aibom.scan_pipeline import _reinstate_protected_dependencies
+
+        dep = self._dep("strands-agents", "a/pyproject.toml")
+        enriched = [dep]
+        result = _reinstate_protected_dependencies([dep], enriched)
+        assert [c.name for c in result] == ["strands-agents"]
+
+
 class TestDefaultBomScope:
     def test_stage_assemble_excludes_test_only_components(self):
         component = AIComponent(
@@ -663,8 +823,8 @@ class TestDefaultBomScope:
         assert components[0].file_path.endswith(".github/workflows/ai-review.yml")
 
     def test_run_filters_test_scope_relationships_and_risk_flags(self):
-        from aibom.models.scan import ComponentRelationship, RiskFlag
         from aibom.models.enums import RelationshipType, Severity
+        from aibom.models.scan import ComponentRelationship, RiskFlag
 
         prod = AIComponent(
             name="gpt-4o",
@@ -719,9 +879,25 @@ class TestDefaultBomScope:
         pipeline = ScanPipeline(scan_paths=["/tmp"])
 
         with (
-            patch.object(pipeline, "_stage_scan", return_value=([prod, test], [kept_rel, dropped_rel])),
-            patch.object(pipeline, "_stage_cross_ref", return_value=([prod, test], MagicMock(), MagicMock(), [])),
-            patch.object(pipeline, "_stage_agentic", return_value=([prod, test], [kept_rel, dropped_rel], [kept_flag, dropped_flag])),
+            patch.object(
+                pipeline,
+                "_stage_scan",
+                return_value=([prod, test], [kept_rel, dropped_rel]),
+            ),
+            patch.object(
+                pipeline,
+                "_stage_cross_ref",
+                return_value=([prod, test], MagicMock(), MagicMock(), []),
+            ),
+            patch.object(
+                pipeline,
+                "_stage_agentic",
+                return_value=(
+                    [prod, test],
+                    [kept_rel, dropped_rel],
+                    [kept_flag, dropped_flag],
+                ),
+            ),
         ):
             result = pipeline.run()
 
@@ -761,8 +937,8 @@ class TestDependencyPolicyScope:
         assert [c.name for c in components] == ["openai"]
 
     def test_run_keeps_name_only_agentic_relationships_for_kept_components(self):
-        from aibom.models.scan import ComponentRelationship
         from aibom.models.enums import RelationshipType
+        from aibom.models.scan import ComponentRelationship
 
         prod = AIComponent(
             name="gpt-4o",
@@ -802,9 +978,21 @@ class TestDependencyPolicyScope:
         pipeline = ScanPipeline(scan_paths=["/tmp"])
 
         with (
-            patch.object(pipeline, "_stage_scan", return_value=([prod, test], [kept_rel, dropped_rel])),
-            patch.object(pipeline, "_stage_cross_ref", return_value=([prod, test], MagicMock(), MagicMock(), [])),
-            patch.object(pipeline, "_stage_agentic", return_value=([prod, test], [kept_rel, dropped_rel], [])),
+            patch.object(
+                pipeline,
+                "_stage_scan",
+                return_value=([prod, test], [kept_rel, dropped_rel]),
+            ),
+            patch.object(
+                pipeline,
+                "_stage_cross_ref",
+                return_value=([prod, test], MagicMock(), MagicMock(), []),
+            ),
+            patch.object(
+                pipeline,
+                "_stage_agentic",
+                return_value=([prod, test], [kept_rel, dropped_rel], []),
+            ),
         ):
             result = pipeline.run()
 
@@ -842,8 +1030,7 @@ class TestSymmetricEvidenceGate:
         path.write_text(source, encoding="utf-8")
         lines = source.splitlines()
         class_start = next(
-            i + 1 for i, line in enumerate(lines)
-            if line.lstrip().startswith("class ")
+            i + 1 for i, line in enumerate(lines) if line.lstrip().startswith("class ")
         )
         return str(path), class_start, len(lines)
 
@@ -875,9 +1062,7 @@ class TestSymmetricEvidenceGate:
         )
         after = before.model_copy()
 
-        kept = _evidence_gate(
-            [before], [after], scan_paths=[str(tmp_path)]
-        )
+        kept = _evidence_gate([before], [after], scan_paths=[str(tmp_path)])
 
         assert kept == [], (
             "A structural agent emission without agent_evidence must "
@@ -898,9 +1083,7 @@ class TestSymmetricEvidenceGate:
         file_path, class_start, class_end = self._make_class_file(
             tmp_path, "traced.py", source
         )
-        snippet = "\n".join(
-            source.splitlines()[class_start - 1:class_end]
-        )
+        snippet = "\n".join(source.splitlines()[class_start - 1 : class_end])
         before = AIComponent(
             name="TracedLoop",
             component_type=AIComponentType.AGENT,
@@ -921,9 +1104,7 @@ class TestSymmetricEvidenceGate:
         )
         after = before.model_copy()
 
-        kept = _evidence_gate(
-            [before], [after], scan_paths=[str(tmp_path)]
-        )
+        kept = _evidence_gate([before], [after], scan_paths=[str(tmp_path)])
 
         assert len(kept) == 1
         assert kept[0].name == "TracedLoop"
@@ -966,26 +1147,18 @@ class TestSymmetricEvidenceGate:
         )
         after = before.model_copy()
 
-        kept = _evidence_gate(
-            [before], [after], scan_paths=[str(tmp_path)]
-        )
+        kept = _evidence_gate([before], [after], scan_paths=[str(tmp_path)])
 
         assert kept == []
 
-    def test_llm_type_flip_without_evidence_is_dropped(
-        self, tmp_path: Path
-    ) -> None:
+    def test_llm_type_flip_without_evidence_is_dropped(self, tmp_path: Path) -> None:
         """If the LLM reclassifies a non-agent component to AGENT but
         the middleware somehow failed to attach evidence, the pipeline
         gate must still drop it.
         """
         from aibom.scan_pipeline import _evidence_gate
 
-        source = (
-            "class Endpoint:\n"
-            "    def run(self, x):\n"
-            "        return x\n"
-        )
+        source = "class Endpoint:\n" "    def run(self, x):\n" "        return x\n"
         file_path, class_start, class_end = self._make_class_file(
             tmp_path, "endpoint.py", source
         )
@@ -999,15 +1172,11 @@ class TestSymmetricEvidenceGate:
             update={"component_type": AIComponentType.AGENT},
         )
 
-        kept = _evidence_gate(
-            [before], [after], scan_paths=[str(tmp_path)]
-        )
+        kept = _evidence_gate([before], [after], scan_paths=[str(tmp_path)])
 
         assert kept == []
 
-    def test_kb_agent_without_structural_marker_is_kept(
-        self, tmp_path: Path
-    ) -> None:
+    def test_kb_agent_without_structural_marker_is_kept(self, tmp_path: Path) -> None:
         """An AGENT that did not come from the structural scanner and
         was not reclassified by the LLM (type did not change) is left
         alone by the symmetric gate — its authority comes from whichever
@@ -1028,9 +1197,7 @@ class TestSymmetricEvidenceGate:
         )
         after = before.model_copy()
 
-        kept = _evidence_gate(
-            [before], [after], scan_paths=[str(tmp_path)]
-        )
+        kept = _evidence_gate([before], [after], scan_paths=[str(tmp_path)])
 
         assert len(kept) == 1
         assert kept[0].name == "FrameworkAgent"
@@ -1071,9 +1238,7 @@ class TestSymmetricEvidenceGate:
         )
         after = before.model_copy()
 
-        kept = _evidence_gate(
-            [before], [after], scan_paths=[str(tmp_path)]
-        )
+        kept = _evidence_gate([before], [after], scan_paths=[str(tmp_path)])
 
         assert kept == [], (
             "Import-only agent candidate without agent_evidence must be "
@@ -1124,9 +1289,7 @@ class TestSymmetricEvidenceGate:
             },
         )
 
-        kept = _evidence_gate(
-            [before], [after], scan_paths=[str(tmp_path)]
-        )
+        kept = _evidence_gate([before], [after], scan_paths=[str(tmp_path)])
 
         assert kept == [], (
             "Import-only status must be based on the original scanner "
@@ -1151,9 +1314,7 @@ class TestSymmetricEvidenceGate:
         file_path, class_start, class_end = self._make_class_file(
             tmp_path, "deep_agent_loop.py", source
         )
-        snippet = "\n".join(
-            source.splitlines()[class_start - 1:class_end]
-        )
+        snippet = "\n".join(source.splitlines()[class_start - 1 : class_end])
         before = AIComponent(
             name="DeepAgentLoop",
             component_type=AIComponentType.AGENT,
@@ -1162,9 +1323,7 @@ class TestSymmetricEvidenceGate:
             framework="kb_enrichment",
             heuristic_confidence=0.35,
             metadata={
-                "import_statement": (
-                    "from local.deep import DeepAgentLoop"
-                ),
+                "import_statement": ("from local.deep import DeepAgentLoop"),
                 "agent_evidence": {
                     "pattern": "react_loop",
                     "definition_file": file_path,
@@ -1177,9 +1336,7 @@ class TestSymmetricEvidenceGate:
         )
         after = before.model_copy()
 
-        kept = _evidence_gate(
-            [before], [after], scan_paths=[str(tmp_path)]
-        )
+        kept = _evidence_gate([before], [after], scan_paths=[str(tmp_path)])
 
         assert len(kept) == 1
         assert kept[0].name == "DeepAgentLoop"
@@ -1345,27 +1502,26 @@ class TestPipelineEnvPrefixInvariant:
 
     _FORBIDDEN_PREFIXES = ("env_model_", "env_embedding_", "dockerfile_env_")
 
-    def test_dotenv_model_does_not_leak_env_prefix(
-        self, tmp_path: Path
-    ) -> None:
+    def test_dotenv_model_does_not_leak_env_prefix(self, tmp_path: Path) -> None:
         (tmp_path / ".env").write_text(
             "ANTHROPIC_MODEL=claude-sonnet-4-20250514\n"
             "EMBED_MODEL=text-embedding-3-large\n"
         )
         (tmp_path / "app.py").write_text(
-            'import os\nfrom anthropic import Anthropic\n'
-            'client = Anthropic()\n'
-            'resp = client.messages.create(\n'
+            "import os\nfrom anthropic import Anthropic\n"
+            "client = Anthropic()\n"
+            "resp = client.messages.create(\n"
             '    model=os.getenv("ANTHROPIC_MODEL"),\n'
-            '    messages=[]\n'
-            ')\n'
+            "    messages=[]\n"
+            ")\n"
         )
         pipeline = ScanPipeline(scan_paths=[str(tmp_path)])
         result = pipeline.run()
 
         for c in result.components:
             if c.component_type not in (
-                AIComponentType.MODEL, AIComponentType.EMBEDDING,
+                AIComponentType.MODEL,
+                AIComponentType.EMBEDDING,
             ):
                 continue
             if not (isinstance(c.model_name, str) and c.model_name):
@@ -1376,20 +1532,19 @@ class TestPipelineEnvPrefixInvariant:
                     f"name={c.name!r}, model_name={c.model_name!r}"
                 )
 
-    def test_dockerfile_env_model_does_not_leak_prefix(
-        self, tmp_path: Path
-    ) -> None:
+    def test_dockerfile_env_model_does_not_leak_prefix(self, tmp_path: Path) -> None:
         (tmp_path / "Dockerfile").write_text(
             "FROM python:3.11-slim\n"
             "ENV OPENAI_MODEL=gpt-4o\n"
-            "CMD [\"python\", \"app.py\"]\n"
+            'CMD ["python", "app.py"]\n'
         )
         pipeline = ScanPipeline(scan_paths=[str(tmp_path)])
         result = pipeline.run()
 
         for c in result.components:
             if c.component_type not in (
-                AIComponentType.MODEL, AIComponentType.EMBEDDING,
+                AIComponentType.MODEL,
+                AIComponentType.EMBEDDING,
             ):
                 continue
             if not (isinstance(c.model_name, str) and c.model_name):

--- a/aibom/tests/test_source_attribution.py
+++ b/aibom/tests/test_source_attribution.py
@@ -27,6 +27,9 @@ from aibom.source_attribution import (
     SOURCE_KIND_LOCAL_PATH,
     canonicalize_image_ref,
     canonicalize_source_ref,
+    capture_git_head_sha,
+    capture_git_remote,
+    capture_source_ref_version,
     detect_source_kind,
 )
 
@@ -46,6 +49,19 @@ def _init_repo(path: Path) -> None:
     _git("init", cwd=path)
     _git("config", "user.email", "dev@example.com", cwd=path)
     _git("config", "user.name", "Dev", cwd=path)
+
+
+def _commit(path: Path) -> str:
+    (path / "README.md").write_text("hello\n", encoding="utf-8")
+    _git("add", "README.md", cwd=path)
+    _git("commit", "-m", "initial", cwd=path)
+    result = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
 
 
 class TestDetectSourceKind:
@@ -151,3 +167,71 @@ class TestCanonicalizeImageRef:
             canonicalize_source_ref("redis:7", SOURCE_KIND_CONTAINER_IMAGE)
             == "docker.io/library/redis"
         )
+
+
+class TestCaptureSourceRefVersion:
+    def test_git_head_sha_captured(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        expected = _commit(tmp_path)
+        sha = capture_git_head_sha(str(tmp_path))
+        assert sha == expected
+        assert len(sha) == 40  # full SHA, not abbreviated
+
+    def test_capture_version_git(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        expected = _commit(tmp_path)
+        version = capture_source_ref_version(str(tmp_path), SOURCE_KIND_GIT)
+        assert version == expected
+
+    def test_capture_version_container_uses_digest(self) -> None:
+        digest = "sha256:" + "b" * 64
+        version = capture_source_ref_version(
+            "my-app:latest",
+            SOURCE_KIND_CONTAINER_IMAGE,
+            image_digest=digest,
+        )
+        assert version == digest
+
+    def test_capture_version_container_without_digest_is_none(self) -> None:
+        assert (
+            capture_source_ref_version("my-app:latest", SOURCE_KIND_CONTAINER_IMAGE)
+            is None
+        )
+
+    def test_no_commits_returns_none(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)  # no commit yet
+        assert capture_git_head_sha(str(tmp_path)) is None
+
+    def test_local_path_has_no_version(self, tmp_path: Path) -> None:
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        assert capture_source_ref_version(str(plain), SOURCE_KIND_LOCAL_PATH) is None
+
+
+class TestCaptureGitRemote:
+    def test_origin_remote_captured(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        _git(
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:org/repo.git",
+            cwd=tmp_path,
+        )
+        assert capture_git_remote(str(tmp_path)) == "git@github.com:org/repo.git"
+
+    def test_no_remote_returns_none(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        assert capture_git_remote(str(tmp_path)) is None
+
+    def test_captured_remote_canonicalizes(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        _git(
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/org/repo.git",
+            cwd=tmp_path,
+        )
+        remote = capture_git_remote(str(tmp_path))
+        assert canonicalize_source_ref(remote, SOURCE_KIND_GIT) == "github.com/org/repo"

--- a/aibom/tests/test_source_attribution.py
+++ b/aibom/tests/test_source_attribution.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from aibom.source_attribution import (
+    SOURCE_KIND_CONTAINER_IMAGE,
+    SOURCE_KIND_GIT,
+    SOURCE_KIND_LOCAL_PATH,
+    detect_source_kind,
+)
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git("init", cwd=path)
+    _git("config", "user.email", "dev@example.com", cwd=path)
+    _git("config", "user.name", "Dev", cwd=path)
+
+
+class TestDetectSourceKind:
+    def test_git_working_tree_is_git(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        assert detect_source_kind(str(tmp_path)) == SOURCE_KIND_GIT
+
+    def test_nested_dir_in_git_tree_is_git(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        nested = tmp_path / "pkg" / "sub"
+        nested.mkdir(parents=True)
+        assert detect_source_kind(str(nested)) == SOURCE_KIND_GIT
+
+    def test_plain_directory_is_local_path(self, tmp_path: Path) -> None:
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        assert detect_source_kind(str(plain)) == SOURCE_KIND_LOCAL_PATH
+
+    def test_container_image_flag_short_circuits(self, tmp_path: Path) -> None:
+        assert (
+            detect_source_kind("my-app:latest", is_container_image=True)
+            == SOURCE_KIND_CONTAINER_IMAGE
+        )
+
+    def test_nonexistent_path_is_local_path(self) -> None:
+        assert detect_source_kind("/no/such/path/here") == SOURCE_KIND_LOCAL_PATH
+
+    def test_detection_is_deterministic(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        first = detect_source_kind(str(tmp_path))
+        second = detect_source_kind(str(tmp_path))
+        assert first == second == SOURCE_KIND_GIT

--- a/aibom/tests/test_source_attribution.py
+++ b/aibom/tests/test_source_attribution.py
@@ -19,10 +19,14 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from aibom.source_attribution import (
     SOURCE_KIND_CONTAINER_IMAGE,
     SOURCE_KIND_GIT,
     SOURCE_KIND_LOCAL_PATH,
+    canonicalize_image_ref,
+    canonicalize_source_ref,
     detect_source_kind,
 )
 
@@ -74,3 +78,76 @@ class TestDetectSourceKind:
         first = detect_source_kind(str(tmp_path))
         second = detect_source_kind(str(tmp_path))
         assert first == second == SOURCE_KIND_GIT
+
+
+class TestCanonicalizeGitRemote:
+    # Every spelling of the same repo must collapse to one identical string.
+    EQUIVALENT = [
+        "git@github.com:org/repo.git",
+        "git@github.com:org/repo",
+        "https://github.com/org/repo",
+        "https://github.com/org/repo.git",
+        "https://github.com/org/repo/",
+        "https://user:token@github.com/org/repo.git",
+        "ssh://git@github.com/org/repo.git",
+        "https://GitHub.com/org/repo.git",
+        "git://github.com/org/repo.git",
+    ]
+
+    @pytest.mark.parametrize("remote", EQUIVALENT)
+    def test_all_spellings_collapse(self, remote: str) -> None:
+        assert canonicalize_source_ref(remote, SOURCE_KIND_GIT) == "github.com/org/repo"
+
+    def test_one_identical_string_across_set(self) -> None:
+        results = {canonicalize_source_ref(r, SOURCE_KIND_GIT) for r in self.EQUIVALENT}
+        assert results == {"github.com/org/repo"}
+
+    def test_path_case_preserved_host_lowered(self) -> None:
+        # Host lowercased; path stays case-sensitive (org/repo can be mixed).
+        assert (
+            canonicalize_source_ref("https://GitLab.com/Org/Repo.git", SOURCE_KIND_GIT)
+            == "gitlab.com/Org/Repo"
+        )
+
+    def test_self_hosted_with_port(self) -> None:
+        assert (
+            canonicalize_source_ref(
+                "https://git.internal.example:8443/team/svc.git",
+                SOURCE_KIND_GIT,
+            )
+            == "git.internal.example/team/svc"
+        )
+
+    def test_empty_returns_empty(self) -> None:
+        assert canonicalize_source_ref("", SOURCE_KIND_GIT) == ""
+
+
+class TestCanonicalizeImageRef:
+    def test_tag_stripped_and_hub_defaults(self) -> None:
+        assert canonicalize_image_ref("redis:7") == "docker.io/library/redis"
+
+    def test_namespaced_hub_image(self) -> None:
+        assert (
+            canonicalize_image_ref("bitnami/redis:latest") == "docker.io/bitnami/redis"
+        )
+
+    def test_digest_stripped(self) -> None:
+        assert (
+            canonicalize_image_ref("ghcr.io/org/app@sha256:" + "a" * 64)
+            == "ghcr.io/org/app"
+        )
+
+    def test_registry_with_port(self) -> None:
+        assert (
+            canonicalize_image_ref("registry.example.com:5000/team/app:v1.2")
+            == "registry.example.com:5000/team/app"
+        )
+
+    def test_uppercase_registry_lowered(self) -> None:
+        assert canonicalize_image_ref("GHCR.io/Org/App:latest") == "ghcr.io/Org/App"
+
+    def test_via_canonicalize_source_ref(self) -> None:
+        assert (
+            canonicalize_source_ref("redis:7", SOURCE_KIND_CONTAINER_IMAGE)
+            == "docker.io/library/redis"
+        )

--- a/aibom/tests/test_source_attribution_e2e.py
+++ b/aibom/tests/test_source_attribution_e2e.py
@@ -1,0 +1,154 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end source-attribution test.
+
+Exercises the full attribution path the way a downstream backend consumes it:
+scan a real git working tree, render the BOM JSON through the production
+reporter, and assert that the emitted ``metadata`` block carries the same
+``(source_kind, source_ref_canonical, source_ref_version)`` the CLI computed —
+and that those values, which a backend hashes into a stable per-asset identity,
+are identical across a repeat scan of the same source (no duplicate asset).
+
+The staging ingestion backend that projects assets lives outside this repo, so
+the "projection triple match" is asserted here against the BOM the backend
+would ingest, and identity stability is asserted by re-rendering the same
+source and comparing the triple byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from io import StringIO
+from pathlib import Path
+
+from aibom.models import AIComponent, AIComponentType, ScanResult, SourceResult
+from aibom.reporters import JsonReporter
+from aibom.source_attribution import (
+    canonicalize_source_ref,
+    capture_source_ref_version,
+)
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _make_repo(path: Path) -> str:
+    """Create a git working tree with an origin remote and one commit."""
+    path.mkdir(parents=True, exist_ok=True)
+    _git("init", cwd=path)
+    _git("config", "user.email", "dev@example.com", cwd=path)
+    _git("config", "user.name", "Dev", cwd=path)
+    _git("remote", "add", "origin", "https://github.com/example-org/svc.git", cwd=path)
+    (path / "agent.py").write_text(
+        "from langgraph.prebuilt import create_react_agent\n"
+        "agent = create_react_agent(model=llm, tools=tools)\n",
+        encoding="utf-8",
+    )
+    _git("add", "agent.py", cwd=path)
+    _git("commit", "-m", "initial", cwd=path)
+    out = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip()
+
+
+def _scan_result_for(path: str) -> ScanResult:
+    # A minimal but realistic single-source result; the reporter derives the
+    # attribution block from the path on disk.
+    comp = AIComponent(
+        name="agent",
+        component_type=AIComponentType.AGENT,
+        file_path=str(Path(path) / "agent.py"),
+        line_number=2,
+        framework="langgraph",
+    )
+    return ScanResult(
+        metadata={"analyzer_version": "test", "run_id": "e2e-001"},
+        sources=[SourceResult(path=path, components=[comp], relationships=[])],
+    )
+
+
+def _render_triple(path: str) -> dict:
+    buf = StringIO()
+    JsonReporter().render(_scan_result_for(path), buf)
+    data = json.loads(buf.getvalue())
+    src = next(iter(data["aibom_analysis"]["sources"].values()))
+    return src["metadata"]
+
+
+class TestSourceAttributionEndToEnd:
+    def test_emitted_triple_matches_computed_values(self, tmp_path: Path) -> None:
+        head = _make_repo(tmp_path)
+
+        meta = _render_triple(str(tmp_path))
+
+        # The BOM the backend ingests carries the attribution the CLI computed.
+        assert meta["source_kind"] == "git"
+        assert meta["source_ref_canonical"] == canonicalize_source_ref(
+            "https://github.com/example-org/svc.git", "git"
+        )
+        assert meta["source_ref_canonical"] == "github.com/example-org/svc"
+        assert meta["source_ref_version"] == head
+        assert meta["source_ref_version"] == capture_source_ref_version(
+            str(tmp_path), "git"
+        )
+
+    def test_identity_triple_stable_across_repeat_scan(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+
+        first = _render_triple(str(tmp_path))
+        second = _render_triple(str(tmp_path))
+
+        # The identity-bearing fields must be byte-for-byte identical across a
+        # repeat scan of the same source so the backend de-duplicates the asset.
+        identity_keys = ("source_kind", "source_ref_canonical", "source_ref_version")
+        assert {k: first[k] for k in identity_keys} == {
+            k: second[k] for k in identity_keys
+        }
+
+    def test_two_distinct_repos_have_distinct_canonical_refs(
+        self, tmp_path: Path
+    ) -> None:
+        repo_a = tmp_path / "a"
+        repo_b = tmp_path / "b"
+        _make_repo(repo_a)
+        repo_b.mkdir()
+        _git("init", cwd=repo_b)
+        _git("config", "user.email", "dev@example.com", cwd=repo_b)
+        _git("config", "user.name", "Dev", cwd=repo_b)
+        _git(
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:example-org/other.git",
+            cwd=repo_b,
+        )
+        (repo_b / "f.py").write_text("x = 1\n", encoding="utf-8")
+        _git("add", "f.py", cwd=repo_b)
+        _git("commit", "-m", "init", cwd=repo_b)
+
+        meta_a = _render_triple(str(repo_a))
+        meta_b = _render_triple(str(repo_b))
+
+        assert meta_a["source_ref_canonical"] == "github.com/example-org/svc"
+        assert meta_b["source_ref_canonical"] == "github.com/example-org/other"
+        assert meta_a["source_ref_canonical"] != meta_b["source_ref_canonical"]


### PR DESCRIPTION
## Summary

This PR broadens what the AI BOM scanner detects and adds **source attribution** so every component records where it came from. It also hardens the agentic enrichment stage against hangs and fixes several pipeline correctness bugs.

No new runtime dependencies. All changes are additive or corrective; existing report consumers continue to work.

## What's included

### Component coverage
- **MCP clients** — detect Streamable-HTTP, SSE, and stdio transports, plus Google ADK toolsets.
- **Agents** — detect LangGraph `create_react_agent` and broaden the set of recognized agent frameworks.
- **Guardrails** — detect `agentsec.protect()` (Cisco AI Defense SDK) and broaden the guardrail-framework vocabulary.
- **Knowledge-base vocabulary** — accept an expanded concept set so guardrail, MCP, and skill assets surface in the BOM.
- Recognized AI dependencies are no longer dropped from the BOM.

### Relationships
- New `USES_AGENT` and `USES_SKILL` relationship types, with detection.
- Endpoint `instance_id`s are backfilled on agent-derived edges so relationships resolve to concrete components.

### Source attribution
- Detect `source_kind` (git working tree vs. container image).
- Canonicalize `source_ref` for git remotes and image references.
- Capture `source_ref_version` (git HEAD SHA / image digest) for reproducible identity.
- Emit a source-attribution metadata block in the BOM JSON.
- End-to-end test covering attribution and identity stability across re-scans.

### Robustness & correctness
- **Bounded agentic invocations.** Every synchronous `agent.invoke` (batch enrichment, cross-repo coordination, container-layout resolution, repo triage) now runs under a shared daemon-thread wall-clock deadline. Previously a hung model call could block the scan indefinitely at event-loop teardown; it now times out and fails open. The result cache is written atomically (temp file + rename) so an interrupted run can't leave a corrupt entry that a resume would read.
- **Reasoning-model parameters.** Reasoning-class models now receive `max_completion_tokens` (and omit a custom `temperature`) instead of `max_tokens`, which those models reject.
- **Test-vs-production classification.** Production files living under `spec/`, `testing/`, or `fixtures/` directories are no longer misclassified as test-only and dropped; test-only removals no longer cascade to production siblings.

## Testing

- Full unit suite green (**1,840 tests**); lint clean on changed files.
- Manual end-to-end scans (LLM-assisted enrichment enabled) against public repositories:
  - `cisco-ai-defense/ai-defense-python-sdk` — `examples/agentsec` (agent-framework examples)
  - `aws-samples/sample-Advanced-Strands-Agents-with-MCP`
- Verified precision/recall against a ground-truth fixture for the agent-framework examples, and confirmed bounded agentic timeouts fail open without wedging a scan.

## Compatibility

- BOM JSON gains a source-attribution metadata block and new relationship types; existing fields are unchanged.
- No new third-party dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
