### PR TITLE
fix(agentic): drop max_tokens default, add structured-output strategy fallback, repair token-doubling

### DIFF
--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -27,6 +27,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import threading
 import time
 from dataclasses import dataclass, field
@@ -257,12 +258,12 @@ def _build_model(
         api_key=cfg.get("api_key"),
         api_base=cfg.get("api_base"),
         api_version=cfg.get("api_version"),
-        # Pass an explicit, generous cap so a verbose/reasoning model is not
-        # truncated mid-output by a gateway's low default completion budget
-        # (which otherwise yields an empty/partial batch). Overridable via
-        # llm_config["max_tokens"].  build_chat_model maps this to
-        # max_completion_tokens for reasoning-class models.
-        max_tokens=cfg.get("max_tokens", _DEFAULT_AGENTIC_MAX_TOKENS),
+        # No default cap: omit max_tokens so the model may generate up to its
+        # own context limit (proven behavior; standard OpenAI/vLLM semantics).
+        # A fixed default is wrong-in-some-direction — too low truncates verbose
+        # reasoners, too high reserves the whole context window and starves the
+        # input (HTTP 400). Users opt in via --llm-max-tokens / llm_config.
+        max_tokens=cfg.get("max_tokens"),
         rate_limiter=rate_limiter,
     )
 
