### PR TITLE
chore: prepare 1.0.1 release

### DIFF
--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-aibom"
-version = "1.0.0"
+version = "1.0.1"
 description = "A tool to generate an AI BOM from source code."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/aibom/src/aibom/manifest.json
+++ b/aibom/src/aibom/manifest.json
@@ -1,8 +1,8 @@
 {
-  "analyzer_version": "1.0.0",
-  "schema_version": "1.0.0",
+  "analyzer_version": "1.0.1",
+  "schema_version": "1.0.1",
   "duckdb_sha256": "b1165384a646094aa6a4762d676f285c1c68b6d7f9367c90a129b529904a3268",
-  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.0.duckdb",
+  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.1.duckdb",
   "upload_mode": "direct",
   "max_direct_upload_mb": 25,
   "log_level": "INFO"

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "cisco-aibom"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Prepare the **1.0.1** release: bump `1.0.0 -> 1.0.1` across the three release-prep files, matching the established `chore: prepare X release` pattern (e.g. #43 for 1.0.0).

## Changes

| File | Change |
|------|--------|
| `aibom/pyproject.toml` | `version = "1.0.0"` → `"1.0.1"` |
| `aibom/src/aibom/manifest.json` | `analyzer_version` + `schema_version` → `1.0.1`; `duckdb_file` → `aibom_catalog-1.0.1.duckdb` |
| `aibom/uv.lock` | `cisco-aibom` package `version` → `1.0.1` (re-locked via `uv version`) |

`duckdb_sha256` is **unchanged** (`b1165384…`) — the DuckDB catalog content is identical to 1.0.0; only the version-stamped filename moves. No dependency pins changed this release, so `uv.lock` carries only the package version bump.

README needs no change (it uses a `${VERSION}` placeholder in the kb-download snippet).

## Verification

- `uv version 1.0.1` for the canonical pyproject + lockfile bump; `manifest.json` edited manually (uv doesn't manage it)
- `uv lock --check` → clean (222 packages, no relock needed)
- `uv run pytest` → **1840 passed**, 0 failed
- No test asserts against the shipped manifest version (all use injected/temp values)

## Out of scope (done at tag time, not in this PR)

Tagging `1.0.1` and publishing the GitHub release with the `aibom_catalog-1.0.1.duckdb` asset (a version-named copy of the existing 1.0.0 catalog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
