### PR TITLE
fix(cli): fan out upload to one request per scanned source

### DIFF
--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-aibom"
-version = "1.0.1"
+version = "1.0.2"
 description = "A tool to generate an AI BOM from source code."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -884,6 +884,91 @@ def _build_submission_payload(
     }
 
 
+def _attribution_from_source_entry(entry: Dict[str, Any]) -> Optional[Dict[str, str]]:
+    """Return the request-level ``source_attribution`` triple for one source.
+
+    The triple is read from the per-source ``metadata`` block embedded by the
+    JSON reporter (computed there by ``_source_attribution``). Returns ``None``
+    when the source cannot be attributed — a plain local path, a detached
+    tarball, or a git tree with no remote — so the caller uploads it without
+    attribution rather than crashing. The backend needs all three fields to
+    project an asset, so every field must be present.
+    """
+    from .source_attribution import (
+        SOURCE_KIND_CONTAINER_IMAGE,
+        SOURCE_KIND_GIT,
+    )
+
+    meta = entry.get("metadata", {}) if isinstance(entry.get("metadata"), dict) else {}
+    source_kind = meta.get("source_kind")
+    canonical = meta.get("source_ref_canonical")
+    version = meta.get("source_ref_version")
+    if source_kind not in (SOURCE_KIND_GIT, SOURCE_KIND_CONTAINER_IMAGE):
+        return None
+    if not canonical or not version:
+        return None
+    return {
+        "source_kind": source_kind,
+        "source_ref_canonical": canonical,
+        "source_ref_version": version,
+    }
+
+
+def _scope_report_to_source(
+    report: Dict[str, Any],
+    source_key: str,
+    entry: Dict[str, Any],
+    run_id: Optional[str],
+) -> Dict[str, Any]:
+    """Build a copy of *report* whose sources are scoped to a single source.
+
+    The backend's model is one upload = one source scope, so each fanned-out
+    upload carries only its own source and a distinct ``run_id`` (the backend
+    idempotency key is ``(tenant_id, run_id)``; reusing one across sources
+    would collapse them into a single ingest).
+    """
+    analysis = report.get("aibom_analysis", {})
+    scoped_analysis = dict(analysis)
+    scoped_metadata = dict(analysis.get("metadata", {}))
+    scoped_metadata["run_id"] = run_id
+    scoped_analysis["metadata"] = scoped_metadata
+    scoped_analysis["sources"] = {source_key: entry}
+    return {"aibom_analysis": scoped_analysis}
+
+
+def _build_submission_payloads(
+    report: Dict[str, Any],
+    source_outcomes: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> List[Dict[str, Any]]:
+    """Fan out an upload to one submission per scanned source.
+
+    The backend creates one asset projection per ingest, where one ingest = one
+    repo/image. A multi-source scan (``--discover-repos``/``--github-org``)
+    therefore needs one upload per source, each carrying that source's own
+    ``source_attribution`` triple and a distinct ``run_id``. A single-source
+    scan still produces exactly one upload.
+    """
+    analysis = report.get("aibom_analysis", {})
+    sources = analysis.get("sources", {})
+    if not isinstance(sources, dict) or not sources:
+        # No per-source breakdown (e.g. a legacy report); fall back to a single
+        # combined submission so the upload still happens.
+        return [_build_submission_payload(report, source_outcomes)]
+
+    base_run_id = analysis.get("metadata", {}).get("run_id")
+    total = len(sources)
+    payloads: List[Dict[str, Any]] = []
+    for index, (source_key, entry) in enumerate(sources.items()):
+        run_id = base_run_id if total <= 1 else f"{base_run_id}-{index}"
+        scoped_report = _scope_report_to_source(report, source_key, entry, run_id)
+        payload = _build_submission_payload(scoped_report)
+        attribution = _attribution_from_source_entry(entry)
+        if attribution is not None:
+            payload["source_attribution"] = attribution
+        payloads.append(payload)
+    return payloads
+
+
 def _source_outcomes_from_report(report: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     """Reconstruct per-source submission metadata from an on-disk JSON report."""
     analysis = report.get("aibom_analysis", {})
@@ -1072,15 +1157,18 @@ def report_command(
                 "[yellow]Warning:[/] Report uses a deprecated schema without "
                 "`report_schema_version`; synthesizing the current schema for upload."
             )
-        submission_payload = _build_submission_payload(canonical_report)
-        post_report_with_retries(
-            post_url,
-            submission_payload,
-            api_key=ai_defense_api_key,
-            verify_tls=post_verify_tls,
-            timeout_seconds=post_timeout,
+        submission_payloads = _build_submission_payloads(canonical_report)
+        for submission_payload in submission_payloads:
+            post_report_with_retries(
+                post_url,
+                submission_payload,
+                api_key=ai_defense_api_key,
+                verify_tls=post_verify_tls,
+                timeout_seconds=post_timeout,
+            )
+        console.print(
+            f"[green]Uploaded {len(submission_payloads)} report(s) to {post_url}[/]"
         )
-        console.print(f"[green]Report uploaded to {post_url}[/]")
     except ValueError as exc:
         console.print(f"[red]{exc}[/]")
         raise typer.Exit(code=1)
@@ -1998,15 +2086,18 @@ def analyze(
             json_rep.render(scan_result, buf)
             report_data = json.loads(buf.getvalue())
             try:
-                submission_payload = _build_submission_payload(report_data, source_outcomes)
-                logging.info("Sending report")
-                post_report_with_retries(
-                    post_url,
-                    submission_payload,
-                    api_key=ai_defense_api_key,
-                    verify_tls=post_verify_tls,
-                    timeout_seconds=post_timeout,
+                submission_payloads = _build_submission_payloads(
+                    report_data, source_outcomes
                 )
+                logging.info("Sending %d report(s)", len(submission_payloads))
+                for submission_payload in submission_payloads:
+                    post_report_with_retries(
+                        post_url,
+                        submission_payload,
+                        api_key=ai_defense_api_key,
+                        verify_tls=post_verify_tls,
+                        timeout_seconds=post_timeout,
+                    )
                 logging.info("Report uploaded to %s", post_url)
             except Exception as exc:  # noqa: BLE001
                 logging.error("Failed to POST report: %s", exc)

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -958,8 +958,13 @@ def _build_submission_payloads(
     base_run_id = analysis.get("metadata", {}).get("run_id")
     total = len(sources)
     payloads: List[Dict[str, Any]] = []
-    for index, (source_key, entry) in enumerate(sources.items()):
-        run_id = base_run_id if total <= 1 else f"{base_run_id}-{index}"
+    for source_key, entry in sources.items():
+        # Each upload needs its own distinct run_id (the backend idempotency key
+        # is (tenant_id, run_id); a shared run_id collapses sources into one
+        # ingest). run_id is a UUID by convention, so a fan-out mints a fresh
+        # one per source rather than suffixing the base. The single-source
+        # common case keeps the original run_id untouched.
+        run_id = base_run_id if total <= 1 else str(uuid.uuid4())
         scoped_report = _scope_report_to_source(report, source_key, entry, run_id)
         payload = _build_submission_payload(scoped_report)
         attribution = _attribution_from_source_entry(entry)

--- a/aibom/src/aibom/diff.py
+++ b/aibom/src/aibom/diff.py
@@ -131,11 +131,16 @@ def load_scan_result_json(path: Path | str) -> ScanResult:
     for path_s, src in sources_raw.items():
         source_path = str(src.get("source_path") or path_s)
         summary = src.get("summary", {}) if isinstance(src, dict) else {}
+        per_source_meta = src.get("metadata", {}) if isinstance(src, dict) else {}
         source_details[source_path] = {
             "source_key": path_s,
             "source_name": src.get("source_name") or path_s,
             "source_path": source_path,
             "source_kind": summary.get("source_kind"),
+            # Preserve the attribution triple so it survives the disk round-trip
+            # (it lives in the per-source ``metadata`` block, not ``summary``).
+            "source_ref_canonical": per_source_meta.get("source_ref_canonical"),
+            "source_ref_version": per_source_meta.get("source_ref_version"),
             "status": summary.get("status"),
             "last_generated_at": summary.get("last_generated_at"),
             "assets_discovered": summary.get("assets_discovered"),

--- a/aibom/src/aibom/manifest.json
+++ b/aibom/src/aibom/manifest.json
@@ -1,8 +1,8 @@
 {
-  "analyzer_version": "1.0.1",
-  "schema_version": "1.0.1",
+  "analyzer_version": "1.0.2",
+  "schema_version": "1.0.2",
   "duckdb_sha256": "b1165384a646094aa6a4762d676f285c1c68b6d7f9367c90a129b529904a3268",
-  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.1.duckdb",
+  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.2.duckdb",
   "upload_mode": "direct",
   "max_direct_upload_mb": 25,
   "log_level": "INFO"

--- a/aibom/tests/test_cli_report.py
+++ b/aibom/tests/test_cli_report.py
@@ -137,3 +137,165 @@ def test_report_upload_rejects_non_aibom_json(tmp_path: Path):
 
     assert result.exit_code == 1
     assert "aibom_analysis" in result.output
+
+
+def _write_multi_source_report(
+    path: Path, sources_spec: list[dict], *, run_id: str = "run-123"
+) -> None:
+    """Write a report whose per-source metadata carries an attribution triple.
+
+    Injecting ``source_outcomes`` into the scan metadata lets the JSON reporter
+    embed the triple deterministically without touching git or a registry.
+    """
+    source_outcomes: dict = {}
+    sources = []
+    for spec in sources_spec:
+        sources.append(
+            SourceResult(
+                path=spec["path"],
+                components=[
+                    AIComponent(
+                        name="router_agent",
+                        component_type=AIComponentType.AGENT,
+                        file_path=spec["path"] + "/app.py",
+                        line_number=12,
+                    )
+                ],
+                relationships=[],
+            )
+        )
+        source_outcomes[spec["path"]] = {
+            "source_name": spec["name"],
+            "source_path": spec["path"],
+            "source_kind": spec["kind"],
+            "source_ref_canonical": spec["canonical"],
+            "source_ref_version": spec["version"],
+            "status": "completed",
+        }
+    result = ScanResult(
+        metadata={
+            "run_id": run_id,
+            "analyzer_version": "1.2.3",
+            "completed_at": "2026-04-11T12:00:00Z",
+            "source_outcomes": source_outcomes,
+        },
+        sources=sources,
+        risk=RiskScore(),
+        errors=[],
+    )
+    buf = StringIO()
+    JsonReporter().render(result, buf)
+    path.write_text(buf.getvalue(), encoding="utf-8")
+
+
+def _invoke_upload(report_file: Path):
+    return runner.invoke(
+        app,
+        [
+            "report",
+            "upload",
+            str(report_file),
+            "--format",
+            "json",
+            "--post-url",
+            "https://mgmt.example.test/upload",
+            "--ai-defense-api-key",
+            "tenant-key",
+        ],
+    )
+
+
+@patch("aibom.cli.post_report_with_retries")
+def test_single_git_source_uploads_once_with_full_triple(mock_post, tmp_path: Path):
+    report_file = tmp_path / "report.json"
+    _write_multi_source_report(
+        report_file,
+        [
+            {
+                "path": "/repo/service-a",
+                "name": "org/service-a",
+                "kind": "git",
+                "canonical": "github.com/org/service-a",
+                "version": "abc123",
+            }
+        ],
+    )
+
+    result = _invoke_upload(report_file)
+
+    assert result.exit_code == 0, result.output
+    assert mock_post.call_count == 1
+    payload = mock_post.call_args.args[1]
+    assert payload["run_id"] == "run-123"
+    assert payload["source_attribution"] == {
+        "source_kind": "git",
+        "source_ref_canonical": "github.com/org/service-a",
+        "source_ref_version": "abc123",
+    }
+
+
+@patch("aibom.cli.post_report_with_retries")
+def test_two_sources_fan_out_to_two_uploads(mock_post, tmp_path: Path):
+    report_file = tmp_path / "report.json"
+    _write_multi_source_report(
+        report_file,
+        [
+            {
+                "path": "/repo/service-a",
+                "name": "org/service-a",
+                "kind": "git",
+                "canonical": "github.com/org/service-a",
+                "version": "aaa",
+            },
+            {
+                "path": "registry/app:1.0",
+                "name": "registry/app",
+                "kind": "container_image",
+                "canonical": "registry.example.com/app",
+                "version": "sha256:deadbeef",
+            },
+        ],
+    )
+
+    result = _invoke_upload(report_file)
+
+    assert result.exit_code == 0, result.output
+    assert mock_post.call_count == 2
+    payloads = [call.args[1] for call in mock_post.call_args_list]
+
+    run_ids = {p["run_id"] for p in payloads}
+    assert len(run_ids) == 2, f"run_ids must be distinct, got {run_ids}"
+
+    canonicals = {p["source_attribution"]["source_ref_canonical"] for p in payloads}
+    assert canonicals == {"github.com/org/service-a", "registry.example.com/app"}
+
+    kinds = {p["source_attribution"]["source_kind"] for p in payloads}
+    assert kinds == {"git", "container_image"}
+
+    # Each upload's report is scoped to exactly one source.
+    for p in payloads:
+        assert len(p["report"]["aibom_analysis"]["sources"]) == 1
+
+
+@patch("aibom.cli.post_report_with_retries")
+def test_unresolved_source_uploads_without_attribution(mock_post, tmp_path: Path):
+    report_file = tmp_path / "report.json"
+    _write_multi_source_report(
+        report_file,
+        [
+            {
+                "path": "/tmp/extracted-tarball",
+                "name": "extracted",
+                "kind": "local-path",
+                "canonical": "",
+                "version": "",
+            }
+        ],
+    )
+
+    result = _invoke_upload(report_file)
+
+    assert result.exit_code == 0, result.output
+    assert mock_post.call_count == 1
+    payload = mock_post.call_args.args[1]
+    assert "source_attribution" not in payload

--- a/aibom/tests/test_cli_report.py
+++ b/aibom/tests/test_cli_report.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import uuid
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
@@ -265,6 +266,9 @@ def test_two_sources_fan_out_to_two_uploads(mock_post, tmp_path: Path):
 
     run_ids = {p["run_id"] for p in payloads}
     assert len(run_ids) == 2, f"run_ids must be distinct, got {run_ids}"
+    # A fanned-out run_id must stay a valid UUID (the backend keys ingests on it).
+    for rid in run_ids:
+        uuid.UUID(str(rid))
 
     canonicals = {p["source_attribution"]["source_ref_canonical"] for p in payloads}
     assert canonicals == {"github.com/org/service-a", "registry.example.com/app"}

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "cisco-aibom"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Problem

Scanned components were not appearing as Inventory assets.

The backend projects a BOM into Inventory assets only when the **upload request itself** carries the source-attribution triple — `source_kind`, `source_ref_canonical`, `source_ref_version` — and its ingestion model is **one upload = one repo/image**.

The CLI computed the triple and wrote it into the BOM report *body*, but never onto the upload *request*, so the backend saw nothing and created no asset. Worse, a scan of many sources (`--discover-repos`, `--github-org`) was sent as a **single combined upload** with one request-level scope, which cannot represent N repos — so at most one source could ever project.

## Fix

Fan out the upload to **one submission per scanned source**:

- each submission's report is scoped to that single source;
- the request-level `source_attribution` is set from that source's own triple (the value already computed into the report body);
- each submission gets a **distinct `run_id`** so the backend idempotency key does not collapse multiple sources into one ingest;
- if a source's attribution can't be resolved (e.g. a detached tarball or a git tree with no remote), it uploads **without** `source_attribution` rather than crashing — it still ingests, just without projection.

A **single-source scan still produces exactly one upload** (the common case).

`run_id` is a UUID by convention (the CLI generates it as `uuid.uuid4()`), so a fan-out **mints a fresh UUID per source** rather than suffixing the base — keeping each upload both distinct and UUID-valid. The single-source case keeps its original `run_id` untouched.

This is applied at both upload call sites (`report upload` and `analyze --post-url`). The report-file load path now also preserves the attribution triple across a disk round-trip, so `report upload <file>` carries it correctly (the triple lives in the per-source `metadata` block, which the loader previously dropped).

## Tests

Added to `tests/test_cli_report.py`, exercising the real upload path:

| Scenario | Assertion |
| --- | --- |
| Single git source | one upload; request carries the full triple; `run_id` preserved |
| Two sources | two uploads; each has its own triple and a distinct, UUID-valid `run_id`; each report scoped to one source |
| Unresolved source | uploads with no `source_attribution`; no crash |

`uv run pytest tests` — **1843 passed**.

## Release

Bundles the **1.0.2** release prep: version bumped `1.0.1 → 1.0.2` in `pyproject.toml` (via `uv version`), `manifest.json` (`analyzer_version`, `schema_version`, and the version-stamped catalog filename), and `uv.lock`. The KB catalog content is unchanged, so `duckdb_sha256` is left as-is and only the filename is updated. No dependency pins changed; `uv lock --check` is clean.

> Tag and the `aibom_catalog-1.0.2.duckdb` GitHub release asset are published at tag time, after merge — not in this branch.

## Acceptance

- One upload per scanned repo/image, each request carrying its own `source_attribution`.
- Distinct, UUID-valid `run_id` per upload.
- Multi-repo scans now project every repo, not just one.