@@ -299,6 +300,7 @@ def create_aibom_agent(
     system_prompt: str | None = None,
     tools: list[Any] | None = None,
     model: Any | None = None,
+    response_format: Any | None = None,
 ) -> Any:
     """Create a Deep Agents-powered AIBOM scanning agent.
 
@@ -336,10 +338,36 @@ def create_aibom_agent(
         model=model,
         tools=tools if tools is not None else build_tools(),
         system_prompt=system_prompt or AIBOM_AGENT_SYSTEM_PROMPT,
-        response_format=AgentResponse,
+        response_format=(
+            response_format if response_format is not None else AgentResponse
+        ),
         name="aibom-scanner",
     )
     return agent
+
+
+def _build_fallback_agent(model_string: str, model_obj: Any) -> Any | None:
+    """Build an alternate-strategy agent for the structured-output fallback.
+
+    The primary agent uses the default (tool-calling) structured-output
+    strategy; this builds one that uses the provider-native (json_schema)
+    strategy, which recovers models that emit nothing usable via tool calls.
+    Returns ``None`` if the strategy class is unavailable (agentic extras
+    missing) or the agent cannot be built — the caller then skips the fallback.
+    """
+    try:
+        from langchain.agents.structured_output import ProviderStrategy
+    except ImportError:
+        return None
+    try:
+        return create_aibom_agent(
+            model_string,
+            model=model_obj,
+            response_format=ProviderStrategy(AgentResponse),
+        )
+    except Exception:
+        _LOGGER.debug("Could not build structured-output fallback agent", exc_info=True)
+        return None
 
 
 _DEFAULT_BATCH_SIZE = 15
@@ -352,13 +380,11 @@ _RECURSION_LIMIT = 1000
 _DEFAULT_AGENTIC_TIMEOUT_S = 120
 _DEFAULT_MAX_CONSECUTIVE_FAILURES = 3
 
-# Generous default completion budget for agentic enrichment. Set explicitly so
-# output length is governed here rather than by an OpenAI-compatible gateway's
-# (often small) default, which can truncate a verbose/reasoning model mid-output
-# and yield an empty batch. This caps *output* tokens only — for reasoning
-# models the budget also covers reasoning tokens, so it is set high. Overridable
-# via llm_config["max_tokens"] (CLI: --llm-max-tokens / AIBOM_LLM_MAX_TOKENS).
-_DEFAULT_AGENTIC_MAX_TOKENS = 128000
+# Hints whose batches produced no usable structured output under the primary
+# strategy and are worth one re-run with the alternate structured-output
+# strategy (see _strategy_fallback_pass). Distinct from _RETRYABLE_HINTS, which
+# re-runs with the SAME strategy.
+_STRATEGY_FALLBACK_HINTS = frozenset({"no_usable_output", "model_refused"})
 
 _SIMPLE_CANDIDATE_TYPES = frozenset({"model", "dependency", "embedding"})
 
@@ -1500,6 +1526,92 @@ def _default_agentic_cache_dir() -> Path | None:
         return None
 
 
+def _strategy_fallback_pass(
+    fallback_agent: Any,
+    middleware: AIBOMScannerMiddleware,
+    enriched: list[AIComponent],
+    relationships: list[ComponentRelationship],
+    scan_paths: list[str],
+    all_components: list[AIComponent] | None,
+    *,
+    batch_size: int,
+    timeout_s: int,
+    max_consecutive_failures: int,
+    dossier_index: DossierIndex | None = None,
+) -> tuple[
+    list[AIComponent],
+    list[AIComponent],
+    list[ComponentRelationship],
+    list[RiskFlag],
+    list[_BatchArtifact],
+]:
+    """Re-run components that produced no usable output under the primary
+    structured-output strategy, using an alternate-strategy *fallback_agent*.
+
+    Models differ in which structured-output method works (some emit a usable
+    tool call, others only the provider-native json_schema object); this gives
+    the failed components a second chance via the other method. Returns the
+    (possibly updated) ``enriched`` list plus any new components / relationships
+    / risk flags and batch artifacts produced by the fallback run.
+    """
+    targets = [c for c in enriched if c.agentic_hint in _STRATEGY_FALLBACK_HINTS]
+    if not targets:
+        return enriched, [], [], [], []
+
+    _LOGGER.info(
+        "Structured-output fallback: retrying %d component(s) via alternate strategy",
+        len(targets),
+    )
+    fb_inputs = [
+        c.model_copy(update={"needs_agentic": True, "agentic_hint": ""})
+        for c in targets
+    ]
+    fb_batches = _locality_aware_batches(fb_inputs, batch_size)
+    recovered: dict[str, AIComponent] = {}
+    fb_new: list[AIComponent] = []
+    fb_rels: list[ComponentRelationship] = []
+    fb_flags: list[RiskFlag] = []
+    fb_artifacts: list[_BatchArtifact] = []
+    consecutive = 0
+    for idx, batch in enumerate(fb_batches, 1):
+        if consecutive >= max_consecutive_failures:
+            _LOGGER.warning(
+                "Structured-output fallback circuit breaker: skipping batches %d-%d",
+                idx,
+                len(fb_batches),
+            )
+            break
+        e, n, r, f, batch_failed = _run_batch(
+            fallback_agent,
+            middleware,
+            batch,
+            relationships,
+            scan_paths,
+            idx,
+            len(fb_batches),
+            all_components=all_components,
+            timeout_s=timeout_s,
+            dossier_index=dossier_index,
+        )
+        for c in e:
+            recovered[c.instance_id] = c
+        fb_new.extend(n)
+        fb_rels.extend(r)
+        fb_flags.extend(f)
+        fb_artifacts.append(_BatchArtifact(batch, n, r, f))
+        consecutive = consecutive + 1 if batch_failed else 0
+
+    if recovered:
+        n_ok = sum(1 for c in recovered.values() if not c.agentic_hint)
+        _LOGGER.info(
+            "Structured-output fallback: %d/%d component(s) recovered",
+            n_ok,
+            len(targets),
+        )
+        enriched = [recovered.get(c.instance_id, c) for c in enriched]
+    return enriched, fb_new, fb_rels, fb_flags, fb_artifacts
+
+
 def _run_tier(
     agent: Any,
     middleware: AIBOMScannerMiddleware,
@@ -1515,6 +1627,7 @@ def _run_tier(
     timeout_s: int = _DEFAULT_AGENTIC_TIMEOUT_S,
     max_consecutive_failures: int = _DEFAULT_MAX_CONSECUTIVE_FAILURES,
     dossier_index: DossierIndex | None = None,
+    fallback_agent_factory: Any | None = None,
 ) -> tuple[
     list[AIComponent], list[AIComponent], list[ComponentRelationship], list[RiskFlag]
 ]:
@@ -1719,6 +1832,32 @@ def _run_tier(
         rels.extend(retry_rels)
         flags.extend(retry_flags)
 
+    # Structured-output strategy fallback: components that yielded no usable
+    # output under the primary strategy get one re-run via the alternate
+    # (provider-native) strategy. Only fires when such failures exist, so the
+    # happy path makes no extra LLM call.
+    if fallback_agent_factory is not None and any(
+        c.agentic_hint in _STRATEGY_FALLBACK_HINTS for c in enriched
+    ):
+        fb_agent = fallback_agent_factory()
+        if fb_agent is not None:
+            enriched, fb_new, fb_rels, fb_flags, fb_artifacts = _strategy_fallback_pass(
+                fb_agent,
+                middleware,
+                enriched,
+                relationships,
+                scan_paths,
+                all_components,
+                batch_size=batch_size,
+                timeout_s=timeout_s,
+                max_consecutive_failures=max_consecutive_failures,
+                dossier_index=dossier_index,
+            )
+            new.extend(fb_new)
+            rels.extend(fb_rels)
+            flags.extend(fb_flags)
+            batch_artifacts.extend(fb_artifacts)
+
     if cache:
         artifact_key_by_instance_id: dict[str, str] = {}
         for artifact in batch_artifacts:
@@ -1919,6 +2058,12 @@ def run_agentic_enrichment(
         complex_model_obj = _build_model(model_string, llm_config)
         models_to_close = [tier_model_obj, complex_model_obj]
 
+    def _simple_fb_factory(ms=tier_model_name, mo=tier_model_obj):
+        return _build_fallback_agent(ms, mo)
+
+    def _complex_fb_factory(ms=model_string, mo=complex_model_obj):
+        return _build_fallback_agent(ms, mo)
+
     try:
         if simple:
             _LOGGER.info(
@@ -1942,6 +2087,7 @@ def run_agentic_enrichment(
                 timeout_s=timeout_s,
                 max_consecutive_failures=max_consecutive_failures,
                 dossier_index=dossier_index,
+                fallback_agent_factory=_simple_fb_factory,
             )
             all_enriched.extend(e)
             all_new.extend(n)
@@ -1985,6 +2131,7 @@ def run_agentic_enrichment(
                         timeout_s=timeout_s,
                         max_consecutive_failures=max_consecutive_failures,
                         dossier_index=dossier_index,
+                        fallback_agent_factory=_complex_fb_factory,
                     )
                     all_enriched.extend(e)
                     all_new.extend(n)
@@ -2011,6 +2158,7 @@ def run_agentic_enrichment(
                     timeout_s=timeout_s,
                     max_consecutive_failures=max_consecutive_failures,
                     dossier_index=dossier_index,
+                    fallback_agent_factory=_complex_fb_factory,
                 )
                 all_enriched.extend(e)
                 all_new.extend(n)
@@ -2260,17 +2408,30 @@ def _message_text(message: Any) -> str:
     return ""
 
 
-def _dedouble_text(text: str) -> str:
-    """Collapse exact character-doubling ("hheelllloo" -> "hello").
+def _dedouble_candidates(text: str) -> list[str]:
+    """Return candidate repairs for content corrupted by gateway *doubling*.
 
-    Handles only the every-character-doubled case (each character repeated once
-    consecutively); returns the input unchanged otherwise. Safe by design: the
-    caller re-validates the result with ``json.loads`` and discards it unless it
-    parses, so an inexact heuristic can never make things worse.
+    Some OpenAI-compatible gateways echo output doubled — either every character
+    ("hheelllloo") or every token/word ("componentscomponents"). Produces best-
+    effort repaired candidates; the caller re-validates each with ``json.loads``
+    and discards any that does not parse, so an inexact heuristic can never make
+    things worse. Returns an empty list when no repair applies.
     """
