### PR TITLE
chore: prepare 1.0.5 release

### DIFF
--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-aibom"
-version = "1.0.4"
+version = "1.0.5"
 description = "A tool to generate an AI BOM from source code."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/aibom/src/aibom/manifest.json
+++ b/aibom/src/aibom/manifest.json
@@ -1,8 +1,8 @@
 {
-  "analyzer_version": "1.0.4",
-  "schema_version": "1.0.4",
+  "analyzer_version": "1.0.5",
+  "schema_version": "1.0.5",
   "duckdb_sha256": "b1165384a646094aa6a4762d676f285c1c68b6d7f9367c90a129b529904a3268",
-  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.4.duckdb",
+  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.5.duckdb",
   "upload_mode": "direct",
   "max_direct_upload_mb": 25,
   "log_level": "INFO"

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "cisco-aibom"
-version = "1.0.4"
+version = "1.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## 1.0.5 release prep

Patch release. `main` is at 1.0.4 (published) with the agentic structured-output
fixes from #50 merged on top and not yet released — this cuts them as 1.0.5.

### What's included since 1.0.4 (from #50)
- **Drop the `max_tokens` default** (regression fix). A fixed default cap
  reserved the context window for output and starved the input — every
  enrichment batch returned HTTP 400 on ~128–131K-context models (zero
  agentic enrichment by default); a low default truncates verbose reasoners.
  Now omitted by default; `--llm-max-tokens` / `AIBOM_LLM_MAX_TOKENS` is an
  opt-in override.
- **Structured-output strategy fallback** — when a batch yields no usable
  output under the primary (tool-calling) strategy, re-run those components
  once via the provider-native (`json_schema`) strategy; fallback removals are
  preserved. Only fires on failure (no extra LLM call on the happy path).
- **Character-level de-double** of gateway-corrupted content, re-validated via
  `json.loads`.

### Release-prep changes (standard set)
- `aibom/pyproject.toml` — version 1.0.4 → 1.0.5 (`uv version`)
- `aibom/uv.lock` — `cisco-aibom` version relock
- `aibom/src/aibom/manifest.json` — `analyzer_version` / `schema_version` →
  1.0.5, `duckdb_file` → `aibom_catalog-1.0.5.duckdb`. `duckdb_sha256`
  unchanged — the KB catalog content is identical; only the version-stamped
  filename changes.

### Verified
- `uv lock --check` — consistent
- `uv run pytest` — 1873 passed, 2 skipped
- No source changes in this PR (only version/manifest/lock)

The GitHub release (tag `1.0.5` + the `aibom_catalog-1.0.5.duckdb` asset) is cut
after this merges, per the release process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the package and manifest version to **1.0.5**.
  * Updated the catalog file reference to the new **1.0.5** path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->