### PR TITLE
chore: prepare 1.0.4 release

### DIFF
--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-aibom"
-version = "1.0.3"
+version = "1.0.4"
 description = "A tool to generate an AI BOM from source code."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/aibom/src/aibom/manifest.json
+++ b/aibom/src/aibom/manifest.json
@@ -1,8 +1,8 @@
 {
-  "analyzer_version": "1.0.3",
-  "schema_version": "1.0.3",
+  "analyzer_version": "1.0.4",
+  "schema_version": "1.0.4",
   "duckdb_sha256": "b1165384a646094aa6a4762d676f285c1c68b6d7f9367c90a129b529904a3268",
-  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.3.duckdb",
+  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.4.duckdb",
   "upload_mode": "direct",
   "max_direct_upload_mb": 25,
   "log_level": "INFO"

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "cisco-aibom"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## 1.0.4 release prep

Patch release. `main` is at 1.0.3 (already published), with the agentic
structured-output extraction fixes merged on top and not yet released — this
cuts them as 1.0.4.

### What's included since 1.0.3
- Recover structured output from models that return it via tool-call args, a
  parsed object, or list-form content blocks (previously dropped as "no usable
  output"); recover from a raised `StructuredOutputValidationError` via its
  `ai_message`.
- Classify batch failures into distinct hints (`provider_outage`,
  `rate_limited`, `structured_output_parse_error`, `model_refused`,
  `no_usable_output`) instead of one catch-all.
- New `--llm-max-tokens` (env `AIBOM_LLM_MAX_TOKENS`, validated `>= 1`) with a
  generous default; propagated to repo triage as well.

### Release-prep changes (standard set)
- `aibom/pyproject.toml` — version 1.0.3 → 1.0.4 (`uv version`)
- `aibom/uv.lock` — `cisco-aibom` version relock
- `aibom/src/aibom/manifest.json` — `analyzer_version` / `schema_version` →
  1.0.4, `duckdb_file` → `aibom_catalog-1.0.4.duckdb`. `duckdb_sha256`
  unchanged — the KB catalog content is identical; only the version-stamped
  filename changes.

### Verified
- `uv lock --check` — consistent
- `uv run pytest` — 1869 passed, 3 skipped
- No source changes in this PR → black/isort clean

The GitHub release (tag `1.0.4` + the `aibom_catalog-1.0.4.duckdb` asset) is
cut after this merges, per the release process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app/package version to **1.0.4**.
  * Updated release metadata to match the new version, including the associated catalog reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->