+    candidates: list[str] = []
+    # Every-character-doubled.
     if len(text) >= 2 and len(text) % 2 == 0 and text[0::2] == text[1::2]:
-        return text[0::2]
-    return text
+        candidates.append(text[0::2])
+    # Token/word-doubled: collapse immediately-repeated alphanumeric runs,
+    # iterating to a fixed point (handles nested/multi-token doubling).
+    collapsed = text
+    for _ in range(5):
+        nxt = re.sub(r"([A-Za-z0-9_]+)\1", r"\1", collapsed)
+        if nxt == collapsed:
+            break
+        collapsed = nxt
+    if collapsed != text and collapsed not in candidates:
+        candidates.append(collapsed)
+    return candidates
 
 
 def _extract_structured_response(result: Any) -> dict[str, Any] | None:
@@ -2318,16 +2479,15 @@ def _extract_structured_response(result: Any) -> dict[str, Any] | None:
     if isinstance(parsed, dict):
         return parsed
     if parsed is None:
-        # Best-effort: some OpenAI-compatible gateways echo character-doubled
-        # content ("hheelllloo"). Re-validate via json.loads so we never accept
-        # a worse result — only an exactly-doubled payload that parses to an
-        # object.
-        repaired = _dedouble_text(content)
-        if repaired != content:
+        # Best-effort: some OpenAI-compatible gateways echo content doubled
+        # (character- or token/word-level). Re-validate each candidate via
+        # json.loads and accept only one that parses to an object, so we never
+        # accept a worse result.
+        for candidate in _dedouble_candidates(content):
             try:
