### PR TITLE
fix: correct source-attribution projection kind and upload wire value

### DIFF
--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-aibom"
-version = "1.0.2"
+version = "1.0.3"
 description = "A tool to generate an AI BOM from source code."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -839,6 +839,27 @@ def _map_source_kind(kind: Optional[str]) -> str:
     return "SOURCE_KIND_UNSPECIFIED"
 
 
+def _map_projection_source_kind(kind: Optional[str]) -> Optional[str]:
+    """Map an internal projection source kind to the value the backend expects.
+
+    The downstream backend that projects assets expects the source kind as an
+    uppercase ``PROJECTION_SOURCE_KIND_*`` value, not the internal lowercase
+    ``git`` / ``container_image`` constant, so the kind must be mapped before
+    upload. Returns ``None`` for any kind that is not projection-eligible
+    (e.g. the analyze-only ``local-path``).
+    """
+    from .source_attribution import (
+        SOURCE_KIND_CONTAINER_IMAGE,
+        SOURCE_KIND_GIT,
+    )
+
+    if kind == SOURCE_KIND_GIT:
+        return "PROJECTION_SOURCE_KIND_GIT"
+    if kind == SOURCE_KIND_CONTAINER_IMAGE:
+        return "PROJECTION_SOURCE_KIND_CONTAINER_IMAGE"
+    return None
+
+
 def _build_submission_payload(
     report: Dict[str, Any],
     source_outcomes: Optional[Dict[str, Dict[str, Any]]] = None,
@@ -894,16 +915,11 @@ def _attribution_from_source_entry(entry: Dict[str, Any]) -> Optional[Dict[str, 
     attribution rather than crashing. The backend needs all three fields to
     project an asset, so every field must be present.
     """
-    from .source_attribution import (
-        SOURCE_KIND_CONTAINER_IMAGE,
-        SOURCE_KIND_GIT,
-    )
-
     meta = entry.get("metadata", {}) if isinstance(entry.get("metadata"), dict) else {}
-    source_kind = meta.get("source_kind")
+    source_kind = _map_projection_source_kind(meta.get("source_kind"))
     canonical = meta.get("source_ref_canonical")
     version = meta.get("source_ref_version")
-    if source_kind not in (SOURCE_KIND_GIT, SOURCE_KIND_CONTAINER_IMAGE):
+    if source_kind is None:
         return None
     if not canonical or not version:
         return None

--- a/aibom/src/aibom/manifest.json
+++ b/aibom/src/aibom/manifest.json
@@ -1,8 +1,8 @@
 {
-  "analyzer_version": "1.0.2",
-  "schema_version": "1.0.2",
+  "analyzer_version": "1.0.3",
+  "schema_version": "1.0.3",
   "duckdb_sha256": "b1165384a646094aa6a4762d676f285c1c68b6d7f9367c90a129b529904a3268",
-  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.2.duckdb",
+  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.3.duckdb",
   "upload_mode": "direct",
   "max_direct_upload_mb": 25,
   "log_level": "INFO"

--- a/aibom/src/aibom/reporters/json_reporter.py
+++ b/aibom/src/aibom/reporters/json_reporter.py
@@ -60,24 +60,36 @@ def _friendly_source_name(path: str) -> str:
 def _source_attribution(path: str, detail: dict[str, Any]) -> dict[str, str]:
     """Resolve the source-attribution triple for one scanned source.
 
-    Values supplied by the scan pipeline / cross-repo discovery (in ``detail``)
-    win, since that path may already know the resolved remote or image digest.
-    Otherwise the triple is derived deterministically from the local path:
-    ``source_kind`` from the working tree, ``source_ref_canonical`` from the
-    canonicalized ``origin`` remote, and ``source_ref_version`` from ``HEAD``.
+    The ``source_kind`` returned here is the *projection* kind (``git`` /
+    ``container_image`` / ``local-path``) a downstream backend uses to derive a
+    stable asset identity. This is a different taxonomy from the *analyze*
+    source kind the pipeline records (``git-url`` / ``container`` /
+    ``local-path``): a local git checkout is legitimately ``local-path`` for
+    analyze and ``git`` for projection. The projection kind is therefore derived
+    from the git/container reality of the source, not the analyze ``detail``
+    kind — only a ``detail`` kind that is already a valid projection kind (e.g.
+    a cross-repo source that resolved the image directly) is reused. Resolved
+    ref/version values supplied in ``detail`` still win.
     """
     from ..source_attribution import (
         SOURCE_KIND_CONTAINER_IMAGE,
+        SOURCE_KIND_GIT,
         canonicalize_source_ref,
         capture_git_remote,
         capture_source_ref_version,
         detect_source_kind,
     )
 
-    is_image = (detail.get("source_kind") == SOURCE_KIND_CONTAINER_IMAGE) or None
-    source_kind = detail.get("source_kind") or detect_source_kind(
-        path, is_container_image=is_image
-    )
+    detail_kind = detail.get("source_kind")
+    if detail_kind in (SOURCE_KIND_GIT, SOURCE_KIND_CONTAINER_IMAGE):
+        source_kind = detail_kind
+    else:
+        # ``detail_kind`` here is an analyze kind (or absent). Only the analyze
+        # ``container`` kind hints at an image; everything else is detected from
+        # the source so a local checkout is attributed as ``git`` rather than
+        # being suppressed by its ``local-path`` analyze kind.
+        is_image = (detail_kind == "container") or None
+        source_kind = detect_source_kind(path, is_container_image=is_image)
 
     canonical = detail.get("source_ref_canonical")
     if not canonical:
@@ -178,7 +190,11 @@ def _aibom_payload(
         source_key = _disambiguate_source_key(source_name, seen_source_names)
         source_path = detail.get("source_path") or src.path
         attribution = _source_attribution(src.path, detail)
-        source_kind = attribution["source_kind"]
+        # The summary keeps the analyze-side source kind (``git-url`` /
+        # ``container`` / ``local-path``); only the attribution ``metadata``
+        # block carries the projection kind. Fall back to the projection kind
+        # when the analyze kind is absent (e.g. cross-repo discovery).
+        summary_source_kind = detail.get("source_kind") or attribution["source_kind"]
         per_source_meta: dict[str, Any] = {
             "source_kind": attribution["source_kind"],
             "source_ref_canonical": attribution["source_ref_canonical"],
@@ -195,7 +211,7 @@ def _aibom_payload(
             "relationships": [r.model_dump(mode="json") for r in src.relationships],
             "summary": {
                 "status": detail.get("status") or "completed",
-                "source_kind": source_kind,
+                "source_kind": summary_source_kind,
                 "assets_discovered": detail.get("assets_discovered")
                 or total_components,
                 "last_generated_at": (

--- a/aibom/tests/test_cli_report.py
+++ b/aibom/tests/test_cli_report.py
@@ -228,8 +228,10 @@ def test_single_git_source_uploads_once_with_full_triple(mock_post, tmp_path: Pa
     assert mock_post.call_count == 1
     payload = mock_post.call_args.args[1]
     assert payload["run_id"] == "run-123"
+    # The wire value is the uppercase source-kind the backend expects, not the
+    # internal lowercase kind.
     assert payload["source_attribution"] == {
-        "source_kind": "git",
+        "source_kind": "PROJECTION_SOURCE_KIND_GIT",
         "source_ref_canonical": "github.com/org/service-a",
         "source_ref_version": "abc123",
     }
@@ -274,7 +276,10 @@ def test_two_sources_fan_out_to_two_uploads(mock_post, tmp_path: Path):
     assert canonicals == {"github.com/org/service-a", "registry.example.com/app"}
 
     kinds = {p["source_attribution"]["source_kind"] for p in payloads}
-    assert kinds == {"git", "container_image"}
+    assert kinds == {
+        "PROJECTION_SOURCE_KIND_GIT",
+        "PROJECTION_SOURCE_KIND_CONTAINER_IMAGE",
+    }
 
     # Each upload's report is scoped to exactly one source.
     for p in payloads:
@@ -303,3 +308,48 @@ def test_unresolved_source_uploads_without_attribution(mock_post, tmp_path: Path
     assert mock_post.call_count == 1
     payload = mock_post.call_args.args[1]
     assert "source_attribution" not in payload
+
+
+def test_attribution_from_source_entry_maps_projection_enum():
+    """The projection kind is sent as the uppercase value the backend expects."""
+    from aibom.cli import _attribution_from_source_entry
+
+    git = _attribution_from_source_entry(
+        {
+            "metadata": {
+                "source_kind": "git",
+                "source_ref_canonical": "github.com/org/repo",
+                "source_ref_version": "a" * 40,
+            }
+        }
+    )
+    assert git == {
+        "source_kind": "PROJECTION_SOURCE_KIND_GIT",
+        "source_ref_canonical": "github.com/org/repo",
+        "source_ref_version": "a" * 40,
+    }
+
+    image = _attribution_from_source_entry(
+        {
+            "metadata": {
+                "source_kind": "container_image",
+                "source_ref_canonical": "registry.example.com/app",
+                "source_ref_version": "sha256:deadbeef",
+            }
+        }
+    )
+    assert image["source_kind"] == "PROJECTION_SOURCE_KIND_CONTAINER_IMAGE"
+
+    # An analyze-only kind (local-path) is not projection-eligible -> omitted.
+    assert (
+        _attribution_from_source_entry(
+            {
+                "metadata": {
+                    "source_kind": "local-path",
+                    "source_ref_canonical": "",
+                    "source_ref_version": "",
+                }
+            }
+        )
+        is None
+    )

--- a/aibom/tests/test_source_attribution_e2e.py
+++ b/aibom/tests/test_source_attribution_e2e.py
@@ -152,3 +152,69 @@ class TestSourceAttributionEndToEnd:
         assert meta_a["source_ref_canonical"] == "github.com/example-org/svc"
         assert meta_b["source_ref_canonical"] == "github.com/example-org/other"
         assert meta_a["source_ref_canonical"] != meta_b["source_ref_canonical"]
+
+
+def _scan_result_with_analyze_kind(path: str, analyze_kind: str) -> ScanResult:
+    """Single-source result whose pipeline detail carries the *analyze* source
+    kind (``local-path``/``git-url``/``container``), exactly as the real CLI
+    emits it into ``source_outcomes``."""
+    comp = AIComponent(
+        name="agent",
+        component_type=AIComponentType.AGENT,
+        file_path=str(Path(path) / "agent.py"),
+        line_number=2,
+        framework="langgraph",
+    )
+    return ScanResult(
+        metadata={
+            "analyzer_version": "test",
+            "run_id": "e2e-002",
+            "source_outcomes": {
+                path: {
+                    "source_name": "svc",
+                    "source_path": path,
+                    "source_kind": analyze_kind,
+                    "status": "completed",
+                }
+            },
+        },
+        sources=[SourceResult(path=path, components=[comp], relationships=[])],
+    )
+
+
+def _render_source(path: str, analyze_kind: str) -> dict:
+    buf = StringIO()
+    JsonReporter().render(_scan_result_with_analyze_kind(path, analyze_kind), buf)
+    data = json.loads(buf.getvalue())
+    return next(iter(data["aibom_analysis"]["sources"].values()))
+
+
+class TestAnalyzeKindDoesNotSuppressProjectionKind:
+    """A local git checkout has analyze kind ``local-path`` but must still be
+    attributed as ``git`` for projection."""
+
+    def test_local_git_checkout_is_attributed_as_git(self, tmp_path: Path) -> None:
+        head = _make_repo(tmp_path)
+
+        src = _render_source(str(tmp_path), "local-path")
+        meta = src["metadata"]
+
+        # Projection attribution reflects the git reality of the source.
+        assert meta["source_kind"] == "git"
+        assert meta["source_ref_canonical"] == "github.com/example-org/svc"
+        assert meta["source_ref_version"] == head
+        # The analyze-side summary kind is intentionally left untouched.
+        assert src["summary"]["source_kind"] == "local-path"
+
+    def test_plain_dir_degrades_to_local_path_with_empty_refs(
+        self, tmp_path: Path
+    ) -> None:
+        # No ``git init`` -> a plain directory that is not a checkout.
+        (tmp_path / "agent.py").write_text("x = 1\n", encoding="utf-8")
+
+        src = _render_source(str(tmp_path), "local-path")
+        meta = src["metadata"]
+
+        assert meta["source_kind"] == "local-path"
+        assert meta["source_ref_canonical"] == ""
+        assert meta["source_ref_version"] == ""

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "cisco-aibom"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Two coupled fixes to the per-source `source_attribution` the CLI emits and uploads, plus the 1.0.3 release bump.

### 1. Attribute local git checkouts as `git` for projection
A local git working tree is analyzed as `source_kind="local-path"`, but for downstream asset projection it is a `git` source. `_source_attribution` conflated the two taxonomies: the truthy *analyze* kind (`local-path`/`git-url`) won over git detection, so the projection kind came out `local-path` with an empty `source_ref_version` and no asset projection was produced.

The projection kind is now derived from the git/container reality of the source. A supplied detail kind is reused only when it is already a valid projection kind (`git`/`container_image`); the analyze-side `summary.source_kind` is left untouched.

### 2. Send the projection `source_kind` as the value the backend expects
The CLI sent `source_attribution.source_kind` as the internal lowercase `git`/`container_image`, but the downstream backend expects the uppercase `PROJECTION_SOURCE_KIND_*` value, so valid attribution was rejected on upload. A small mapping helper now converts the kind when assembling the upload payload.

### 3. Release 1.0.3
Version bump across `pyproject.toml`, `uv.lock`, and `manifest.json` (catalog filename + schema/analyzer versions).

## Behavior

| Scan target | Before | After |
|---|---|---|
| Local git checkout | `local-path`, empty version, no attribution uploaded | `git` + canonical remote + HEAD SHA, attribution uploaded |
| Plain (non-git) directory | `local-path`, omitted | `local-path`, omitted (unchanged, graceful) |
| Uploaded `source_kind` wire value | `git` / `container_image` (rejected) | `PROJECTION_SOURCE_KIND_GIT` / `PROJECTION_SOURCE_KIND_CONTAINER_IMAGE` (accepted) |

## Testing
- New unit/e2e coverage: local git checkout yields the full `git` triple with the analyze-side summary kind preserved; a plain directory degrades gracefully (omitted); wire-value mapping verified for both projection kinds and for the non-eligible kind.
- Full suite: **1843 passed, 3 skipped**.
