### PR TITLE
fix(agentic): recover structured output from non-OpenAI-native models

### DIFF
--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -355,8 +355,10 @@ _DEFAULT_MAX_CONSECUTIVE_FAILURES = 3
 # Generous default completion budget for agentic enrichment. Set explicitly so
 # output length is governed here rather than by an OpenAI-compatible gateway's
 # (often small) default, which can truncate a verbose/reasoning model mid-output
-# and yield an empty batch. Overridable via llm_config["max_tokens"].
-_DEFAULT_AGENTIC_MAX_TOKENS = 16000
+# and yield an empty batch. This caps *output* tokens only — for reasoning
+# models the budget also covers reasoning tokens, so it is set high. Overridable
+# via llm_config["max_tokens"] (CLI: --llm-max-tokens / AIBOM_LLM_MAX_TOKENS).
+_DEFAULT_AGENTIC_MAX_TOKENS = 128000
 
 _SIMPLE_CANDIDATE_TYPES = frozenset({"model", "dependency", "embedding"})
 
@@ -1188,7 +1190,9 @@ def _run_batch(
             # parsed object, or text) instead of dropping the whole batch.
             ai_message = getattr(exc, "ai_message", None)
             if ai_message is not None:
-                data = _extract_structured_response({"messages": [ai_message]})
+                recovered = {"messages": [ai_message]}
+                _accumulate_token_usage(recovered)
+                data = _extract_structured_response(recovered)
         if data:
             _LOGGER.info(
                 "Batch %d: recovering partial results from failed run", batch_num
@@ -1322,7 +1326,9 @@ async def _run_batch_async(
             # parsed object, or text) instead of dropping the whole batch.
             ai_message = getattr(exc, "ai_message", None)
             if ai_message is not None:
-                data = _extract_structured_response({"messages": [ai_message]})
+                recovered = {"messages": [ai_message]}
+                _accumulate_token_usage(recovered)
+                data = _extract_structured_response(recovered)
         if data:
             _LOGGER.info(
                 "Batch %d: recovering partial results from failed run", batch_num
@@ -2194,12 +2200,16 @@ def _structured_from_tool_calls(message: Any) -> dict[str, Any] | None:
     tool_calls = getattr(message, "tool_calls", None)
     if not isinstance(tool_calls, list) or not tool_calls:
         return None
+    response_fields = set(AgentResponse.model_fields)
     for call in reversed(tool_calls):
         if isinstance(call, dict):
             args = call.get("args")
         else:
             args = getattr(call, "args", None)
-        if isinstance(args, dict) and args:
+        # Only treat a tool call as the structured response when its args carry
+        # AgentResponse fields. A normal tool invocation (search_codebase,
+        # lookup_model, ...) must not be misread as the agent's response.
+        if isinstance(args, dict) and (response_fields & args.keys()):
             return args
     return None
 
@@ -2300,28 +2310,35 @@ def _extract_structured_response(result: Any) -> dict[str, Any] | None:
     if not content:
         return None
     try:
-        return json.loads(content)
+        parsed = json.loads(content)
     except json.JSONDecodeError:
+        parsed = None
+    # Only a JSON object is a usable response; arrays/scalars would pass a
+    # truthy check and then break middleware's ``data.get(...)``.
+    if isinstance(parsed, dict):
+        return parsed
+    if parsed is None:
         # Best-effort: some OpenAI-compatible gateways echo character-doubled
         # content ("hheelllloo"). Re-validate via json.loads so we never accept
-        # a worse result — only an exactly-doubled payload that parses cleanly.
+        # a worse result — only an exactly-doubled payload that parses to an
+        # object.
         repaired = _dedouble_text(content)
         if repaired != content:
             try:
-                data = json.loads(repaired)
+                redone = json.loads(repaired)
             except json.JSONDecodeError:
-                data = None
-            if data is not None:
+                redone = None
+            if isinstance(redone, dict):
                 _LOGGER.info(
                     "Recovered structured output after de-doubling "
                     "gateway-corrupted content"
                 )
-                return data
-        _LOGGER.warning(
-            "Failed to parse agent JSON output — first 300 chars: %s",
-            content[:300],
-        )
-        return None
+                return redone
+    _LOGGER.warning(
+        "Failed to parse agent JSON output — first 300 chars: %s",
+        content[:300],
+    )
+    return None
 
 
 _CROSS_REPO_COORDINATOR_PROMPT = """\

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -257,6 +257,12 @@ def _build_model(
         api_key=cfg.get("api_key"),
         api_base=cfg.get("api_base"),
         api_version=cfg.get("api_version"),
+        # Pass an explicit, generous cap so a verbose/reasoning model is not
+        # truncated mid-output by a gateway's low default completion budget
+        # (which otherwise yields an empty/partial batch). Overridable via
+        # llm_config["max_tokens"].  build_chat_model maps this to
+        # max_completion_tokens for reasoning-class models.
+        max_tokens=cfg.get("max_tokens", _DEFAULT_AGENTIC_MAX_TOKENS),
         rate_limiter=rate_limiter,
     )
 
@@ -346,6 +352,12 @@ _RECURSION_LIMIT = 1000
 _DEFAULT_AGENTIC_TIMEOUT_S = 120
 _DEFAULT_MAX_CONSECUTIVE_FAILURES = 3
 
+# Generous default completion budget for agentic enrichment. Set explicitly so
+# output length is governed here rather than by an OpenAI-compatible gateway's
+# (often small) default, which can truncate a verbose/reasoning model mid-output
+# and yield an empty batch. Overridable via llm_config["max_tokens"].
+_DEFAULT_AGENTIC_MAX_TOKENS = 16000
+
 _SIMPLE_CANDIDATE_TYPES = frozenset({"model", "dependency", "embedding"})
 
 _SUB_AGENT_THRESHOLD = 50
@@ -356,8 +368,51 @@ _RETRYABLE_HINTS = frozenset(
         "batch_timeout",
         "batch_recursion_limit",
         "circuit_breaker_tripped",
+        # Transient provider-side failures — worth one retry pass.
+        "provider_outage",
+        "rate_limited",
+        "structured_output_parse_error",
     }
 )
+
+
+def _classify_failure_hint(exc: Exception) -> str:
+    """Classify a batch-invocation exception into a precise agentic hint.
+
+    Distinguishes provider outages and rate limits (HTTP status carried by
+    ``openai.APIStatusError`` and friends) and structured-output parse failures
+    (``langchain`` ``StructuredOutputValidationError`` carries an ``ai_message``)
+    from the generic recursion/unknown bucket. Uses duck-typed attributes so no
+    optional provider/agent dependency is imported.
+    """
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        if status == 429:
+            return "rate_limited"
+        if status >= 500:
+            return "provider_outage"
+    if getattr(exc, "ai_message", None) is not None:
+        return "structured_output_parse_error"
+    if type(exc).__name__ in (
+        "StructuredOutputValidationError",
+        "OutputParserException",
+    ):
+        return "structured_output_parse_error"
+    return "batch_recursion_limit"
+
+
+def _refusal_present(result: Any) -> bool:
+    """True when the final message is a model refusal with no usable content.
+
+    Providers surface refusals in ``additional_kwargs['refusal']``; aibom uses
+    this to record a distinct ``model_refused`` status instead of conflating a
+    refusal with "examined and found nothing".
+    """
+    messages = result.get("messages", []) if isinstance(result, dict) else []
+    if not messages:
+        return False
+    extra = getattr(messages[-1], "additional_kwargs", None)
+    return isinstance(extra, dict) and bool(extra.get("refusal"))
 
 
 def _collect_failed(
@@ -1123,17 +1178,26 @@ def _run_batch(
             exc,
             json.dumps(stats),
         )
+        data = None
         if result is not None:
             _accumulate_token_usage(result)
             data = _extract_structured_response(result)
-            if data:
-                _LOGGER.info(
-                    "Batch %d: recovering partial results from failed run", batch_num
-                )
-                new_c, new_r, rf = middleware.extract_findings_from_dict(data)
-                enriched = middleware.apply_enrichments_from_dict(batch, data)
-                return enriched, new_c, new_r, rf, False
-        enriched = _degraded_batch_components(batch, hint="batch_recursion_limit")
+        if not data:
+            # langchain's StructuredOutputValidationError carries the offending
+            # AIMessage; recover the answer from its carriers (tool-call args,
+            # parsed object, or text) instead of dropping the whole batch.
+            ai_message = getattr(exc, "ai_message", None)
+            if ai_message is not None:
+                data = _extract_structured_response({"messages": [ai_message]})
+        if data:
+            _LOGGER.info(
+                "Batch %d: recovering partial results from failed run", batch_num
+            )
+            new_c, new_r, rf = middleware.extract_findings_from_dict(data)
+            enriched = middleware.apply_enrichments_from_dict(batch, data)
+            return enriched, new_c, new_r, rf, False
+        hint = _classify_failure_hint(exc)
+        enriched = _degraded_batch_components(batch, hint=hint)
         return enriched, [], [], [], True
 
     _accumulate_token_usage(result)
@@ -1153,8 +1217,23 @@ def _run_batch(
 
     data = _extract_structured_response(result)
     if not data:
+        if _refusal_present(result):
+            _LOGGER.warning("Batch %d: model refused", batch_num)
+            return (
+                _degraded_batch_components(batch, hint="model_refused"),
+                [],
+                [],
+                [],
+                True,
+            )
         _LOGGER.warning("Batch %d returned no usable output", batch_num)
-        return batch, [], [], [], True
+        return (
+            _degraded_batch_components(batch, hint="no_usable_output"),
+            [],
+            [],
+            [],
+            True,
+        )
 
     new_components, new_rels, risk_flags = middleware.extract_findings_from_dict(data)
     enriched = middleware.apply_enrichments_from_dict(batch, data)
@@ -1233,17 +1312,26 @@ async def _run_batch_async(
             exc,
             json.dumps(stats),
         )
+        data = None
         if result is not None:
             _accumulate_token_usage(result)
             data = _extract_structured_response(result)
-            if data:
-                _LOGGER.info(
-                    "Batch %d: recovering partial results from failed run", batch_num
-                )
-                new_c, new_r, rf = middleware.extract_findings_from_dict(data)
-                enriched = middleware.apply_enrichments_from_dict(batch, data)
-                return enriched, new_c, new_r, rf, False
-        enriched = _degraded_batch_components(batch, hint="batch_recursion_limit")
+        if not data:
+            # langchain's StructuredOutputValidationError carries the offending
+            # AIMessage; recover the answer from its carriers (tool-call args,
+            # parsed object, or text) instead of dropping the whole batch.
+            ai_message = getattr(exc, "ai_message", None)
+            if ai_message is not None:
+                data = _extract_structured_response({"messages": [ai_message]})
+        if data:
+            _LOGGER.info(
+                "Batch %d: recovering partial results from failed run", batch_num
+            )
+            new_c, new_r, rf = middleware.extract_findings_from_dict(data)
+            enriched = middleware.apply_enrichments_from_dict(batch, data)
+            return enriched, new_c, new_r, rf, False
+        hint = _classify_failure_hint(exc)
+        enriched = _degraded_batch_components(batch, hint=hint)
         return enriched, [], [], [], True
 
     _accumulate_token_usage(result)
@@ -1263,8 +1351,23 @@ async def _run_batch_async(
 
     data = _extract_structured_response(result)
     if not data:
+        if _refusal_present(result):
+            _LOGGER.warning("Batch %d: model refused", batch_num)
+            return (
+                _degraded_batch_components(batch, hint="model_refused"),
+                [],
+                [],
+                [],
+                True,
+            )
         _LOGGER.warning("Batch %d returned no usable output", batch_num)
-        return batch, [], [], [], True
+        return (
+            _degraded_batch_components(batch, hint="no_usable_output"),
+            [],
+            [],
+            [],
+            True,
+        )
 
     new_components, new_rels, risk_flags = middleware.extract_findings_from_dict(data)
     enriched = middleware.apply_enrichments_from_dict(batch, data)
@@ -2081,12 +2184,94 @@ def _build_context_message(
     )
 
 
+def _structured_from_tool_calls(message: Any) -> dict[str, Any] | None:
+    """Return the structured object from a message's tool-call args, if any.
+
+    The ``function_calling`` structured-output method carries the answer as a
+    dict in ``tool_calls[].args``. This is uniform across LangChain providers
+    (OpenAI, Anthropic, Bedrock, Google), so reading it is provider-agnostic.
+    """
+    tool_calls = getattr(message, "tool_calls", None)
+    if not isinstance(tool_calls, list) or not tool_calls:
+        return None
+    for call in reversed(tool_calls):
+        if isinstance(call, dict):
+            args = call.get("args")
+        else:
+            args = getattr(call, "args", None)
+        if isinstance(args, dict) and args:
+            return args
+    return None
+
+
+def _structured_from_parsed(message: Any) -> dict[str, Any] | None:
+    """Return the parsed object from ``additional_kwargs['parsed']``, if any.
+
+    The ``json_schema`` structured-output method (ChatOpenAI's default)
+    deposits the parsed object here while leaving ``content`` empty.
+    """
+    extra = getattr(message, "additional_kwargs", None)
+    if not isinstance(extra, dict):
+        return None
+    parsed = extra.get("parsed")
+    if isinstance(parsed, BaseModel):
+        return parsed.model_dump()
+    if isinstance(parsed, dict):
+        return parsed
+    return None
+
+
+def _message_text(message: Any) -> str:
+    """Return the textual content of a message.
+
+    Handles both string content and list-form content blocks
+    (thinking/tool_use/text) returned by Anthropic, Bedrock, and Gemini by
+    concatenating only the ``text`` blocks — never ``str()``-coercing the whole
+    list, which would yield an unparseable Python repr.
+    """
+    if hasattr(message, "content"):
+        content = message.content
+    elif isinstance(message, dict):
+        content = message.get("content", "")
+    else:
+        return str(message)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "".join(parts)
+    return ""
+
+
+def _dedouble_text(text: str) -> str:
+    """Collapse exact character-doubling ("hheelllloo" -> "hello").
+
+    Handles only the every-character-doubled case (each character repeated once
+    consecutively); returns the input unchanged otherwise. Safe by design: the
+    caller re-validates the result with ``json.loads`` and discards it unless it
+    parses, so an inexact heuristic can never make things worse.
+    """
+    if len(text) >= 2 and len(text) % 2 == 0 and text[0::2] == text[1::2]:
+        return text[0::2]
+    return text
+
+
 def _extract_structured_response(result: Any) -> dict[str, Any] | None:
     """Extract the structured response from the agent's final state.
 
     When ``response_format`` is provided, Deep Agents populates
-    ``structured_response`` in the graph state.  Falls back to parsing
-    the last message as JSON if structured output is unavailable.
+    ``structured_response`` in the graph state.  When it does not — because the
+    model emitted the answer via a tool call, a parsed object, or list-form
+    content blocks instead of a JSON string — recover it from the last
+    message's carriers in order of reliability before falling back to JSON
+    parsing of the message text.
     """
     sr = result.get("structured_response")
     if sr is not None:
@@ -2099,20 +2284,39 @@ def _extract_structured_response(result: Any) -> dict[str, Any] | None:
     if not messages:
         return None
     last = messages[-1]
-    content = ""
-    if hasattr(last, "content"):
-        content = last.content if isinstance(last.content, str) else str(last.content)
-    elif isinstance(last, dict):
-        content = str(last.get("content", ""))
-    else:
-        content = str(last)
 
-    content = content.strip()
+    # Prefer the already-parsed carriers (no JSON parsing needed): tool-call
+    # args (function_calling), then a parsed object (json_schema).
+    from_tools = _structured_from_tool_calls(last)
+    if from_tools is not None:
+        return from_tools
+    from_parsed = _structured_from_parsed(last)
+    if from_parsed is not None:
+        return from_parsed
+
+    # Fall back to JSON embedded in the message text, concatenating text blocks
+    # for list-form content rather than str()-coercing the whole list.
+    content = _message_text(last).strip()
     if not content:
         return None
     try:
         return json.loads(content)
     except json.JSONDecodeError:
+        # Best-effort: some OpenAI-compatible gateways echo character-doubled
+        # content ("hheelllloo"). Re-validate via json.loads so we never accept
+        # a worse result — only an exactly-doubled payload that parses cleanly.
+        repaired = _dedouble_text(content)
+        if repaired != content:
+            try:
+                data = json.loads(repaired)
+            except json.JSONDecodeError:
+                data = None
+            if data is not None:
+                _LOGGER.info(
+                    "Recovered structured output after de-doubling "
+                    "gateway-corrupted content"
+                )
+                return data
         _LOGGER.warning(
             "Failed to parse agent JSON output — first 300 chars: %s",
             content[:300],

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -45,30 +45,37 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.tree import Tree
 
-from .report_sender import post_report_with_retries
-from .utils.version import resolve_package_version
-from .scanners.container_extractor import extract_source_from_image, is_container_image, VALID_TIERS, validate_tier
+from .api_handler import start_api_server
+from .cache_paths import cache_dir as resolve_cache_type_dir
 from .cache_paths import (
-    cache_dir as resolve_cache_type_dir,
     cache_read_dirs,
     cache_types,
     resolve_cache_root,
 )
-from .llm_factory import ensure_llm_runtime_available
 from .custom_catalog import (
     CustomCatalogConfig,
     load_custom_catalog,
 )
-from .api_handler import start_api_server
-from .reporters import get_reporter, reporter_registry
+from .kb.manager import KBError, KBManager
+from .llm_factory import ensure_llm_runtime_available
 from .models.enums import Severity as SeverityEnum
-from .kb.manager import KBManager, KBError
+from .report_sender import post_report_with_retries
+from .reporters import get_reporter, reporter_registry
+from .scanners.container_extractor import (
+    VALID_TIERS,
+    extract_source_from_image,
+    is_container_image,
+    validate_tier,
+)
+from .utils.version import resolve_package_version
 
 _LOGGER = logging.getLogger(__name__)
 
 console = Console()
 
-_VALID_OUTPUT_FORMATS = {"plaintext", "json", "api"} | {r.name for r in reporter_registry}
+_VALID_OUTPUT_FORMATS = {"plaintext", "json", "api"} | {
+    r.name for r in reporter_registry
+}
 
 app = typer.Typer(
     help="Generate an AI BOM from source code.",
@@ -143,12 +150,18 @@ def _print_timing_table(console: "rich.console.Console", result: "PipelineResult
 
     table = Table(title="Pipeline Timing", show_footer=True)
     table.add_column("Stage", footer="Total")
-    table.add_column("Elapsed", justify="right", footer=f"{result.total_elapsed_s:.2f}s")
+    table.add_column(
+        "Elapsed", justify="right", footer=f"{result.total_elapsed_s:.2f}s"
+    )
     table.add_column("%", justify="right")
     table.add_column("Detail")
 
     for st in result.timings:
-        pct = (st.elapsed_s / result.total_elapsed_s * 100) if result.total_elapsed_s else 0
+        pct = (
+            (st.elapsed_s / result.total_elapsed_s * 100)
+            if result.total_elapsed_s
+            else 0
+        )
         table.add_row(st.name, f"{st.elapsed_s:.2f}s", f"{pct:.1f}%", st.detail)
 
     console.print(table)
@@ -434,14 +447,11 @@ def _gather_analysis_sources(
                     topic_filter=repo_topic_filter,
                 )
                 console.print(
-                    f"  [dim]{plat}: discovered {len(repos)} repo(s) "
-                    f"in {ns}[/]"
+                    f"  [dim]{plat}: discovered {len(repos)} repo(s) " f"in {ns}[/]"
                 )
                 sources_to_process.extend(r.clone_url for r in repos)
             except Exception as exc:
-                console.print(
-                    f"[yellow]Warning: {plat} discovery failed: {exc}[/]"
-                )
+                console.print(f"[yellow]Warning: {plat} discovery failed: {exc}[/]")
 
     if len(sources_to_process) > 1 and llm_model:
         from .repo_triage import RepoTriager
@@ -570,8 +580,7 @@ def _print_missing_repositories_panel(result: Any) -> None:
     for d in escaping[:10]:
         label = d.name or d.url_or_path
         lines.append(
-            f"  • [bold]{label}[/] ({d.dep_type}) "
-            f"from {Path(d.source_file).name}"
+            f"  • [bold]{label}[/] ({d.dep_type}) " f"from {Path(d.source_file).name}"
         )
     if len(escaping) > 10:
         lines.append(f"  … and {len(escaping) - 10} more")
@@ -617,8 +626,7 @@ def _cross_repo_llm_enrichment(
     from .models.scan import CrossRepoLink, RepoOccurrence
 
     console.print(
-        f"  [cyan]Cross-repo LLM coordination across "
-        f"{len(v2_outputs)} repos…[/]"
+        f"  [cyan]Cross-repo LLM coordination across " f"{len(v2_outputs)} repos…[/]"
     )
     xrepo_rels, xrepo_flags = run_cross_repo_coordination(
         model_string=llm_config["model"],
@@ -699,7 +707,9 @@ def main_callback(
         raise typer.Exit(code=1)
 
 
-def _render_component_table(source: str, categorized_components: Dict[str, List[Dict[str, Any]]]) -> None:
+def _render_component_table(
+    source: str, categorized_components: Dict[str, List[Dict[str, Any]]]
+) -> None:
     table = Table(
         "Category",
         "Count",
@@ -718,13 +728,17 @@ def _render_component_table(source: str, categorized_components: Dict[str, List[
     if has_rows:
         console.print(table)
     else:
-        console.print(Panel.fit("No components detected.", title=source, style="yellow"))
+        console.print(
+            Panel.fit("No components detected.", title=source, style="yellow")
+        )
 
 
 def _build_workflow_tree(component: Dict[str, Any]) -> Tree:
     title = f"[bold]{component.get('name')}[/] ({component.get('category')})"
     root = Tree(title)
-    workflows = sorted(component.get("workflows") or [], key=lambda wf: wf.get("distance", 0))
+    workflows = sorted(
+        component.get("workflows") or [], key=lambda wf: wf.get("distance", 0)
+    )
     for workflow in workflows:
         distance = workflow.get("distance", 0)
         func = workflow.get("function", "unknown")
@@ -775,29 +789,45 @@ def _render_relationship_table(relationships: List[Any]) -> None:
 def _display_v2_summary(source: str, components: list, relationships: list) -> None:
     """Rich summary for v2 detector output."""
     from .models import AIComponent as _V2Comp
+
     components = [
-        _V2Comp.model_validate(c) if isinstance(c, dict) else c
-        for c in components
+        _V2Comp.model_validate(c) if isinstance(c, dict) else c for c in components
     ]
     panel_title = f"[bold green]Analysis Summary (v2)[/] • {source}"
     console.print(Panel(panel_title, style="green", expand=False))
     if not components:
-        console.print(Panel.fit("No AI components detected.", title=source, style="yellow"))
+        console.print(
+            Panel.fit("No AI components detected.", title=source, style="yellow")
+        )
         return
     by_type: Counter = Counter()
     grouped: Dict[str, list] = {}
     for comp in components:
-        ctype = comp.component_type.value if hasattr(comp.component_type, "value") else str(comp.component_type)
+        ctype = (
+            comp.component_type.value
+            if hasattr(comp.component_type, "value")
+            else str(comp.component_type)
+        )
         by_type[ctype] += 1
         grouped.setdefault(ctype, []).append(comp)
-    table = Table("Category", "Count", title=f"Components in {source}", box=box.SIMPLE_HEAVY, header_style="bold magenta")
+    table = Table(
+        "Category",
+        "Count",
+        title=f"Components in {source}",
+        box=box.SIMPLE_HEAVY,
+        header_style="bold magenta",
+    )
     for ctype, count in sorted(by_type.items()):
         table.add_row(ctype, str(count))
     console.print(table)
     for ctype, items in sorted(grouped.items()):
         console.print(Panel.fit(f"{ctype.upper()} details", style="bold white"))
         for comp in items[:5]:
-            loc = f"{comp.file_path}:{comp.line_path}" if hasattr(comp, "line_path") else f"{comp.file_path}:{comp.line_number}"
+            loc = (
+                f"{comp.file_path}:{comp.line_path}"
+                if hasattr(comp, "line_path")
+                else f"{comp.file_path}:{comp.line_number}"
+            )
             extra = ""
             if comp.model_name:
                 extra = f" model={comp.model_name}"
@@ -809,7 +839,9 @@ def _display_v2_summary(source: str, components: list, relationships: list) -> N
             console.print(f"  [cyan]{comp.name}[/]{extra} [dim]{loc}[/]")
 
 
-def _display_analysis_summary(all_analysis_outputs: Dict[str, Any], max_examples: int = 3) -> None:
+def _display_analysis_summary(
+    all_analysis_outputs: Dict[str, Any], max_examples: int = 3
+) -> None:
     for source, output in all_analysis_outputs.items():
         if isinstance(output, dict) and output.get("_v2"):
             _display_v2_summary(source, output["components"], output["relationships"])
@@ -891,9 +923,7 @@ def _build_submission_payload(
         )
 
     submitted_at = (
-        metadata.get("completed_at")
-        or metadata.get("started_at")
-        or _utcnow_iso()
+        metadata.get("completed_at") or metadata.get("started_at") or _utcnow_iso()
     )
     return {
         "run_id": metadata.get("run_id"),
@@ -998,7 +1028,9 @@ def _source_outcomes_from_report(report: Dict[str, Any]) -> Dict[str, Dict[str, 
     for source_key, entry in sources.items():
         if not isinstance(entry, dict):
             continue
-        summary = entry.get("summary", {}) if isinstance(entry.get("summary"), dict) else {}
+        summary = (
+            entry.get("summary", {}) if isinstance(entry.get("summary"), dict) else {}
+        )
         source_path = str(entry.get("source_path") or source_key)
         outcomes[source_path] = {
             "source_name": str(entry.get("source_name") or source_key),
@@ -1100,7 +1132,11 @@ def report_command(
         resolve_path=True,
         help="Path to the JSON report file when using 'show' or 'upload'.",
     ),
-    raw: bool = typer.Option(False, "--raw-json", help="Display the raw JSON using syntax highlighting before the summary."),
+    raw: bool = typer.Option(
+        False,
+        "--raw-json",
+        help="Display the raw JSON using syntax highlighting before the summary.",
+    ),
     report_format: str = typer.Option(
         "json",
         "--format",
@@ -1294,6 +1330,17 @@ def analyze(
         "--llm-api-version",
         envvar="AIBOM_LLM_API_VERSION",
         help="LLM API version (for Azure OpenAI). May be optional for other providers.",
+    ),
+    llm_max_tokens: Optional[int] = typer.Option(
+        None,
+        "--llm-max-tokens",
+        envvar="AIBOM_LLM_MAX_TOKENS",
+        help=(
+            "Max completion (output) tokens per agentic LLM call. Caps output "
+            "only, not input. Defaults to a generous value; raise it if a "
+            "verbose/reasoning model is being truncated, or lower it to bound "
+            "cost."
+        ),
     ),
     show_summary: bool = typer.Option(
         True,
@@ -1521,7 +1568,9 @@ def analyze(
     """Analyzes a Python codebase to generate an AI BOM."""
     if output_format not in _VALID_OUTPUT_FORMATS:
         valid = ", ".join(sorted(_VALID_OUTPUT_FORMATS))
-        console.print(f"[red]Invalid output format[/] '{output_format}'. Must be one of: {valid}")
+        console.print(
+            f"[red]Invalid output format[/] '{output_format}'. Must be one of: {valid}"
+        )
         raise typer.Exit(code=1)
 
     if component_summary and output_format != "json":
@@ -1548,14 +1597,18 @@ def analyze(
         try:
             fail_on_severity = SeverityEnum(fail_on.lower())
         except ValueError:
-            logging.error(f"Invalid --fail-on value '{fail_on}'. Must be: critical, high, medium, low, info")
+            logging.error(
+                f"Invalid --fail-on value '{fail_on}'. Must be: critical, high, medium, low, info"
+            )
             raise typer.Exit(code=1)
     try:
         severity_filter = SeverityEnum(min_severity.lower())
     except ValueError:
-        logging.error(f"Invalid --severity value '{min_severity}'. Must be: critical, high, medium, low, info")
+        logging.error(
+            f"Invalid --severity value '{min_severity}'. Must be: critical, high, medium, low, info"
+        )
         raise typer.Exit(code=1)
-    
+
     llm_config = None
     if llm_model:
         llm_config = {
@@ -1565,6 +1618,8 @@ def analyze(
             "api_base": llm_api_base,
             "api_version": llm_api_version,
         }
+        if llm_max_tokens is not None:
+            llm_config["max_tokens"] = llm_max_tokens
         try:
             ensure_llm_runtime_available(
                 llm_model,
@@ -1632,7 +1687,9 @@ def analyze(
         explicit_config = load_custom_catalog(Path(custom_catalog))
     cache_root = resolve_cache_root(cache_dir)
     scan_cache_dir = resolve_cache_type_dir("scan", cache_root)
-    scan_cache_read_dirs = [p for p in cache_read_dirs("scan", cache_root) if p != scan_cache_dir]
+    scan_cache_read_dirs = [
+        p for p in cache_read_dirs("scan", cache_root) if p != scan_cache_dir
+    ]
     scan_cache_settings = _scan_cache_settings(
         strict=strict,
         min_severity=severity_filter,
@@ -1655,7 +1712,7 @@ def analyze(
         temp_dir = None
         clone_ctx = None
 
-        from .multi_repo import is_git_url, ClonedRepo
+        from .multi_repo import ClonedRepo, is_git_url
 
         is_git = is_git_url(source)
         if is_git:
@@ -1664,7 +1721,9 @@ def analyze(
             is_container = is_container_image(source)
 
         source_summary = {
-            "source_kind": "git-url" if is_git else "container" if is_container else "local-path",
+            "source_kind": (
+                "git-url" if is_git else "container" if is_container else "local-path"
+            ),
             "status": "in_progress",
             "status_detail": None,
             "assets_discovered": 0,
@@ -1698,7 +1757,9 @@ def analyze(
 
         if is_container:
             logging.info(f"Source '{source}' detected as a container image.")
-            extraction = extract_source_from_image(source, llm_config=llm_config, tier=container_tier)
+            extraction = extract_source_from_image(
+                source, llm_config=llm_config, tier=container_tier
+            )
             if extraction.error or extraction.extracted_dir is None:
                 message = f"Error extracting from container image: {extraction.error or 'unknown'}"
                 logging.error(message)
@@ -1714,12 +1775,17 @@ def analyze(
             path_to_analyze = extraction.extracted_dir
 
         if is_container:
-            source_summary["source_path"] = "/app" if path_to_analyze.name == "app" else str(path_to_analyze)
+            source_summary["source_path"] = (
+                "/app" if path_to_analyze.name == "app" else str(path_to_analyze)
+            )
             source_summary["source_name"] = str(source)
         else:
             source_summary["source_path"] = str(path_to_analyze.resolve())
             from .reporters.json_reporter import _friendly_source_name
-            source_summary["source_name"] = _friendly_source_name(str(path_to_analyze.resolve()))
+
+            source_summary["source_name"] = _friendly_source_name(
+                str(path_to_analyze.resolve())
+            )
 
         if not path_to_analyze.exists():
             message = f"Path or image '{source}' not found or could not be processed."
@@ -1746,12 +1812,13 @@ def analyze(
             cached_sr = org_cache.get_cached(str(path_to_analyze.resolve()))
             if cached_sr is not None:
                 console.print(
-                    f"[green]Org cache hit[/] for {source} "
-                    f"(~/.aibom/cache/org)"
+                    f"[green]Org cache hit[/] for {source} " f"(~/.aibom/cache/org)"
                 )
                 cached_v2_output = _v2_output_from_org_cache(cached_sr)
                 all_analysis_outputs[source] = cached_v2_output
-                source_summary["assets_discovered"] = len(cached_v2_output["components"])
+                source_summary["assets_discovered"] = len(
+                    cached_v2_output["components"]
+                )
                 source_summary["last_generated_at"] = _utcnow_iso()
                 if source_summary["status"] == "in_progress":
                     source_summary["status"] = "completed"
@@ -1876,7 +1943,8 @@ def analyze(
         run_metadata["status"] = "completed"
 
     v2_outputs = {
-        k: v for k, v in all_analysis_outputs.items()
+        k: v
+        for k, v in all_analysis_outputs.items()
         if isinstance(v, dict) and v.get("_v2")
     }
     _cross_repo_links: list = []
@@ -1887,7 +1955,8 @@ def analyze(
 
         scan_paths_for_xrepo = list(v2_outputs.keys())
         _cross_repo_links = build_deterministic_cross_repo_links(
-            v2_outputs, scan_paths_for_xrepo,
+            v2_outputs,
+            scan_paths_for_xrepo,
         )
         if _cross_repo_links:
             console.print(
@@ -1897,7 +1966,9 @@ def analyze(
 
     if llm_config and len(v2_outputs) > 1:
         try:
-            extra_links, extra_flags = _cross_repo_llm_enrichment(llm_config, v2_outputs)
+            extra_links, extra_flags = _cross_repo_llm_enrichment(
+                llm_config, v2_outputs
+            )
             _cross_repo_links.extend(extra_links)
             _cross_repo_risk_flags.extend(extra_flags)
         except ImportError:
@@ -1910,6 +1981,7 @@ def analyze(
             _filter_intra_repo_links,
             _filter_quality_bar,
         )
+
         before = len(_cross_repo_links)
         _cross_repo_links = _filter_intra_repo_links(_cross_repo_links)
         _cross_repo_links = _filter_quality_bar(_cross_repo_links)
@@ -1928,14 +2000,16 @@ def analyze(
     else:
         reporter = get_reporter(output_format)
 
+    from .finding_annotations import annotate_findings
+    from .models import AIComponent as V2Component
     from .models import (
-        AIComponent as V2Component,
         AIComponentType,
-        ComponentRelationship as V2Relationship,
+    )
+    from .models import ComponentRelationship as V2Relationship
+    from .models import (
         ScanResult,
         SourceResult,
     )
-    from .finding_annotations import annotate_findings
     from .models.scan import RiskFlag
     from .risk import RiskScorer
 
@@ -1957,11 +2031,13 @@ def analyze(
                 include_code_snippets=include_code_snippets,
                 allowed_roots=[source_path],
             )
-            v2_sources.append(SourceResult(
-                path=source_path,
-                components=comps,
-                relationships=rels,
-            ))
+            v2_sources.append(
+                SourceResult(
+                    path=source_path,
+                    components=comps,
+                    relationships=rels,
+                )
+            )
     run_metadata["source_outcomes"] = source_outcomes
     scan_result = ScanResult(
         metadata=run_metadata,
@@ -1997,7 +2073,11 @@ def analyze(
     scan_result.risk.flags = annotated_risk_flags
 
     if compliance:
-        from .compliance import ComplianceFramework, evaluate_compliance, parse_compliance_cli_value
+        from .compliance import (
+            ComplianceFramework,
+            evaluate_compliance,
+            parse_compliance_cli_value,
+        )
 
         parsed = parse_compliance_cli_value(compliance)
         frameworks = list(ComplianceFramework) if parsed == "all" else [parsed]
@@ -2014,7 +2094,11 @@ def analyze(
             ctable.add_column("Detail")
             for row in report.results:
                 st = row.status
-                st_style = "green" if st == "pass" else "yellow" if st == "not_applicable" else "red"
+                st_style = (
+                    "green"
+                    if st == "pass"
+                    else "yellow" if st == "not_applicable" else "red"
+                )
                 ctable.add_row(
                     row.requirement_id,
                     row.title,
@@ -2127,7 +2211,8 @@ def analyze(
     if output_format == "api":
         logging.info("--- Starting API Server ---")
         component_map = {
-            source: getattr(output, "components", output) for source, output in all_analysis_outputs.items()
+            source: getattr(output, "components", output)
+            for source, output in all_analysis_outputs.items()
         }
         start_api_server(component_map)
 
@@ -2264,7 +2349,9 @@ def benchmark_run(
 
     allowed = {"table", "json", "csv"}
     if fmt.lower() not in allowed:
-        console.print(f"[red]Invalid --format {fmt!r}.[/] Use: {', '.join(sorted(allowed))}")
+        console.print(
+            f"[red]Invalid --format {fmt!r}.[/] Use: {', '.join(sorted(allowed))}"
+        )
         raise typer.Exit(code=1)
 
     result = benchmark_scan(ground, scan_result, strict_names=strict_names)
@@ -2427,7 +2514,9 @@ def cache_list(
 @cache_app.command("get")
 def cache_get(
     cache_type: str = typer.Argument(..., help="Cache family to inspect."),
-    entry_ref: str = typer.Argument(..., help="Entry id, prefix, or logical reference."),
+    entry_ref: str = typer.Argument(
+        ..., help="Entry id, prefix, or logical reference."
+    ),
     cache_dir: Path = typer.Option(
         resolve_cache_root(),
         "--cache-dir",
@@ -2470,7 +2559,9 @@ def cache_get(
         raise typer.Exit(code=1)
 
     if raw_json:
-        console.print(Syntax(json.dumps(entry["payload"], indent=2), "json", theme="monokai"))
+        console.print(
+            Syntax(json.dumps(entry["payload"], indent=2), "json", theme="monokai")
+        )
         return
 
     summary = Table(title=f"{cache_type.title()} Cache Entry", box=box.SIMPLE_HEAVY)
@@ -2500,15 +2591,11 @@ def cache_get(
             if isinstance(item, dict) and item.get("name")
         ]
         if component_names:
-            console.print(
-                f"[cyan]Components:[/] {', '.join(component_names[:10])}"
-            )
+            console.print(f"[cyan]Components:[/] {', '.join(component_names[:10])}")
     elif cache_type == "model":
         models = payload.get("models", payload)
         if isinstance(models, dict) and models:
-            console.print(
-                f"[cyan]Models:[/] {', '.join(list(models.keys())[:10])}"
-            )
+            console.print(f"[cyan]Models:[/] {', '.join(list(models.keys())[:10])}")
     elif cache_type == "packages":
         if payload.get("summary"):
             console.print(f"[cyan]Summary:[/] {payload['summary']}")
@@ -2518,15 +2605,17 @@ def cache_get(
 # cisco-aibom plugin  — discover and manage plugins
 # ---------------------------------------------------------------------------
 
-plugin_app = typer.Typer(help="Discover and manage AIBOM plugins.", no_args_is_help=True)
+plugin_app = typer.Typer(
+    help="Discover and manage AIBOM plugins.", no_args_is_help=True
+)
 app.add_typer(plugin_app, name="plugin")
+
 
 def _diff_impl(old_report: Path, new_report: Path, fmt: str) -> None:
     allowed = {"table", "json", "markdown"}
     if fmt.lower() not in allowed:
         console.print(
-            f"[red]Invalid --format {fmt!r}.[/] "
-            "Use: table, json, markdown.",
+            f"[red]Invalid --format {fmt!r}.[/] " "Use: table, json, markdown.",
         )
         raise typer.Exit(code=1)
     from pydantic import ValidationError
@@ -2618,7 +2707,12 @@ def plugin_list() -> None:
 
 @kb_app.command("download")
 def kb_download(
-    version: Optional[str] = typer.Option(None, "--version", "-v", help="Specific KB version to download (latest if omitted)."),
+    version: Optional[str] = typer.Option(
+        None,
+        "--version",
+        "-v",
+        help="Specific KB version to download (latest if omitted).",
+    ),
     url: Optional[str] = typer.Option(
         None,
         "--url",
@@ -2686,22 +2780,38 @@ def kb_verify() -> None:
 @kb_app.command("request")
 def kb_request(
     sdk: str = typer.Option(..., "--sdk", help="SDK name (e.g., langchain, openai)."),
-    version: str = typer.Option(..., "--version", "-v", help="SDK version to request KB build for."),
-    language: str = typer.Option("python", "--language", "-l", help="Programming language."),
+    version: str = typer.Option(
+        ..., "--version", "-v", help="SDK version to request KB build for."
+    ),
+    language: str = typer.Option(
+        "python", "--language", "-l", help="Programming language."
+    ),
     api_key: Optional[str] = typer.Option(
-        None, "--api-key", envvar="CISCO_AI_DEFENSE_API_KEY",
+        None,
+        "--api-key",
+        envvar="CISCO_AI_DEFENSE_API_KEY",
         help="Cisco AI Defense API key.",
     ),
     api_base: Optional[str] = typer.Option(
-        None, "--api-base", envvar="CISCO_AI_DEFENSE_API_BASE",
+        None,
+        "--api-base",
+        envvar="CISCO_AI_DEFENSE_API_BASE",
         help="Cisco AI Defense API base URL.",
     ),
 ) -> None:
     """Request a knowledge base build for a specific SDK version."""
     mgr = KBManager()
     try:
-        result = mgr.request_build(sdk=sdk, version=version, language=language, api_key=api_key, api_base=api_base)
-        console.print(f"[green]Request submitted:[/] {result.get('request_id', 'unknown')}")
+        result = mgr.request_build(
+            sdk=sdk,
+            version=version,
+            language=language,
+            api_key=api_key,
+            api_base=api_base,
+        )
+        console.print(
+            f"[green]Request submitted:[/] {result.get('request_id', 'unknown')}"
+        )
         console.print(f"Status: {result.get('status', 'unknown')}")
     except KBError as exc:
         console.print(f"[bold red]Request failed:[/] {exc}")
@@ -2712,10 +2822,14 @@ def kb_request(
 def kb_request_status(
     request_id: str = typer.Argument(..., help="Request ID to check."),
     api_key: Optional[str] = typer.Option(
-        None, "--api-key", envvar="CISCO_AI_DEFENSE_API_KEY",
+        None,
+        "--api-key",
+        envvar="CISCO_AI_DEFENSE_API_KEY",
     ),
     api_base: Optional[str] = typer.Option(
-        None, "--api-base", envvar="CISCO_AI_DEFENSE_API_BASE",
+        None,
+        "--api-base",
+        envvar="CISCO_AI_DEFENSE_API_BASE",
     ),
 ) -> None:
     """Check the status of a KB build request."""
@@ -2732,10 +2846,14 @@ def kb_request_status(
 @kb_app.command("list-requests")
 def kb_list_requests(
     api_key: Optional[str] = typer.Option(
-        None, "--api-key", envvar="CISCO_AI_DEFENSE_API_KEY",
+        None,
+        "--api-key",
+        envvar="CISCO_AI_DEFENSE_API_KEY",
     ),
     api_base: Optional[str] = typer.Option(
-        None, "--api-base", envvar="CISCO_AI_DEFENSE_API_BASE",
+        None,
+        "--api-base",
+        envvar="CISCO_AI_DEFENSE_API_BASE",
     ),
 ) -> None:
     """List all pending KB build requests."""

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -385,6 +385,7 @@ def _gather_analysis_sources(
     llm_api_base: Optional[str],
     llm_api_key: Optional[str],
     llm_api_version: Optional[str],
+    llm_max_tokens: Optional[int],
 ) -> List[str]:
     sources_to_process = list(sources) if sources else []
     if images_file:
@@ -465,6 +466,8 @@ def _gather_analysis_sources(
             triage_llm_cfg["api_key"] = llm_api_key
         if llm_api_version:
             triage_llm_cfg["api_version"] = llm_api_version
+        if llm_max_tokens is not None:
+            triage_llm_cfg["max_tokens"] = llm_max_tokens
 
         triager = RepoTriager(llm_config=triage_llm_cfg)
         triage_results = triager.triage_repos(sources_to_process)
@@ -1335,11 +1338,12 @@ def analyze(
         None,
         "--llm-max-tokens",
         envvar="AIBOM_LLM_MAX_TOKENS",
+        min=1,
         help=(
             "Max completion (output) tokens per agentic LLM call. Caps output "
-            "only, not input. Defaults to a generous value; raise it if a "
-            "verbose/reasoning model is being truncated, or lower it to bound "
-            "cost."
+            "only, not input. Must be a positive integer. Defaults to a generous "
+            "value; raise it if a verbose/reasoning model is being truncated, or "
+            "lower it to bound cost."
         ),
     ),
     show_summary: bool = typer.Option(
@@ -1658,6 +1662,7 @@ def analyze(
         llm_api_base=llm_api_base,
         llm_api_key=llm_api_key,
         llm_api_version=llm_api_version,
+        llm_max_tokens=llm_max_tokens,
     )
 
     if not sources_to_process:

--- a/aibom/src/aibom/repo_triage.py
+++ b/aibom/src/aibom/repo_triage.py
@@ -62,7 +62,10 @@ class RepoTriager:
             if not root.exists():
                 results.append(
                     TriageResult(
-                        repo_path, "skip", "path does not exist", method="deterministic",
+                        repo_path,
+                        "skip",
+                        "path does not exist",
+                        method="deterministic",
                     )
                 )
                 continue
@@ -76,24 +79,26 @@ class RepoTriager:
         """Run the triage agent on a single repository."""
         if not self.llm_config:
             return TriageResult(
-                repo_path, "deep-scan",
+                repo_path,
+                "deep-scan",
                 "no LLM config — defaulting to deep-scan (safe bias)",
                 method="deterministic",
             )
 
         try:
+            from deepagents import create_deep_agent
+
             from .agentic.prompts import TRIAGE_AGENT_SYSTEM_PROMPT
             from .agentic.tools import build_triage_tools
             from .llm_factory import build_chat_model
-
-            from deepagents import create_deep_agent
         except ImportError:
             _LOGGER.warning(
                 "Agentic triage requires 'cisco-aibom[agentic]'; "
                 "defaulting to deep-scan"
             )
             return TriageResult(
-                repo_path, "deep-scan",
+                repo_path,
+                "deep-scan",
                 "agentic extras unavailable — defaulting to deep-scan",
                 method="deterministic",
             )
@@ -108,6 +113,7 @@ class RepoTriager:
                 api_key=cfg.get("api_key"),
                 api_base=cfg.get("api_base"),
                 api_version=cfg.get("api_version"),
+                max_tokens=cfg.get("max_tokens"),
             )
 
             tools = build_triage_tools(repo_path)
@@ -133,10 +139,12 @@ class RepoTriager:
         except Exception:
             _LOGGER.warning(
                 "Agentic triage failed for %s; defaulting to deep-scan",
-                repo_path, exc_info=True,
+                repo_path,
+                exc_info=True,
             )
             return TriageResult(
-                repo_path, "deep-scan",
+                repo_path,
+                "deep-scan",
                 "agentic triage failed — defaulting to deep-scan",
                 method="agentic",
             )
@@ -173,7 +181,9 @@ class RepoTriager:
         if content is None:
             messages = result.get("messages", []) if isinstance(result, dict) else []
             for msg in reversed(messages):
-                text = getattr(msg, "content", "") if hasattr(msg, "content") else str(msg)
+                text = (
+                    getattr(msg, "content", "") if hasattr(msg, "content") else str(msg)
+                )
                 if not text:
                     continue
                 start = text.find("{")
@@ -187,7 +197,8 @@ class RepoTriager:
 
         if not content or not isinstance(content, dict):
             return TriageResult(
-                repo_path, "deep-scan",
+                repo_path,
+                "deep-scan",
                 "could not parse agent response — defaulting to deep-scan",
                 method="agentic",
             )

--- a/aibom/src/aibom/repo_triage.py
+++ b/aibom/src/aibom/repo_triage.py
@@ -179,11 +179,14 @@ class RepoTriager:
                 content = sr
 
         if content is None:
+            # Reuse the shared extractor so list-form content blocks
+            # (thinking/tool_use/text) are normalized to text before JSON
+            # scanning, instead of assuming msg.content is a string.
+            from .agentic.agent import _message_text
+
             messages = result.get("messages", []) if isinstance(result, dict) else []
             for msg in reversed(messages):
-                text = (
-                    getattr(msg, "content", "") if hasattr(msg, "content") else str(msg)
-                )
+                text = _message_text(msg)
                 if not text:
                     continue
                 start = text.find("{")

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -169,6 +169,218 @@ class TestExtractStructuredResponse:
         assert _extract_structured_response({}) is None
 
 
+class TestExtractStructuredResponseCarriers:
+    """Provider-agnostic carriers beyond ``message.content``.
+
+    Many models return the structured answer via tool-call args, a parsed
+    object in ``additional_kwargs``, or list-form content blocks rather than
+    a JSON string in ``message.content``. The extractor must recover all of
+    these so non-OpenAI-native output is not silently dropped.
+    """
+
+    class _Msg:
+        """Minimal stand-in for a LangChain ``AIMessage`` (no langchain dep)."""
+
+        def __init__(self, content="", tool_calls=None, additional_kwargs=None):
+            self.content = content
+            self.tool_calls = [] if tool_calls is None else tool_calls
+            self.additional_kwargs = (
+                {} if additional_kwargs is None else additional_kwargs
+            )
+
+    def test_extracts_from_tool_call_args(self):
+        # function_calling: the answer is a dict in tool_calls[].args, content empty
+        msg = self._Msg(
+            content="",
+            tool_calls=[
+                {
+                    "name": "AgentResponse",
+                    "args": {
+                        "enriched_components": [],
+                        "new_components": [{"name": "x"}],
+                    },
+                    "id": "call_1",
+                }
+            ],
+        )
+        data = _extract_structured_response({"messages": [msg]})
+        assert data == {"enriched_components": [], "new_components": [{"name": "x"}]}
+
+    def test_extracts_from_additional_kwargs_parsed_dict(self):
+        # json_schema: the parsed object lands in additional_kwargs, content empty
+        msg = self._Msg(
+            content="", additional_kwargs={"parsed": {"enriched_components": []}}
+        )
+        data = _extract_structured_response({"messages": [msg]})
+        assert data == {"enriched_components": []}
+
+    def test_extracts_from_additional_kwargs_parsed_model(self):
+        from pydantic import BaseModel as _BM
+
+        class _Parsed(_BM):
+            enriched_components: list = []
+            new_components: list = []
+
+        msg = self._Msg(content="", additional_kwargs={"parsed": _Parsed()})
+        data = _extract_structured_response({"messages": [msg]})
+        assert data == {"enriched_components": [], "new_components": []}
+
+    def test_parses_list_form_text_content(self):
+        # Anthropic/Bedrock/Gemini return content as a list of blocks
+        msg = self._Msg(content=[{"type": "text", "text": '{"new_components": []}'}])
+        data = _extract_structured_response({"messages": [msg]})
+        assert data == {"new_components": []}
+
+    def test_list_form_strips_non_text_blocks(self):
+        msg = self._Msg(
+            content=[
+                {"type": "thinking", "thinking": "let me reason about this..."},
+                {"type": "text", "text": '{"enriched_components": []}'},
+            ]
+        )
+        data = _extract_structured_response({"messages": [msg]})
+        assert data == {"enriched_components": []}
+
+    def test_tool_call_args_preferred_over_content(self):
+        # When both are present, the structured tool-call args win over free text
+        msg = self._Msg(
+            content='{"new_components": [{"name": "from_content"}]}',
+            tool_calls=[
+                {
+                    "name": "AgentResponse",
+                    "args": {"new_components": [{"name": "from_tool"}]},
+                    "id": "call_1",
+                }
+            ],
+        )
+        data = _extract_structured_response({"messages": [msg]})
+        assert data == {"new_components": [{"name": "from_tool"}]}
+
+    def test_recovers_char_doubled_content(self):
+        # Gateways may echo character-doubled content ("hheelllloo"); when the
+        # de-doubled form is valid JSON, recover it.
+        original = '{"enriched_components": [], "new_components": []}'
+        doubled = "".join(ch * 2 for ch in original)
+        msg = self._Msg(content=doubled)
+        data = _extract_structured_response({"messages": [msg]})
+        assert data == {"enriched_components": [], "new_components": []}
+
+    def test_unrepairable_content_returns_none(self):
+        msg = self._Msg(content="this is not json at all")
+        assert _extract_structured_response({"messages": [msg]}) is None
+
+
+class TestFailureClassification:
+    """A batch failure must be classified into a precise, distinct hint."""
+
+    def _exc(self, **attrs):
+        exc = Exception("boom")
+        for k, v in attrs.items():
+            setattr(exc, k, v)
+        return exc
+
+    def test_classify_rate_limited(self):
+        from aibom.agentic.agent import _classify_failure_hint
+
+        assert _classify_failure_hint(self._exc(status_code=429)) == "rate_limited"
+
+    def test_classify_provider_outage(self):
+        from aibom.agentic.agent import _classify_failure_hint
+
+        assert _classify_failure_hint(self._exc(status_code=503)) == "provider_outage"
+        assert _classify_failure_hint(self._exc(status_code=500)) == "provider_outage"
+
+    def test_classify_structured_output_parse_error(self):
+        from aibom.agentic.agent import _classify_failure_hint
+
+        # StructuredOutputValidationError carries an ai_message attribute.
+        exc = self._exc(ai_message=object())
+        assert _classify_failure_hint(exc) == "structured_output_parse_error"
+
+    def test_classify_generic_unknown_stays_recursion_limit(self):
+        from aibom.agentic.agent import _classify_failure_hint
+
+        assert _classify_failure_hint(RuntimeError("x")) == "batch_recursion_limit"
+
+    def test_refusal_present(self):
+        from aibom.agentic.agent import _refusal_present
+
+        class _M:
+            def __init__(self, ak):
+                self.additional_kwargs = ak
+
+        assert _refusal_present({"messages": [_M({"refusal": "no"})]}) is True
+        assert _refusal_present({"messages": [_M({})]}) is False
+        assert _refusal_present({"messages": []}) is False
+
+
+class TestBuildModelMaxTokens:
+    @patch("aibom.agentic.agent._build_rate_limiter", return_value=None)
+    @patch("aibom.llm_factory.build_chat_model")
+    def test_passes_generous_default_max_tokens(self, mock_build, _mock_rl):
+        from aibom.agentic.agent import _DEFAULT_AGENTIC_MAX_TOKENS, _build_model
+
+        _build_model("some-model", {"provider": "openai"})
+        _, kwargs = mock_build.call_args
+        assert kwargs.get("max_tokens") == _DEFAULT_AGENTIC_MAX_TOKENS
+
+    @patch("aibom.agentic.agent._build_rate_limiter", return_value=None)
+    @patch("aibom.llm_factory.build_chat_model")
+    def test_llm_config_overrides_max_tokens(self, mock_build, _mock_rl):
+        from aibom.agentic.agent import _build_model
+
+        _build_model("some-model", {"max_tokens": 123})
+        _, kwargs = mock_build.call_args
+        assert kwargs.get("max_tokens") == 123
+
+
+class TestStructuredOutputRecovery:
+    @patch("aibom.agentic.agent._close_model_clients")
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_recovers_from_structured_output_validation_error(
+        self, mock_create, _mock_build, _mock_close
+    ):
+        from aibom.agentic.agent import run_agentic_enrichment
+
+        class _ParseErr(Exception):
+            def __init__(self, ai_message):
+                super().__init__("parse failed")
+                self.ai_message = ai_message
+
+        class _Msg:
+            def __init__(self):
+                self.content = ""
+                self.tool_calls = [
+                    {
+                        "name": "AgentResponse",
+                        "args": {"enriched_components": [], "new_components": []},
+                        "id": "call_1",
+                    }
+                ]
+                self.additional_kwargs = {}
+
+        mock_create.return_value = MagicMock(
+            invoke=MagicMock(side_effect=_ParseErr(_Msg()))
+        )
+        comp = AIComponent(
+            name="test-model",
+            component_type=AIComponentType.MODEL,
+            file_path="x.py",
+            line_number=1,
+            model_name="gpt-4o",
+        )
+        comps, _rels, _flags, _usage = run_agentic_enrichment(
+            model_string="bad-model",
+            deterministic_components=[comp],
+            deterministic_relationships=[],
+            scan_paths=["/tmp"],
+        )
+        assert len(comps) == 1
+        # Recovered from the exception's ai_message -> not degraded.
+        assert not comps[0].agentic_hint
+
+
 class TestLazyImport:
     def test_aibom_import_does_not_import_deepagents(self):
         """Importing aibom.agentic should NOT trigger deepagents import."""

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -269,6 +269,37 @@ class TestExtractStructuredResponseCarriers:
         msg = self._Msg(content="this is not json at all")
         assert _extract_structured_response({"messages": [msg]}) is None
 
+    def test_ignores_non_agentresponse_tool_call(self):
+        # A normal tool invocation (not the structured-output tool) must not be
+        # mistaken for the agent's response.
+        msg = self._Msg(
+            content="",
+            tool_calls=[
+                {"name": "search_codebase", "args": {"query": "foo"}, "id": "t1"}
+            ],
+        )
+        assert _extract_structured_response({"messages": [msg]}) is None
+
+    def test_falls_through_to_content_when_tool_call_not_response(self):
+        # Non-response tool call ignored, but valid JSON content still parsed.
+        msg = self._Msg(
+            content='{"new_components": []}',
+            tool_calls=[
+                {"name": "lookup_model", "args": {"name": "gpt-4o"}, "id": "t1"}
+            ],
+        )
+        assert _extract_structured_response({"messages": [msg]}) == {
+            "new_components": []
+        }
+
+    def test_rejects_non_object_json_array(self):
+        msg = self._Msg(content="[1, 2, 3]")
+        assert _extract_structured_response({"messages": [msg]}) is None
+
+    def test_rejects_non_object_json_scalar(self):
+        msg = self._Msg(content='"just a string"')
+        assert _extract_structured_response({"messages": [msg]}) is None
+
 
 class TestFailureClassification:
     """A batch failure must be classified into a precise, distinct hint."""
@@ -359,6 +390,11 @@ class TestStructuredOutputRecovery:
                     }
                 ]
                 self.additional_kwargs = {}
+                self.usage_metadata = {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "total_tokens": 15,
+                }
 
         mock_create.return_value = MagicMock(
             invoke=MagicMock(side_effect=_ParseErr(_Msg()))
@@ -370,7 +406,7 @@ class TestStructuredOutputRecovery:
             line_number=1,
             model_name="gpt-4o",
         )
-        comps, _rels, _flags, _usage = run_agentic_enrichment(
+        comps, _rels, _flags, usage = run_agentic_enrichment(
             model_string="bad-model",
             deterministic_components=[comp],
             deterministic_relationships=[],
@@ -379,6 +415,8 @@ class TestStructuredOutputRecovery:
         assert len(comps) == 1
         # Recovered from the exception's ai_message -> not degraded.
         assert not comps[0].agentic_hint
+        # Token usage from the recovered ai_message is counted, not lost.
+        assert usage.total_tokens == 15
 
 
 class TestLazyImport:

--- a/aibom/tests/test_agentic_cli.py
+++ b/aibom/tests/test_agentic_cli.py
@@ -181,6 +181,55 @@ class TestAgenticEnrichmentViaCLI:
                     found = True
         assert found, "llm_config['max_tokens']=99999 not passed to _build_model"
 
+    def test_llm_max_tokens_rejects_non_positive(self, sample_dir, tmp_path):
+        import re
+
+        result = runner.invoke(
+            app,
+            [
+                "analyze",
+                str(sample_dir),
+                "--llm-model",
+                "test-model",
+                "--llm-max-tokens",
+                "0",
+            ],
+        )
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+        assert result.exit_code != 0
+        assert "max-tokens" in clean.lower() or "range" in clean.lower()
+
+    @patch("aibom.repo_triage.RepoTriager")
+    def test_triage_config_includes_max_tokens(self, mock_triager_cls):
+        from aibom.cli import _gather_analysis_sources
+
+        inst = MagicMock()
+        inst.triage_repos.return_value = []
+        mock_triager_cls.return_value = inst
+
+        _gather_analysis_sources(
+            sources=["repoA", "repoB"],
+            images_file=None,
+            repos_file=None,
+            discover_repos=False,
+            github_org=None,
+            gitlab_group=None,
+            bitbucket_project=None,
+            platform_token=None,
+            repo_name_filter=None,
+            repo_topic_filter=None,
+            max_repos=None,
+            parallel_repos=1,
+            llm_model="test-model",
+            llm_provider=None,
+            llm_api_base=None,
+            llm_api_key=None,
+            llm_api_version=None,
+            llm_max_tokens=4242,
+        )
+        _, kwargs = mock_triager_cls.call_args
+        assert kwargs["llm_config"].get("max_tokens") == 4242
+
     def test_missing_agentic_extras_fail_fast_with_install_hint(
         self, monkeypatch, sample_dir, tmp_path
     ):

--- a/aibom/tests/test_agentic_cli.py
+++ b/aibom/tests/test_agentic_cli.py
@@ -18,8 +18,8 @@
 
 from __future__ import annotations
 
-import json
 import importlib
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -46,34 +46,50 @@ class TestAgenticEnrichmentViaCLI:
         result = runner.invoke(
             app,
             [
-                "analyze", str(sample_dir),
-                "--output-format", "plaintext",
-                "--output-file", str(out),
+                "analyze",
+                str(sample_dir),
+                "--output-format",
+                "plaintext",
+                "--output-file",
+                str(out),
             ],
             env={"AIBOM_LLM_MODEL": ""},
         )
         assert result.exit_code == 1
-        assert "llm-model" in result.output.lower() or "AIBOM_LLM_MODEL" in result.output
+        assert (
+            "llm-model" in result.output.lower() or "AIBOM_LLM_MODEL" in result.output
+        )
 
     @patch("aibom.scan_pipeline.ensure_llm_runtime_available", return_value=None)
     @patch("aibom.cli.ensure_llm_runtime_available", return_value=None)
     @patch("aibom.agentic.agent._close_model_clients")
     @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
     @patch("aibom.agentic.agent.create_aibom_agent")
-    def test_llm_model_triggers_agentic_enrichment(self, mock_create, _mock_build, _mock_close, _mock_cli_preflight, _mock_pipeline_preflight, sample_dir, tmp_path):
+    def test_llm_model_triggers_agentic_enrichment(
+        self,
+        mock_create,
+        _mock_build,
+        _mock_close,
+        _mock_cli_preflight,
+        _mock_pipeline_preflight,
+        sample_dir,
+        tmp_path,
+    ):
         out = tmp_path / "report.txt"
-        agent_response = json.dumps({
-            "enriched_components": [],
-            "new_components": [],
-            "new_relationships": [
-                {
-                    "source_name": "client",
-                    "target_name": "gpt-4o",
-                    "relationship_type": "USES_MODEL",
-                }
-            ],
-            "risk_findings": [],
-        })
+        agent_response = json.dumps(
+            {
+                "enriched_components": [],
+                "new_components": [],
+                "new_relationships": [
+                    {
+                        "source_name": "client",
+                        "target_name": "gpt-4o",
+                        "relationship_type": "USES_MODEL",
+                    }
+                ],
+                "risk_findings": [],
+            }
+        )
         mock_msg = MagicMock()
         mock_msg.content = agent_response
         mock_agent = MagicMock()
@@ -83,12 +99,18 @@ class TestAgenticEnrichmentViaCLI:
         result = runner.invoke(
             app,
             [
-                "analyze", str(sample_dir),
-                "--output-format", "plaintext",
-                "--output-file", str(out),
-                "--llm-model", "test-model",
-                "--llm-api-base", "http://localhost:11434",
-                "--agentic-scope", "all",
+                "analyze",
+                str(sample_dir),
+                "--output-format",
+                "plaintext",
+                "--output-file",
+                str(out),
+                "--llm-model",
+                "test-model",
+                "--llm-api-base",
+                "http://localhost:11434",
+                "--agentic-scope",
+                "all",
             ],
         )
         assert result.exit_code == 0
@@ -101,6 +123,63 @@ class TestAgenticEnrichmentViaCLI:
         clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
         assert "--llm-model" in clean
         assert "agentic" in clean
+
+    def test_llm_max_tokens_help_listed(self):
+        import re
+
+        result = runner.invoke(app, ["analyze", "--help"])
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+        assert "--llm-max-tokens" in clean
+
+    @patch("aibom.scan_pipeline.ensure_llm_runtime_available", return_value=None)
+    @patch("aibom.cli.ensure_llm_runtime_available", return_value=None)
+    @patch("aibom.agentic.agent._close_model_clients")
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_llm_max_tokens_flag_threaded_into_config(
+        self,
+        mock_create,
+        mock_build,
+        _mock_close,
+        _mock_cli_preflight,
+        _mock_pipeline_preflight,
+        sample_dir,
+        tmp_path,
+    ):
+        out = tmp_path / "report.txt"
+        mock_msg = MagicMock()
+        mock_msg.content = json.dumps({"enriched_components": [], "new_components": []})
+        mock_agent = MagicMock()
+        mock_agent.invoke.return_value = {"messages": [mock_msg]}
+        mock_create.return_value = mock_agent
+
+        result = runner.invoke(
+            app,
+            [
+                "analyze",
+                str(sample_dir),
+                "--output-format",
+                "plaintext",
+                "--output-file",
+                str(out),
+                "--llm-model",
+                "test-model",
+                "--llm-api-base",
+                "http://localhost:11434",
+                "--llm-max-tokens",
+                "99999",
+                "--agentic-scope",
+                "all",
+            ],
+        )
+        assert result.exit_code == 0
+        # The --llm-max-tokens value must reach _build_model via llm_config.
+        found = False
+        for call in mock_build.call_args_list:
+            for arg in list(call.args) + list(call.kwargs.values()):
+                if isinstance(arg, dict) and arg.get("max_tokens") == 99999:
+                    found = True
+        assert found, "llm_config['max_tokens']=99999 not passed to _build_model"
 
     def test_missing_agentic_extras_fail_fast_with_install_hint(
         self, monkeypatch, sample_dir, tmp_path

--- a/aibom/tests/test_repo_triage.py
+++ b/aibom/tests/test_repo_triage.py
@@ -214,6 +214,19 @@ class TestParseResult:
         tr = triager._parse_result("/repo", result)
         assert tr.decision == "needs-clone"
 
+    def test_message_list_content_fallback(self):
+        # LangChain-style list content (thinking + text blocks) must be
+        # normalized to text before JSON scanning, not break the parser.
+        triager = RepoTriager()
+        msg = MagicMock()
+        msg.content = [
+            {"type": "thinking", "thinking": "let me look..."},
+            {"type": "text", "text": '{"decision": "skip", "reason": "no AI"}'},
+        ]
+        tr = triager._parse_result("/repo", {"messages": [msg]})
+        assert tr.decision == "skip"
+        assert tr.reason == "no AI"
+
     def test_invalid_decision_defaults_deep_scan(self):
         triager = RepoTriager()
         result = {

--- a/aibom/tests/test_repo_triage.py
+++ b/aibom/tests/test_repo_triage.py
@@ -38,8 +38,11 @@ class TestTriageAgentIntegration:
         triager = RepoTriager(llm_config={"model": "test-model", "api_key": "k"})
         with patch.object(triager, "_triage_single") as mock_triage:
             mock_triage.return_value = TriageResult(
-                str(repo), "deep-scan", "uses openai",
-                evidence=["requirements.txt"], method="agentic",
+                str(repo),
+                "deep-scan",
+                "uses openai",
+                evidence=["requirements.txt"],
+                method="agentic",
             )
             results = triager.triage_repos([str(repo)])
 
@@ -53,12 +56,37 @@ class TestTriageAgentIntegration:
         triager = RepoTriager(llm_config={"model": "test-model", "api_key": "k"})
         with patch.object(triager, "_triage_single") as mock_triage:
             mock_triage.return_value = TriageResult(
-                str(repo), "skip", "pure web framework", method="agentic",
+                str(repo),
+                "skip",
+                "pure web framework",
+                method="agentic",
             )
             results = triager.triage_repos([str(repo)])
 
         assert results[0].decision == "skip"
         assert results[0].method == "agentic"
+
+    def test_triage_passes_max_tokens_to_model(self, tmp_path: Path):
+        repo = tmp_path / "ai-app"
+        repo.mkdir()
+
+        fake_deepagents = MagicMock()
+        triager = RepoTriager(
+            llm_config={"model": "test-model", "api_key": "k", "max_tokens": 4242}
+        )
+        with (
+            patch(
+                "aibom.llm_factory.build_chat_model", return_value=MagicMock()
+            ) as mock_build,
+            patch.object(
+                triager, "_invoke_with_timeout", side_effect=RuntimeError("stop")
+            ),
+            patch.dict("sys.modules", {"deepagents": fake_deepagents}),
+        ):
+            triager.triage_repos([str(repo)])
+
+        _, kwargs = mock_build.call_args
+        assert kwargs.get("max_tokens") == 4242
 
     def test_agent_failure_defaults_deep_scan(self, tmp_path: Path):
         repo = tmp_path / "broken"
@@ -66,9 +94,13 @@ class TestTriageAgentIntegration:
 
         fake_deepagents = MagicMock()
         triager = RepoTriager(llm_config={"model": "test-model", "api_key": "k"})
-        with patch.object(triager, "_invoke_with_timeout", side_effect=RuntimeError("LLM timeout")), \
-             patch("aibom.llm_factory.build_chat_model", return_value=MagicMock()), \
-             patch.dict("sys.modules", {"deepagents": fake_deepagents}):
+        with (
+            patch.object(
+                triager, "_invoke_with_timeout", side_effect=RuntimeError("LLM timeout")
+            ),
+            patch("aibom.llm_factory.build_chat_model", return_value=MagicMock()),
+            patch.dict("sys.modules", {"deepagents": fake_deepagents}),
+        ):
             results = triager.triage_repos([str(repo)])
 
         assert results[0].decision == "deep-scan"
@@ -174,7 +206,9 @@ class TestParseResult:
         triager = RepoTriager()
         result = {
             "messages": [
-                MagicMock(content='{"decision": "needs-clone", "reason": "opaque repo"}')
+                MagicMock(
+                    content='{"decision": "needs-clone", "reason": "opaque repo"}'
+                )
             ]
         }
         tr = triager._parse_result("/repo", result)


### PR DESCRIPTION
## Summary

Agentic enrichment silently discarded valid structured output from models
whose tool-call / structured-output shape differs from the OpenAI-native happy
path, causing the BOM to **under-count AI components** for those models. The
model did the work and returned correct components, but
`_extract_structured_response` only looked at `structured_response` or
`json.loads(message.content)` — so output delivered via tool-call args, a
parsed object, or list-form content blocks was dropped and the batch was
recorded as *"returned no usable output"* (indistinguishable from "examined
the code and found nothing").

This is a provider-agnostic gap in the extractor, not a model-capability
problem: each affected model returns usable output via *some* carrier; the
harness just didn't read it.

## What changed

`_extract_structured_response` now tries carriers in order of reliability:

1. `structured_response` (unchanged happy path)
2. `message.tool_calls[].args` — the `function_calling` method's carrier
   (uniform `ToolCall{name, args, id}` across all LangChain providers)
3. `additional_kwargs['parsed']` — the `json_schema` method's parsed object
   (which leaves `content` empty)
4. text-only concatenation of **list-form** content blocks
   (thinking/tool_use/text) instead of `str(list)` — which previously produced
   an unparseable Python repr for Anthropic / Bedrock / Gemini-style content
5. `json.loads`, with a **best-effort de-double** of character-doubled gateway
   output (`"hheelllloo"`), re-validated so it can never make things worse

Additional robustness:

- **Recover from a raised `StructuredOutputValidationError`** via its
  `ai_message`, instead of letting it propagate into a dropped batch.
- **Classify batch failures** into precise hints — `provider_outage` (HTTP
  5xx), `rate_limited` (429), `structured_output_parse_error`, `model_refused`,
  and `no_usable_output` — instead of a single catch-all, and surface a model
  refusal distinctly. Transient classes are added to the retry set.
- **Pass a generous default `max_tokens`** (overridable via `llm_config`) so a
  verbose / reasoning model is not truncated mid-output by a gateway's low
  default completion budget.

Because all of these carriers are part of the uniform LangChain `AIMessage`
interface, the fix hardens native Anthropic, Bedrock, and Google output too —
not just OpenAI-compatible gateways.

## Tests

New unit coverage in `tests/test_agentic_agent.py`:

- extraction from tool-call args, `additional_kwargs['parsed']` (dict and
  pydantic model), list-form text content (with non-text blocks stripped),
  carrier precedence, and char-doubled recovery
- failure classification (rate-limit / provider-outage / parse-error /
  generic), refusal detection
- recovery from a raised `StructuredOutputValidationError` via `ai_message`
- the generous `max_tokens` default and its `llm_config` override

## Test plan

- `uv run pytest` — full suite green (1859 passed, 3 skipped)
- `uv run black --check` / `uv run isort --check-only` — clean on changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--llm-max-tokens` / `AIBOM_LLM_MAX_TOKENS` to `analyze`, threading `max_tokens` into both agentic enrichment and repo triage.
* **Bug Fixes**
  * Prevented low provider token budgets from truncating verbose agentic output by using an explicit agentic `max_tokens` cap.
  * Improved batch error handling with enhanced retry classification, explicit model refusal detection, and more resilient structured-output recovery.
  * Strengthened structured extraction across tool-call arguments, parsed payloads, and message text (including repair attempts).
* **Tests**
  * Expanded unit and CLI coverage for structured extraction, refusal handling, failure classification, and token forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->