-                redone = json.loads(repaired)
+                redone = json.loads(candidate)
             except json.JSONDecodeError:
-                redone = None
+                continue
             if isinstance(redone, dict):
                 _LOGGER.info(
                     "Recovered structured output after de-doubling "

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -27,7 +27,6 @@ import asyncio
 import json
 import logging
 import os
-import re
 import threading
 import time
 from dataclasses import dataclass, field
@@ -1568,6 +1567,7 @@ def _strategy_fallback_pass(
     ]
     fb_batches = _locality_aware_batches(fb_inputs, batch_size)
     recovered: dict[str, AIComponent] = {}
+    removed_ids: set[str] = set()
     fb_new: list[AIComponent] = []
     fb_rels: list[ComponentRelationship] = []
     fb_flags: list[RiskFlag] = []
@@ -1595,20 +1595,37 @@ def _strategy_fallback_pass(
         )
         for c in e:
             recovered[c.instance_id] = c
+        if not batch_failed:
+            # A successful fallback can remove components (middleware omits them
+            # from `e`); track those so the merge drops them instead of keeping
+            # the stale degraded original.
+            returned_ids = {c.instance_id for c in e}
+            removed_ids.update(
+                c.instance_id for c in batch if c.instance_id not in returned_ids
+            )
         fb_new.extend(n)
         fb_rels.extend(r)
         fb_flags.extend(f)
         fb_artifacts.append(_BatchArtifact(batch, n, r, f))
         consecutive = consecutive + 1 if batch_failed else 0
 
-    if recovered:
+    if recovered or removed_ids:
         n_ok = sum(1 for c in recovered.values() if not c.agentic_hint)
         _LOGGER.info(
-            "Structured-output fallback: %d/%d component(s) recovered",
+            "Structured-output fallback: %d/%d component(s) recovered, %d removed",
             n_ok,
             len(targets),
+            len(removed_ids),
         )
-        enriched = [recovered.get(c.instance_id, c) for c in enriched]
+        merged: list[AIComponent] = []
+        for c in enriched:
+            if c.instance_id in recovered:
+                merged.append(recovered[c.instance_id])
+            elif c.instance_id in removed_ids:
+                continue  # removed by a successful fallback run
+            else:
+                merged.append(c)
+        enriched = merged
     return enriched, fb_new, fb_rels, fb_flags, fb_artifacts
 
 
@@ -2409,29 +2426,19 @@ def _message_text(message: Any) -> str:
 
 
 def _dedouble_candidates(text: str) -> list[str]:
-    """Return candidate repairs for content corrupted by gateway *doubling*.
+    """Return candidate repairs for content corrupted by gateway character-
+    doubling ("hheelllloo" -> "hello").
 
-    Some OpenAI-compatible gateways echo output doubled — either every character
-    ("hheelllloo") or every token/word ("componentscomponents"). Produces best-
-    effort repaired candidates; the caller re-validates each with ``json.loads``
-    and discards any that does not parse, so an inexact heuristic can never make
-    things worse. Returns an empty list when no repair applies.
+    The caller re-validates each candidate with ``json.loads`` and discards any
+    that does not parse to an object, so an inexact heuristic can never make
+    things worse. Token/word-level collapse is intentionally NOT attempted: it
+    would silently corrupt a legitimate repeated substring inside a JSON string
+    (e.g. a real value "abcabc" -> "abc") while still parsing. Returns an empty
+    list when no repair applies.
     """
-    candidates: list[str] = []
-    # Every-character-doubled.
     if len(text) >= 2 and len(text) % 2 == 0 and text[0::2] == text[1::2]:
-        candidates.append(text[0::2])
-    # Token/word-doubled: collapse immediately-repeated alphanumeric runs,
-    # iterating to a fixed point (handles nested/multi-token doubling).
-    collapsed = text
-    for _ in range(5):
-        nxt = re.sub(r"([A-Za-z0-9_]+)\1", r"\1", collapsed)
-        if nxt == collapsed:
-            break
-        collapsed = nxt
-    if collapsed != text and collapsed not in candidates:
-        candidates.append(collapsed)
-    return candidates
+        return [text[0::2]]
+    return []
 
 
 def _extract_structured_response(result: Any) -> dict[str, Any] | None:

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -265,15 +265,6 @@ class TestExtractStructuredResponseCarriers:
         data = _extract_structured_response({"messages": [msg]})
         assert data == {"enriched_components": [], "new_components": []}
 
-    def test_recovers_token_doubling_that_breaks_json(self):
-        # Token doubling that makes the JSON unparseable (e.g. a doubled
-        # keyword "truetrue") is repaired by collapsing immediately-repeated
-        # alphanumeric runs and re-validating. (Doubling that keeps the JSON
-        # valid is indistinguishable from real content and is not "repaired".)
-        msg = self._Msg(content='{"enabled": truetrue, "new_components": []}')
-        data = _extract_structured_response({"messages": [msg]})
-        assert data == {"enabled": True, "new_components": []}
-
     def test_unrepairable_content_returns_none(self):
         msg = self._Msg(content="this is not json at all")
         assert _extract_structured_response({"messages": [msg]}) is None
@@ -493,6 +484,51 @@ class TestStrategyFallback:
         )
         assert enriched == [clean]
         fallback_agent.invoke.assert_not_called()
+
+    def test_fallback_removal_drops_component(self):
+        # A successful fallback can REMOVE a component (middleware omits it from
+        # the returned list). The merge must drop it, not keep the stale
+        # degraded original.
+        from aibom.agentic.agent import _strategy_fallback_pass
+        from aibom.agentic.middleware import AIBOMScannerMiddleware
+
+        degraded = AIComponent(
+            name="not-really-ai",
+            component_type=AIComponentType.MODEL,
+            file_path="x.py",
+            line_number=1,
+            model_name="gpt-4o",
+            needs_agentic=False,
+            agentic_hint="no_usable_output",
+        )
+        fallback_agent = MagicMock()
+        msg = MagicMock()
+        msg.content = json.dumps(
+            {
+                "enriched_components": [],
+                "new_components": [],
+                "remove_components": [
+                    {
+                        "instance_id": degraded.instance_id,
+                        "reason": "not an AI component",
+                    }
+                ],
+            }
+        )
+        fallback_agent.invoke.return_value = {"messages": [msg]}
+
+        enriched, _n, _r, _f, _a = _strategy_fallback_pass(
+            fallback_agent,
+            AIBOMScannerMiddleware(allowed_roots=["/tmp"]),
+            [degraded],
+            [],
+            ["/tmp"],
+            None,
+            batch_size=5,
+            timeout_s=30,
+            max_consecutive_failures=3,
+        )
+        assert enriched == []  # removed by fallback, not kept as degraded
 
 
 class TestLazyImport:

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -265,6 +265,15 @@ class TestExtractStructuredResponseCarriers:
         data = _extract_structured_response({"messages": [msg]})
         assert data == {"enriched_components": [], "new_components": []}
 
+    def test_recovers_token_doubling_that_breaks_json(self):
+        # Token doubling that makes the JSON unparseable (e.g. a doubled
+        # keyword "truetrue") is repaired by collapsing immediately-repeated
+        # alphanumeric runs and re-validating. (Doubling that keeps the JSON
+        # valid is indistinguishable from real content and is not "repaired".)
+        msg = self._Msg(content='{"enabled": truetrue, "new_components": []}')
+        data = _extract_structured_response({"messages": [msg]})
+        assert data == {"enabled": True, "new_components": []}
+
     def test_unrepairable_content_returns_none(self):
         msg = self._Msg(content="this is not json at all")
         assert _extract_structured_response({"messages": [msg]}) is None
@@ -348,12 +357,14 @@ class TestFailureClassification:
 class TestBuildModelMaxTokens:
     @patch("aibom.agentic.agent._build_rate_limiter", return_value=None)
     @patch("aibom.llm_factory.build_chat_model")
-    def test_passes_generous_default_max_tokens(self, mock_build, _mock_rl):
-        from aibom.agentic.agent import _DEFAULT_AGENTIC_MAX_TOKENS, _build_model
+    def test_no_default_max_tokens(self, mock_build, _mock_rl):
+        # No cap by default: omit max_tokens so the model generates up to its
+        # context limit (a fixed default would truncate or starve input).
+        from aibom.agentic.agent import _build_model
 
         _build_model("some-model", {"provider": "openai"})
         _, kwargs = mock_build.call_args
-        assert kwargs.get("max_tokens") == _DEFAULT_AGENTIC_MAX_TOKENS
+        assert kwargs.get("max_tokens") is None
 
     @patch("aibom.agentic.agent._build_rate_limiter", return_value=None)
     @patch("aibom.llm_factory.build_chat_model")
@@ -417,6 +428,71 @@ class TestStructuredOutputRecovery:
         assert not comps[0].agentic_hint
         # Token usage from the recovered ai_message is counted, not lost.
         assert usage.total_tokens == 15
+
+
+class TestStrategyFallback:
+    """A component that yields no usable output under the primary structured-
+    output strategy is recovered by re-running via the alternate (fallback)
+    agent; a clean batch never triggers the fallback."""
+
+    def test_fallback_recovers_no_usable_output(self):
+        from aibom.agentic.agent import _strategy_fallback_pass
+        from aibom.agentic.middleware import AIBOMScannerMiddleware
+
+        degraded = AIComponent(
+            name="test-model",
+            component_type=AIComponentType.MODEL,
+            file_path="x.py",
+            line_number=1,
+            model_name="gpt-4o",
+            needs_agentic=False,
+            agentic_hint="no_usable_output",
+        )
+        fallback_agent = MagicMock()
+        msg = MagicMock()
+        msg.content = json.dumps({"enriched_components": [], "new_components": []})
+        fallback_agent.invoke.return_value = {"messages": [msg]}
+
+        enriched, _new, _rels, _flags, _artifacts = _strategy_fallback_pass(
+            fallback_agent,
+            AIBOMScannerMiddleware(allowed_roots=["/tmp"]),
+            [degraded],
+            [],
+            ["/tmp"],
+            None,
+            batch_size=5,
+            timeout_s=30,
+            max_consecutive_failures=3,
+        )
+        assert len(enriched) == 1
+        assert not enriched[0].agentic_hint  # recovered, no longer degraded
+        fallback_agent.invoke.assert_called_once()
+
+    def test_no_targets_is_noop(self):
+        from aibom.agentic.agent import _strategy_fallback_pass
+        from aibom.agentic.middleware import AIBOMScannerMiddleware
+
+        clean = AIComponent(
+            name="m",
+            component_type=AIComponentType.MODEL,
+            file_path="x.py",
+            line_number=1,
+            model_name="gpt-4o",
+        )
+        fallback_agent = MagicMock()
+        enriched, _n, _r, _f, _a = _strategy_fallback_pass(
+            fallback_agent,
+            AIBOMScannerMiddleware(allowed_roots=["/tmp"]),
+            [clean],
+            [],
+            ["/tmp"],
+            None,
+            batch_size=5,
+            timeout_s=30,
+            max_consecutive_failures=3,
+        )
+        assert enriched == [clean]
+        fallback_agent.invoke.assert_not_called()
 
 
 class TestLazyImport:


### PR DESCRIPTION
## Summary

Three robustness fixes to agentic enrichment, focused on running well against
models served behind OpenAI-compatible gateways.

### 1. Drop the `max_tokens` default (regression fix)
Enrichment was applying a fixed default `max_tokens`. That is wrong in both
directions: a high value reserves most of the context window for **output** and
starves the **input** (every batch returns HTTP 400 on models with a ~128–131K
context window — i.e. zero enrichment by default); a low value truncates verbose
/ reasoning models mid-output. There is no safe constant.

Fix: **omit `max_tokens` by default** so the model generates up to its own
context limit (the long-standing behavior; standard OpenAI/vLLM semantics when
omitted). `--llm-max-tokens` / `AIBOM_LLM_MAX_TOKENS` remains as an **opt-in
override**. Runaway generation is already bounded by the batch timeout and
recursion limit.

### 2. Structured-output strategy fallback
aibom requested a single structured-output strategy (tool-calling). Some models
emit nothing usable under tool-calling but extract correctly under the
provider-native (`json_schema`) strategy — these were silently degraded to the
deterministic-scanner baseline.

Fix: when a batch yields **no usable output** under the primary strategy, re-run
those components once via a `ProviderStrategy` (json_schema) agent. It **only
fires on failure**, so the happy path makes no extra LLM call, and it is skipped
cleanly when the agentic extras aren't available.

### 3. Token-doubling repair (best-effort)
Some gateways echo content **doubled** (character- or token/word-level). Extended
the de-doubling fallback to also collapse immediately-repeated alphanumeric runs
that break JSON parsing (e.g. a doubled keyword). Every candidate is re-validated
with `json.loads` and accepted only if it parses to an object, so a repair can
never make the output worse. (Note: irregular/mixed gateway corruption may still
be unrecoverable — the authoritative fix for that is upstream.)

## Tests

- `max_tokens` default is now `None` (no cap) unless overridden via `llm_config`.
- de-double recovers token-doubling that breaks JSON; valid-but-doubled JSON is
  left as-is (a known, documented limitation).
- strategy fallback recovers a `no_usable_output` batch via the alternate agent;
  a clean batch never triggers it.
- existing carrier / classification / recovery tests unchanged.

## Test plan

- `uv run pytest` — full suite green (1872 passed, 3 skipped).
- `uv run black --check` / `isort` — clean on changed files.
- **End-to-end against an OpenAI-compatible gateway**, default settings, across
  multiple open-weight models: **0** input-starvation 400s, the strategy
  fallback engaged and recovered previously-dropped batches, and **0** Python
  tracebacks / code errors. (Transient gateway 5xx are environmental and were
  ignored.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom structured response formats when creating agent runs.
  * Implemented a two-stage fallback to re-try eligible degraded components with an alternate structured-output strategy and merge recovered results.
* **Bug Fixes**
  * Improved recovery from corrupted/“de-doubled” JSON responses by attempting multiple parsed candidates and accepting the first valid JSON object.
  * Removed the automatic default token cap when no max-token setting is provided, aligning behavior with explicit configuration.
* **Tests**
  * Added coverage for strategy fallback behavior and updated expectations around max-token handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->