### PR TITLE
Agentic enrichment: provider-robust temperature/tokens/retries + provider-general structured output

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,14 @@ All LLM options can also be set via environment variables or a `.env` file. See 
 | `--agentic-concurrency` | `1` | Max parallel LLM batches. |
 | `--agentic-timeout` | `120` | Wall-clock seconds per batch before timeout. |
 | `--agentic-fast-model` | — | Cheaper model for simple confirmations (model lookups, dependency checks). |
+| `--agentic-max-consecutive-failures` | `3` | Circuit-breaker threshold before skipping the rest of a tier. |
+| `--agentic-max-retry-seconds` | `1200` | Aggregate wall-clock budget for retries; bounds a failing model so the scan finishes (`0` disables retries). |
+| `--llm-reasoning` | `auto` | `off` disables model "thinking" per provider — use for verbose reasoning/self-hosted models that otherwise time out. |
+| `--llm-init-kwargs` | — | JSON of provider-specific init kwargs (advanced escape hatch). |
 | `--progress` | `auto` | Show live per-stage and per-scanner progress in interactive terminals. |
 | `--include-code-snippets` | `off` | Include raw code snippets inside per-finding decision annotations. |
+
+Running a slow self-hosted or verbose reasoning model? See [Self-hosted & reasoning-model tuning](https://github.com/cisco-ai-defense/aibom/blob/main/docs/AGENTIC_MODE.md#self-hosted--reasoning-model-tuning) — disabling "thinking" and raising the timeout/concurrency is usually the difference between real enrichment and a silent deterministic-only fallback.
 
 ### Report and cache utilities
 

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -49,7 +49,7 @@ from ..models import (
 )
 from .evidence_injection import DossierIndex, build_dossier_index
 from .middleware import AIBOMScannerMiddleware
-from .prompts import AIBOM_AGENT_SYSTEM_PROMPT
+from .prompts import AGENTIC_COERCION_PROMPT, AIBOM_AGENT_SYSTEM_PROMPT
 
 _IID_DESC = (
     "The EXACT instance_id string as provided in the input — "
@@ -84,15 +84,92 @@ def get_token_usage() -> TokenUsage:
     return _token_accumulator
 
 
+def _as_int(value: Any) -> int:
+    """Coerce a token count to int, treating missing/invalid as 0."""
+    return value if isinstance(value, int) else 0
+
+
+def _resolve_message_usage(msg: Any) -> tuple[int, int, int]:
+    """Resolve ``(prompt, completion, total)`` tokens for one AI message.
+
+    LangChain's standardized ``usage_metadata`` is preferred, but several
+    providers do not populate it and instead surface usage under
+    ``response_metadata``:
+
+    * OpenAI / Azure (incl. the ``gpt-5.3-codex`` deployment):
+      ``response_metadata['token_usage']`` with
+      ``prompt_tokens`` / ``completion_tokens`` / ``total_tokens``.
+    * AWS Bedrock Converse: ``response_metadata['usage']`` with
+      ``input_tokens`` / ``output_tokens``.
+    * AWS Bedrock Invoke: ``response_metadata['amazon-bedrock-invocationMetrics']``
+      with ``inputTokenCount`` / ``outputTokenCount``.
+
+    The first populated carrier wins, so ``usage_metadata`` (which LangChain
+    often derives from ``response_metadata``) is never double-counted. ``total``
+    is synthesized from prompt+completion when the provider omits it. Returns
+    ``(0, 0, 0)`` — logged at debug — when no carrier resolves.
+    """
+    um = getattr(msg, "usage_metadata", None)
+    if isinstance(um, dict):
+        prompt = _as_int(um.get("input_tokens"))
+        completion = _as_int(um.get("output_tokens"))
+        total = _as_int(um.get("total_tokens"))
+        if prompt or completion or total:
+            return prompt, completion, total or (prompt + completion)
+
+    rm = getattr(msg, "response_metadata", None)
+    if isinstance(rm, dict):
+        token_usage = rm.get("token_usage")
+        if isinstance(token_usage, dict):
+            prompt = _as_int(token_usage.get("prompt_tokens"))
+            completion = _as_int(token_usage.get("completion_tokens"))
+            total = _as_int(token_usage.get("total_tokens"))
+            if prompt or completion or total:
+                return prompt, completion, total or (prompt + completion)
+
+        usage = rm.get("usage")
+        if isinstance(usage, dict):
+            prompt = _as_int(usage.get("input_tokens"))
+            completion = _as_int(usage.get("output_tokens"))
+            total = _as_int(usage.get("total_tokens"))
+            if prompt or completion or total:
+                return prompt, completion, total or (prompt + completion)
+
+        metrics = rm.get("amazon-bedrock-invocationMetrics")
+        if isinstance(metrics, dict):
+            prompt = _as_int(metrics.get("inputTokenCount"))
+            completion = _as_int(metrics.get("outputTokenCount"))
+            if prompt or completion:
+                return prompt, completion, prompt + completion
+
+    return 0, 0, 0
+
+
 def _accumulate_token_usage(result: Any) -> None:
-    """Sum ``usage_metadata`` from all AI messages in a LangGraph result."""
+    """Sum token usage across all AI messages in a LangGraph result.
+
+    Reads ``usage_metadata`` when present and falls back to
+    ``response_metadata`` carriers for providers that omit it (see
+    :func:`_resolve_message_usage`).
+    """
     messages = result.get("messages", []) if isinstance(result, dict) else []
     for msg in messages:
-        um = getattr(msg, "usage_metadata", None)
-        if um and isinstance(um, dict):
-            _token_accumulator.prompt_tokens += um.get("input_tokens", 0)
-            _token_accumulator.completion_tokens += um.get("output_tokens", 0)
-            _token_accumulator.total_tokens += um.get("total_tokens", 0)
+        prompt, completion, total = _resolve_message_usage(msg)
+        if not (prompt or completion or total):
+            um = getattr(msg, "usage_metadata", None)
+            rm = getattr(msg, "response_metadata", None)
+            if um or rm:
+                _LOGGER.debug(
+                    "No resolvable token usage for %s message "
+                    "(usage_metadata=%s, response_metadata keys=%s)",
+                    type(msg).__name__,
+                    bool(um),
+                    sorted(rm) if isinstance(rm, dict) else None,
+                )
+            continue
+        _token_accumulator.prompt_tokens += prompt
+        _token_accumulator.completion_tokens += completion
+        _token_accumulator.total_tokens += total
 
 
 class _EvidenceLocation(BaseModel):
@@ -264,6 +341,8 @@ def _build_model(
         # input (HTTP 400). Users opt in via --llm-max-tokens / llm_config.
         max_tokens=cfg.get("max_tokens"),
         rate_limiter=rate_limiter,
+        reasoning=cfg.get("reasoning", "auto"),
+        init_kwargs_extra=cfg.get("init_kwargs"),
     )
 
 
@@ -290,6 +369,27 @@ def _close_model_clients(*models: Any) -> None:
                 sc.close()
         except Exception:
             pass
+
+
+class _AgentBundle:
+    """Wraps a compiled deep-agent graph and carries the underlying chat model.
+
+    The batch runners invoke the graph via ``.invoke()`` / ``.ainvoke()``; those
+    (and any other graph attribute) are transparently proxied. The extra
+    ``aibom_chat_model`` and ``needs_coercion`` attributes let the two-phase
+    structured-output path run a tool-less coercion call without
+    threading the model through every batch/tier signature.
+    """
+
+    def __init__(self, graph: Any, chat_model: Any, *, needs_coercion: bool):
+        self._graph = graph
+        self.aibom_chat_model = chat_model
+        self.needs_coercion = needs_coercion
+
+    def __getattr__(self, name: str) -> Any:
+        # Only reached for attributes not set on the bundle itself → proxy to the
+        # underlying compiled graph (invoke, ainvoke, get_state, …).
+        return getattr(self._graph, name)
 
 
 def create_aibom_agent(
@@ -324,7 +424,22 @@ def create_aibom_agent(
 
     Returns
     -------
-    A compiled LangGraph ``CompiledStateGraph`` ready for ``.invoke()``.
+    An :class:`_AgentBundle` wrapping the compiled LangGraph agent. It proxies
+    ``.invoke()`` / ``.ainvoke()`` to the graph and also carries the underlying
+    chat model so the two-phase structured-output path can run a
+    tool-less coercion call.
+
+    Two-phase structured output
+    ----------------------------------------
+    By default (``response_format is None``) the agent runs the tool loop
+    **unforced** — no structured-output tool is bound, so LangChain uses
+    ``tool_choice="auto"`` and the loop terminates naturally on every provider
+    (instead of ``ToolStrategy``'s per-turn ``tool_choice="any"``, which
+    tool-eager Claude-on-Bedrock never escapes). The structured ``AgentResponse``
+    is then produced by a separate, tool-less coercion call (see
+    :func:`_coerce_structured`). Callers that want the legacy in-loop structured
+    output (e.g. the provider-native fallback agent) pass an explicit
+    *response_format*.
     """
     from deepagents import create_deep_agent
 
@@ -333,16 +448,58 @@ def create_aibom_agent(
     if model is None:
         model = _build_model(model_string, llm_config)
 
-    agent = create_deep_agent(
+    graph = create_deep_agent(
         model=model,
         tools=tools if tools is not None else build_tools(),
         system_prompt=system_prompt or AIBOM_AGENT_SYSTEM_PROMPT,
-        response_format=(
-            response_format if response_format is not None else AgentResponse
-        ),
+        response_format=response_format,
         name="aibom-scanner",
     )
-    return agent
+    return _AgentBundle(graph, model, needs_coercion=response_format is None)
+
+
+def _supports_inloop_structured_output(
+    resolved_provider: str | None, model_id: str
+) -> bool:
+    """True when the model's LangChain integration reliably supports NATIVE
+    in-loop structured output (``create_agent`` ProviderStrategy).
+
+    Capability gate for the two-phase decouple. When True, aibom
+    keeps the single-pass agent (``response_format=AgentResponse`` → native
+    json_schema terminal — the proven, full-fidelity path for GPT). When False,
+    it uses the provider-general two-phase decouple, because LangChain's
+    ``AutoStrategy`` would otherwise route the model to ``ToolStrategy`` and bind
+    ``tool_choice="any"`` on every turn — the trap that makes tool-eager
+    Claude-on-Bedrock (and self-hosted/vLLM open models) never terminate.
+
+    Mirrors ``create_agent``'s ProviderStrategy capability for the OpenAI family
+    (gpt-*, o-series, grok, gpt-oss) on the ``openai``/``azure_openai`` providers
+    (or LangChain-inferred). Bedrock Claude (InvokeModel), native Anthropic on
+    pinned ids, Google, Ollama, and non-GPT open models served via an
+    OpenAI-compatible endpoint all fall to the two-phase path.
+    """
+    prov = (resolved_provider or "").lower()
+    if prov not in ("openai", "azure_openai", ""):
+        return False
+    leaf = model_id.rsplit("/", 1)[-1].strip().lower()
+    if leaf.startswith(("gpt-", "grok", "gpt-oss")):
+        return True
+    # o-series reasoning models: o1 / o3-mini / o4-… (an ``o`` then a digit).
+    return len(leaf) >= 2 and leaf[0] == "o" and leaf[1].isdigit()
+
+
+def _agent_response_format(model_id: str, llm_config: dict[str, Any] | None) -> Any:
+    """Pick the ``create_aibom_agent`` ``response_format`` for *model_id*.
+
+    ``AgentResponse`` (single-pass native structured output) for
+    ProviderStrategy-capable models; ``None`` (two-phase decouple) otherwise.
+    """
+    from ..llm_factory import resolve_provider
+
+    provider = resolve_provider(model_id, (llm_config or {}).get("provider"))
+    if _supports_inloop_structured_output(provider, model_id):
+        return AgentResponse
+    return None
 
 
 def _build_fallback_agent(model_string: str, model_obj: Any) -> Any | None:
@@ -378,6 +535,12 @@ _RECURSION_LIMIT = 1000
 
 _DEFAULT_AGENTIC_TIMEOUT_S = 120
 _DEFAULT_MAX_CONSECUTIVE_FAILURES = 3
+
+# Aggregate wall-clock budget (seconds) for ALL retry activity across a single
+# enrichment run. Bounds the retry pass so a persistently-failing model/gateway
+# degrades the affected components and the scan finishes, instead of retrying in
+# ever-smaller batches for hours. 0 disables the retry pass.
+_DEFAULT_MAX_RETRY_SECONDS = 1200
 
 # Hints whose batches produced no usable structured output under the primary
 # strategy and are worth one re-run with the alternate structured-output
@@ -985,6 +1148,157 @@ def _circuit_breaker_skipped_batch(batch: list[AIComponent]) -> list[AIComponent
     return _degraded_batch_components(batch, hint="circuit_breaker_tripped")
 
 
+def _apply_batch_findings(
+    middleware: AIBOMScannerMiddleware,
+    batch: list[AIComponent],
+    data: dict[str, Any],
+    batch_num: int,
+) -> tuple[
+    list[AIComponent],
+    list[AIComponent],
+    list[ComponentRelationship],
+    list[RiskFlag],
+    bool,
+]:
+    """Apply a parsed structured response to *batch*, failing OPEN per batch.
+
+    ``extract_findings_from_dict`` / ``apply_enrichments_from_dict`` operate on
+    model-supplied data that can be partial or malformed after structured-output
+    recovery. Any unexpected error here must degrade only this batch — never
+    propagate up and abort the whole agentic stage. The batch is
+    marked with a retryable hint so a later pass can still recover it.
+
+    Returns ``(enriched, new_components, new_relationships, risk_flags,
+    degraded)`` matching the batch-runner contract.
+    """
+    try:
+        new_components, new_rels, risk_flags = middleware.extract_findings_from_dict(
+            data
+        )
+        enriched = middleware.apply_enrichments_from_dict(batch, data)
+        return enriched, new_components, new_rels, risk_flags, False
+    except Exception:
+        _LOGGER.warning(
+            "Batch %d: could not apply structured output (malformed/partial "
+            "recovered data); degrading this batch only",
+            batch_num,
+            exc_info=True,
+        )
+        degraded = _degraded_batch_components(
+            batch, hint="structured_output_parse_error"
+        )
+        return degraded, [], [], [], True
+
+
+def _all_batches_failed(
+    enriched: list[AIComponent],
+    new: list[AIComponent],
+    rels: list[ComponentRelationship],
+    flags: list[RiskFlag],
+) -> bool:
+    """True when the agentic layer produced no usable output at all.
+
+    Distinguishes a *total* failure — every returned component degraded and
+    nothing discovered (e.g. a provider rejecting every batch) —
+    from the benign "examined everything and found nothing to add". Lets the
+    run surface a degraded status instead of logging "enrichment complete".
+    """
+    if new or rels or flags:
+        return False
+    considered = [c for c in enriched if c.instance_id]
+    if not considered:
+        return False
+    return all(c.agentic_hint for c in considered)
+
+
+def _coerce_structured(model: Any, messages: list[Any]) -> dict[str, Any] | None:
+    """Phase 2 of the two-phase decouple.
+
+    Turn the unforced agent's finished transcript into a schema-valid
+    ``AgentResponse`` via a single, tool-less ``with_structured_output`` call.
+    This uses each provider's *native* structured-output mechanism (OpenAI/Azure
+    json_schema, Anthropic output_config, Google response_json_schema, Bedrock a
+    single forced tool call, Ollama format=json_schema) and, having no tools,
+    cannot loop — so it terminates cleanly on every provider.
+
+    ``include_raw=True`` keeps the raw ``AIMessage`` so Phase-2 token usage is
+    still accounted and a parse error can be recovered from the message carriers.
+    Returns the response dict, or ``None`` if coercion is unavailable/failed.
+    """
+    if model is None:
+        return None
+    from langchain_core.messages import HumanMessage
+
+    try:
+        structured = model.with_structured_output(AgentResponse, include_raw=True)
+    except Exception:
+        # Some wrappers don't accept include_raw; retry without it.
+        try:
+            structured = model.with_structured_output(AgentResponse)
+        except Exception:
+            _LOGGER.debug(
+                "with_structured_output unavailable for Phase-2 coercion",
+                exc_info=True,
+            )
+            return None
+
+    prompt = list(messages) + [HumanMessage(content=AGENTIC_COERCION_PROMPT)]
+    try:
+        out = structured.invoke(prompt)
+    except Exception as exc:
+        # StructuredOutputValidationError and friends carry the offending message.
+        ai_message = getattr(exc, "ai_message", None)
+        if ai_message is not None:
+            _accumulate_token_usage({"messages": [ai_message]})
+            return _extract_structured_response({"messages": [ai_message]})
+        _LOGGER.warning("Phase-2 structured coercion failed: %s", exc)
+        return None
+
+    # include_raw shape: {"raw": AIMessage, "parsed": <model|None>, "parsing_error"}
+    if isinstance(out, dict) and ("raw" in out or "parsed" in out):
+        raw = out.get("raw")
+        if raw is not None:
+            _accumulate_token_usage({"messages": [raw]})
+        parsed = out.get("parsed")
+        if isinstance(parsed, BaseModel):
+            return parsed.model_dump()
+        if isinstance(parsed, dict):
+            return parsed
+        if raw is not None:
+            return _extract_structured_response({"messages": [raw]})
+        return None
+
+    # No include_raw: a direct model / dict.
+    if isinstance(out, BaseModel):
+        return out.model_dump()
+    if isinstance(out, dict):
+        return out
+    return None
+
+
+def _resolve_batch_data(agent: Any, result: Any) -> dict[str, Any] | None:
+    """Get the structured ``AgentResponse`` dict from a finished batch.
+
+    Prefers the cheap multi-carrier extractor (``structured_response`` / tool
+    calls / parsed / JSON-in-text) — which already yields data for legacy or
+    provider-native (ProviderStrategy fallback) agents, and for unforced agents
+    whose final message is clean JSON. Only when that finds nothing AND the agent
+    is an unforced Phase-1 agent does it spend a Phase-2 ``_coerce_structured``
+    call. Keeps ``recursion_limit`` untouched and adds no extra call on the happy
+    path.
+    """
+    data = _extract_structured_response(result)
+    if data:
+        return data
+    # ``is True`` (not just truthy) so an incidental MagicMock agent in unrelated
+    # tests never trips Phase 2 — only a real unforced bundle sets a bool True.
+    if getattr(agent, "needs_coercion", False) is True:
+        model = getattr(agent, "aibom_chat_model", None)
+        messages = result.get("messages", []) if isinstance(result, dict) else []
+        return _coerce_structured(model, messages)
+    return None
+
+
 class _InvokeTimeout(Exception):
     """Raised when a synchronous ``agent.invoke`` exceeds its wall-clock deadline.
 
@@ -1222,9 +1536,7 @@ def _run_batch(
             _LOGGER.info(
                 "Batch %d: recovering partial results from failed run", batch_num
             )
-            new_c, new_r, rf = middleware.extract_findings_from_dict(data)
-            enriched = middleware.apply_enrichments_from_dict(batch, data)
-            return enriched, new_c, new_r, rf, False
+            return _apply_batch_findings(middleware, batch, data, batch_num)
         hint = _classify_failure_hint(exc)
         enriched = _degraded_batch_components(batch, hint=hint)
         return enriched, [], [], [], True
@@ -1244,7 +1556,7 @@ def _run_batch(
         json.dumps(stats),
     )
 
-    data = _extract_structured_response(result)
+    data = _resolve_batch_data(agent, result)
     if not data:
         if _refusal_present(result):
             _LOGGER.warning("Batch %d: model refused", batch_num)
@@ -1264,9 +1576,7 @@ def _run_batch(
             True,
         )
 
-    new_components, new_rels, risk_flags = middleware.extract_findings_from_dict(data)
-    enriched = middleware.apply_enrichments_from_dict(batch, data)
-    return enriched, new_components, new_rels, risk_flags, False
+    return _apply_batch_findings(middleware, batch, data, batch_num)
 
 
 async def _run_batch_async(
@@ -1358,9 +1668,7 @@ async def _run_batch_async(
             _LOGGER.info(
                 "Batch %d: recovering partial results from failed run", batch_num
             )
-            new_c, new_r, rf = middleware.extract_findings_from_dict(data)
-            enriched = middleware.apply_enrichments_from_dict(batch, data)
-            return enriched, new_c, new_r, rf, False
+            return _apply_batch_findings(middleware, batch, data, batch_num)
         hint = _classify_failure_hint(exc)
         enriched = _degraded_batch_components(batch, hint=hint)
         return enriched, [], [], [], True
@@ -1380,7 +1688,7 @@ async def _run_batch_async(
         json.dumps(stats),
     )
 
-    data = _extract_structured_response(result)
+    data = _resolve_batch_data(agent, result)
     if not data:
         if _refusal_present(result):
             _LOGGER.warning("Batch %d: model refused", batch_num)
@@ -1400,9 +1708,7 @@ async def _run_batch_async(
             True,
         )
 
-    new_components, new_rels, risk_flags = middleware.extract_findings_from_dict(data)
-    enriched = middleware.apply_enrichments_from_dict(batch, data)
-    return enriched, new_components, new_rels, risk_flags, False
+    return _apply_batch_findings(middleware, batch, data, batch_num)
 
 
 async def _run_batches_parallel(
@@ -1643,6 +1949,7 @@ def _run_tier(
     memo: _DecisionMemo | None = None,
     timeout_s: int = _DEFAULT_AGENTIC_TIMEOUT_S,
     max_consecutive_failures: int = _DEFAULT_MAX_CONSECUTIVE_FAILURES,
+    retry_deadline: float | None = None,
     dossier_index: DossierIndex | None = None,
     fallback_agent_factory: Any | None = None,
 ) -> tuple[
@@ -1797,6 +2104,18 @@ def _run_tier(
         retry_flags: list[RiskFlag] = []
         retry_consecutive = 0
         for idx, batch in enumerate(retry_batches, 1):
+            if retry_deadline is not None and time.monotonic() >= retry_deadline:
+                remaining = sum(len(b) for b in retry_batches[idx - 1 :])
+                _LOGGER.warning(
+                    "Aborting retries after budget exhausted; "
+                    "%d component(s) left degraded",
+                    remaining,
+                )
+                for b in retry_batches[idx - 1 :]:
+                    retry_enriched.extend(
+                        _degraded_batch_components(b, hint="retry_budget_exhausted")
+                    )
+                break
             if retry_consecutive >= max_consecutive_failures:
                 _LOGGER.warning(
                     "Retry circuit breaker: skipping retry batches %d–%d",
@@ -1830,12 +2149,11 @@ def _run_tier(
             else:
                 retry_consecutive = 0
 
-        recovered = sum(
-            1
-            for c in retry_enriched
-            if c.agentic_hint not in _RETRYABLE_HINTS
-            and c.agentic_hint != "retry_failed"
-        )
+        # A component is genuinely recovered only when it comes back with no
+        # failure hint. Degraded terminal states (retry_failed,
+        # retry_budget_exhausted) or a still-set retryable hint are NOT
+        # recovered, so they are not counted here.
+        recovered = sum(1 for c in retry_enriched if not c.agentic_hint)
         still_degraded = len(retry_candidates) - recovered
         _LOGGER.info(
             "Retry pass complete: %d/%d recovered, %d still degraded",
@@ -1852,9 +2170,13 @@ def _run_tier(
     # Structured-output strategy fallback: components that yielded no usable
     # output under the primary strategy get one re-run via the alternate
     # (provider-native) strategy. Only fires when such failures exist, so the
-    # happy path makes no extra LLM call.
-    if fallback_agent_factory is not None and any(
-        c.agentic_hint in _STRATEGY_FALLBACK_HINTS for c in enriched
+    # happy path makes no extra LLM call. Skipped once the retry budget is
+    # exhausted so it cannot extend a runaway.
+    budget_left = retry_deadline is None or time.monotonic() < retry_deadline
+    if (
+        fallback_agent_factory is not None
+        and budget_left
+        and any(c.agentic_hint in _STRATEGY_FALLBACK_HINTS for c in enriched)
     ):
         fb_agent = fallback_agent_factory()
         if fb_agent is not None:
@@ -1972,6 +2294,7 @@ def run_agentic_enrichment(
     fast_model: str | None = None,
     timeout_s: int = _DEFAULT_AGENTIC_TIMEOUT_S,
     max_consecutive_failures: int = _DEFAULT_MAX_CONSECUTIVE_FAILURES,
+    max_retry_seconds: int = _DEFAULT_MAX_RETRY_SECONDS,
     cache_dir: Path | None = None,
     include_code_snippets: bool = False,
     agent_signature_catalog: AgentSignatureCatalog | None = None,
@@ -2022,6 +2345,10 @@ def run_agentic_enrichment(
 
     set_allowed_search_roots([str(Path(p).resolve()) for p in scan_paths])
     _reset_token_usage()
+
+    # Shared retry deadline for the whole run: bounds total retry wall-clock
+    # across every tier / sub-agent / strategy-fallback pass.
+    retry_deadline = time.monotonic() + max_retry_seconds
 
     simple, complex_ = _classify_candidates(deterministic_components)
 
@@ -2089,7 +2416,11 @@ def run_agentic_enrichment(
                 tier_model_name,
                 simple_batch_size,
             )
-            agent = create_aibom_agent(tier_model_name, model=tier_model_obj)
+            agent = create_aibom_agent(
+                tier_model_name,
+                model=tier_model_obj,
+                response_format=_agent_response_format(tier_model_name, llm_config),
+            )
             e, n, r, f = _run_tier(
                 agent,
                 middleware,
@@ -2103,6 +2434,7 @@ def run_agentic_enrichment(
                 memo=memo,
                 timeout_s=timeout_s,
                 max_consecutive_failures=max_consecutive_failures,
+                retry_deadline=retry_deadline,
                 dossier_index=dossier_index,
                 fallback_agent_factory=_simple_fb_factory,
             )
@@ -2133,7 +2465,13 @@ def run_agentic_enrichment(
                         len(group),
                         model_string,
                     )
-                    agent = create_aibom_agent(model_string, model=complex_model_obj)
+                    agent = create_aibom_agent(
+                        model_string,
+                        model=complex_model_obj,
+                        response_format=_agent_response_format(
+                            model_string, llm_config
+                        ),
+                    )
                     e, n, r, f = _run_tier(
                         agent,
                         middleware,
@@ -2147,6 +2485,7 @@ def run_agentic_enrichment(
                         memo=memo,
                         timeout_s=timeout_s,
                         max_consecutive_failures=max_consecutive_failures,
+                        retry_deadline=retry_deadline,
                         dossier_index=dossier_index,
                         fallback_agent_factory=_complex_fb_factory,
                     )
@@ -2160,7 +2499,11 @@ def run_agentic_enrichment(
                     len(complex_),
                     model_string,
                 )
-                agent = create_aibom_agent(model_string, model=complex_model_obj)
+                agent = create_aibom_agent(
+                    model_string,
+                    model=complex_model_obj,
+                    response_format=_agent_response_format(model_string, llm_config),
+                )
                 e, n, r, f = _run_tier(
                     agent,
                     middleware,
@@ -2174,6 +2517,7 @@ def run_agentic_enrichment(
                     memo=memo,
                     timeout_s=timeout_s,
                     max_consecutive_failures=max_consecutive_failures,
+                    retry_deadline=retry_deadline,
                     dossier_index=dossier_index,
                     fallback_agent_factory=_complex_fb_factory,
                 )
@@ -2187,17 +2531,36 @@ def run_agentic_enrichment(
     all_components = all_enriched + all_new
 
     usage = get_token_usage()
-    _LOGGER.info(
-        "Agentic enrichment complete: %d enriched, %d new components, "
-        "%d new relationships, %d risk flags, tokens=%d (prompt=%d, completion=%d)",
-        len(all_enriched),
-        len(all_new),
-        len(all_rels),
-        len(all_flags),
-        usage.total_tokens,
-        usage.prompt_tokens,
-        usage.completion_tokens,
-    )
+    if _all_batches_failed(all_enriched, all_new, all_rels, all_flags):
+        from collections import Counter
+
+        hints = Counter(c.agentic_hint for c in all_enriched if c.agentic_hint)
+        dominant = hints.most_common(1)[0][0] if hints else "unknown"
+        _LOGGER.warning(
+            "Agentic enrichment DEGRADED: all %d components failed enrichment "
+            "(dominant hint: %s); the LLM added nothing, so the BOM is "
+            "deterministic-only. Check the provider/model configuration "
+            "(credentials, model access, request params). "
+            "tokens=%d (prompt=%d, completion=%d)",
+            len(all_enriched),
+            dominant,
+            usage.total_tokens,
+            usage.prompt_tokens,
+            usage.completion_tokens,
+        )
+    else:
+        _LOGGER.info(
+            "Agentic enrichment complete: %d enriched, %d new components, "
+            "%d new relationships, %d risk flags, "
+            "tokens=%d (prompt=%d, completion=%d)",
+            len(all_enriched),
+            len(all_new),
+            len(all_rels),
+            len(all_flags),
+            usage.total_tokens,
+            usage.prompt_tokens,
+            usage.completion_tokens,
+        )
 
     return all_components, all_rels, all_flags, usage
 

--- a/aibom/src/aibom/agentic/middleware.py
+++ b/aibom/src/aibom/agentic/middleware.py
@@ -47,6 +47,18 @@ from ..models import (
 _LOGGER = logging.getLogger(__name__)
 
 
+def _skip_non_dict(field: str, item: Any) -> None:
+    """Log a skipped non-dict list item from a structured-output section.
+
+    Partial/garbled provider output can splice a bare string (or other non-dict)
+    into a list the middleware iterates. Each extractor skips such entries to
+    avoid ``AttributeError``; logging at debug keeps that observable — a provider
+    frequently emitting malformed output is otherwise invisible — without the
+    noise of a warning for a recoverable, per-item condition.
+    """
+    _LOGGER.debug("Skipping non-dict %s item: %r", field, item)
+
+
 def _ckey(c: AIComponent) -> tuple[str, str]:
     """Consolidation key matching ``scan_pipeline._consolidation_key``."""
     canonical = (c.model_name or c.name).lower().strip()
@@ -1096,6 +1108,7 @@ class AIBOMScannerMiddleware:
         remove_keys: set[tuple[str, str]] = set()
         for item in data.get("remove_components", []):
             if not isinstance(item, dict):
+                _skip_non_dict("remove_components", item)
                 continue
             iid = item.get("instance_id", "")
             if not iid:
@@ -1181,6 +1194,7 @@ class AIBOMScannerMiddleware:
         reclassify_map: dict[str, str] = {}
         for item in data.get("reclassify_components", []):
             if not isinstance(item, dict):
+                _skip_non_dict("reclassify_components", item)
                 continue
             iid = item.get("instance_id", "")
             new_type = item.get("new_type", "")
@@ -1213,6 +1227,7 @@ class AIBOMScannerMiddleware:
         reclassify_evidence: dict[str, dict[str, Any]] = {}
         for item in data.get("reclassify_components", []):
             if not isinstance(item, dict):
+                _skip_non_dict("reclassify_components", item)
                 continue
             iid = item.get("instance_id", "")
             if iid in reclassify_map:
@@ -1225,6 +1240,7 @@ class AIBOMScannerMiddleware:
         annotations_by_id: dict[str, DecisionAnnotation] = {}
         for item in data.get("enriched_components", []):
             if not isinstance(item, dict):
+                _skip_non_dict("enriched_components", item)
                 continue
             iid = item.get("instance_id", "")
             if not iid:
@@ -1373,6 +1389,7 @@ class AIBOMScannerMiddleware:
         components: list[AIComponent] = []
         for item in data.get("new_components", []):
             if not isinstance(item, dict):
+                _skip_non_dict("new_components", item)
                 continue
             try:
                 comp_type = AIComponentType(item.get("component_type", "other"))
@@ -1469,6 +1486,7 @@ class AIBOMScannerMiddleware:
         relationships: list[ComponentRelationship] = []
         for item in data.get("new_relationships", []):
             if not isinstance(item, dict):
+                _skip_non_dict("new_relationships", item)
                 continue
             try:
                 rel_type = RelationshipType(item.get("relationship_type", "CUSTOM"))
@@ -1563,6 +1581,7 @@ class AIBOMScannerMiddleware:
         flags: list[RiskFlag] = []
         for item in data.get("risk_findings", []):
             if not isinstance(item, dict):
+                _skip_non_dict("risk_findings", item)
                 continue
             flag_name = item.get("flag", "")
             try:

--- a/aibom/src/aibom/agentic/middleware.py
+++ b/aibom/src/aibom/agentic/middleware.py
@@ -1095,6 +1095,8 @@ class AIBOMScannerMiddleware:
         remove_ids: set[str] = set()
         remove_keys: set[tuple[str, str]] = set()
         for item in data.get("remove_components", []):
+            if not isinstance(item, dict):
+                continue
             iid = item.get("instance_id", "")
             if not iid:
                 continue
@@ -1178,6 +1180,8 @@ class AIBOMScannerMiddleware:
 
         reclassify_map: dict[str, str] = {}
         for item in data.get("reclassify_components", []):
+            if not isinstance(item, dict):
+                continue
             iid = item.get("instance_id", "")
             new_type = item.get("new_type", "")
             if not (iid and new_type):
@@ -1208,6 +1212,8 @@ class AIBOMScannerMiddleware:
 
         reclassify_evidence: dict[str, dict[str, Any]] = {}
         for item in data.get("reclassify_components", []):
+            if not isinstance(item, dict):
+                continue
             iid = item.get("instance_id", "")
             if iid in reclassify_map:
                 evidence = item.get("agent_evidence")
@@ -1218,6 +1224,8 @@ class AIBOMScannerMiddleware:
         enrichment_evidence: dict[str, dict[str, Any]] = {}
         annotations_by_id: dict[str, DecisionAnnotation] = {}
         for item in data.get("enriched_components", []):
+            if not isinstance(item, dict):
+                continue
             iid = item.get("instance_id", "")
             if not iid:
                 continue
@@ -1364,6 +1372,8 @@ class AIBOMScannerMiddleware:
     def _extract_new_components(self, data: dict[str, Any]) -> list[AIComponent]:
         components: list[AIComponent] = []
         for item in data.get("new_components", []):
+            if not isinstance(item, dict):
+                continue
             try:
                 comp_type = AIComponentType(item.get("component_type", "other"))
             except ValueError:
@@ -1458,6 +1468,8 @@ class AIBOMScannerMiddleware:
     def _extract_relationships(self, data: dict[str, Any]) -> list[ComponentRelationship]:
         relationships: list[ComponentRelationship] = []
         for item in data.get("new_relationships", []):
+            if not isinstance(item, dict):
+                continue
             try:
                 rel_type = RelationshipType(item.get("relationship_type", "CUSTOM"))
             except ValueError:
@@ -1550,6 +1562,8 @@ class AIBOMScannerMiddleware:
 
         flags: list[RiskFlag] = []
         for item in data.get("risk_findings", []):
+            if not isinstance(item, dict):
+                continue
             flag_name = item.get("flag", "")
             try:
                 severity = Severity(item.get("severity", "info"))

--- a/aibom/src/aibom/agentic/prompts.py
+++ b/aibom/src/aibom/agentic/prompts.py
@@ -981,6 +981,26 @@ Return a SINGLE JSON object:
 """
 
 
+# Phase-2 coercion instruction. The tool-using agent runs UNFORCED
+# in phase 1 (no response_format) so it terminates naturally on every provider;
+# this instruction then drives a single, tool-less ``with_structured_output``
+# call that turns the gathered findings into a schema-valid ``AgentResponse``.
+AGENTIC_COERCION_PROMPT = """\
+Based on your analysis and tool findings above, produce the final AIBOM result now.
+
+Emit a single AgentResponse object capturing everything you determined:
+- enriched_components: field updates / decision annotations for existing candidates
+- new_components: components you discovered that were not in the input
+- remove_components: input candidates that are not real AI components
+- reclassify_components: candidates whose component_type should change
+- new_relationships: relationships between components
+- risk_findings: risks you identified
+
+Use only what the analysis above supports — do NOT invent components, and use
+empty lists for anything with nothing to report. Do not call any tools.
+"""
+
+
 TRIAGE_AGENT_SYSTEM_PROMPT = """\
 You are a repository triage agent for an AI Bill of Materials (AIBOM) scanner.
 Your job: decide whether a repository contains AI/ML assets worth scanning.

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -289,6 +289,8 @@ def _scan_cache_settings(
     agentic_concurrency: int,
     agentic_fast_model: Optional[str],
     agentic_timeout: int,
+    agentic_max_consecutive_failures: int,
+    agentic_max_retry_seconds: int,
     include_code_snippets: bool,
     container_tier: str,
     custom_catalog: Optional[Path],
@@ -301,6 +303,8 @@ def _scan_cache_settings(
             "provider": llm_config.get("provider"),
             "api_base": llm_config.get("api_base"),
             "api_version": llm_config.get("api_version"),
+            "reasoning": llm_config.get("reasoning"),
+            "init_kwargs": llm_config.get("init_kwargs"),
         }
     return {
         "strict": strict,
@@ -311,6 +315,8 @@ def _scan_cache_settings(
         "agentic_concurrency": agentic_concurrency,
         "agentic_fast_model": agentic_fast_model,
         "agentic_timeout": agentic_timeout,
+        "agentic_max_consecutive_failures": agentic_max_consecutive_failures,
+        "agentic_max_retry_seconds": agentic_max_retry_seconds,
         "include_code_snippets": include_code_snippets,
         "container_tier": container_tier,
         "custom_catalog": _file_cache_fingerprint(custom_catalog),
@@ -386,6 +392,8 @@ def _gather_analysis_sources(
     llm_api_key: Optional[str],
     llm_api_version: Optional[str],
     llm_max_tokens: Optional[int],
+    llm_reasoning: str = "auto",
+    llm_init_kwargs: Optional[Dict[str, Any]] = None,
 ) -> List[str]:
     sources_to_process = list(sources) if sources else []
     if images_file:
@@ -468,6 +476,10 @@ def _gather_analysis_sources(
             triage_llm_cfg["api_version"] = llm_api_version
         if llm_max_tokens is not None:
             triage_llm_cfg["max_tokens"] = llm_max_tokens
+        if llm_reasoning and llm_reasoning != "auto":
+            triage_llm_cfg["reasoning"] = llm_reasoning
+        if llm_init_kwargs is not None:
+            triage_llm_cfg["init_kwargs"] = llm_init_kwargs
 
         triager = RepoTriager(llm_config=triage_llm_cfg)
         triage_results = triager.triage_repos(sources_to_process)
@@ -1346,6 +1358,30 @@ def analyze(
             "lower it to bound cost."
         ),
     ),
+    llm_reasoning: str = typer.Option(
+        "auto",
+        "--llm-reasoning",
+        envvar="AIBOM_LLM_REASONING",
+        help=(
+            "Control model 'thinking'/reasoning for agentic enrichment: "
+            "'auto' (provider default, no change), 'off' (disable — emits the "
+            "correct per-provider parameter), or 'on'. Use 'off' for "
+            "reasoning-class/self-hosted models whose verbose thinking makes "
+            "every batch exceed --agentic-timeout."
+        ),
+    ),
+    llm_init_kwargs: Optional[str] = typer.Option(
+        None,
+        "--llm-init-kwargs",
+        envvar="AIBOM_LLM_INIT_KWARGS",
+        help=(
+            "JSON object of provider-specific init kwargs merged verbatim into "
+            "the LLM constructor and overriding derived settings. Keys are "
+            "provider-specific (extra_body, model_kwargs, "
+            "additional_model_request_fields, reasoning_effort, ...). "
+            "Escape hatch for advanced tuning."
+        ),
+    ),
     show_summary: bool = typer.Option(
         True,
         "--show-summary/--no-show-summary",
@@ -1433,6 +1469,29 @@ def analyze(
         120,
         "--agentic-timeout",
         help="Wall-clock timeout (seconds) per agentic LLM batch (default 120).",
+    ),
+    agentic_max_consecutive_failures: int = typer.Option(
+        3,
+        "--agentic-max-consecutive-failures",
+        envvar="AIBOM_AGENTIC_MAX_FAILURES",
+        min=1,
+        help=(
+            "Circuit-breaker threshold: skip the rest of a tier after this many "
+            "consecutive batch failures (default 3). Raise it for a flaky "
+            "endpoint you still want to push through."
+        ),
+    ),
+    agentic_max_retry_seconds: int = typer.Option(
+        1200,
+        "--agentic-max-retry-seconds",
+        envvar="AIBOM_AGENTIC_MAX_RETRY_SECONDS",
+        min=0,
+        help=(
+            "Aggregate wall-clock budget (seconds) for all agentic retry "
+            "activity in a run (default 1200). Bounds a persistently-failing "
+            "model so the scan finishes with degraded components instead of "
+            "retrying for hours. 0 disables the retry pass."
+        ),
     ),
     include_code_snippets: bool = typer.Option(
         False,
@@ -1613,6 +1672,34 @@ def analyze(
         )
         raise typer.Exit(code=1)
 
+    reasoning_choice = (llm_reasoning or "auto").lower()
+    if reasoning_choice not in ("auto", "off", "on"):
+        console.print(
+            f"[bold red]Error:[/] Invalid --llm-reasoning value "
+            f"'{escape(llm_reasoning)}'. Must be: auto, off, on.",
+            highlight=False,
+        )
+        raise typer.Exit(code=1)
+
+    parsed_init_kwargs: Optional[Dict[str, Any]] = None
+    if llm_init_kwargs is not None:
+        try:
+            parsed_init_kwargs = json.loads(llm_init_kwargs)
+        except json.JSONDecodeError as exc:
+            console.print(
+                f"[bold red]Error:[/] --llm-init-kwargs is not valid JSON: "
+                f"{escape(str(exc))}",
+                highlight=False,
+            )
+            raise typer.Exit(code=1)
+        if not isinstance(parsed_init_kwargs, dict):
+            console.print(
+                "[bold red]Error:[/] --llm-init-kwargs must be a JSON object "
+                "(e.g. '{\"extra_body\": {...}}').",
+                highlight=False,
+            )
+            raise typer.Exit(code=1)
+
     llm_config = None
     if llm_model:
         llm_config = {
@@ -1621,9 +1708,12 @@ def analyze(
             "api_key": llm_api_key,
             "api_base": llm_api_base,
             "api_version": llm_api_version,
+            "reasoning": reasoning_choice,
         }
         if llm_max_tokens is not None:
             llm_config["max_tokens"] = llm_max_tokens
+        if parsed_init_kwargs is not None:
+            llm_config["init_kwargs"] = parsed_init_kwargs
         try:
             ensure_llm_runtime_available(
                 llm_model,
@@ -1663,6 +1753,8 @@ def analyze(
         llm_api_key=llm_api_key,
         llm_api_version=llm_api_version,
         llm_max_tokens=llm_max_tokens,
+        llm_reasoning=reasoning_choice,
+        llm_init_kwargs=parsed_init_kwargs,
     )
 
     if not sources_to_process:
@@ -1704,6 +1796,8 @@ def analyze(
         agentic_concurrency=agentic_concurrency,
         agentic_fast_model=agentic_fast_model,
         agentic_timeout=agentic_timeout,
+        agentic_max_consecutive_failures=agentic_max_consecutive_failures,
+        agentic_max_retry_seconds=agentic_max_retry_seconds,
         include_code_snippets=include_code_snippets,
         container_tier=container_tier,
         custom_catalog=custom_catalog,
@@ -1866,6 +1960,8 @@ def analyze(
             agentic_concurrency=agentic_concurrency,
             agentic_fast_model=agentic_fast_model,
             agentic_timeout=agentic_timeout,
+            agentic_max_consecutive_failures=agentic_max_consecutive_failures,
+            agentic_max_retry_seconds=agentic_max_retry_seconds,
             agentic_cache_dir=agentic_cache_dir,
             include_code_snippets=include_code_snippets,
             custom_catalog=explicit_config,

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -1691,7 +1691,7 @@ def analyze(
                 f"{escape(str(exc))}",
                 highlight=False,
             )
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1) from exc
         if not isinstance(parsed_init_kwargs, dict):
             console.print(
                 "[bold red]Error:[/] --llm-init-kwargs must be a JSON object "

--- a/aibom/src/aibom/llm_factory.py
+++ b/aibom/src/aibom/llm_factory.py
@@ -37,6 +37,42 @@ _REASONING_MODEL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Newer-generation Anthropic Claude models — reached via the native
+# ``anthropic`` provider OR via ``bedrock`` — removed the sampling parameters:
+# sending an explicit ``temperature`` returns HTTP 400 (native) or
+# ``ValidationException: temperature is deprecated for this model`` (Bedrock).
+# The deprecation begins at Opus 4.7. Matched on the leaf id after
+# stripping any ``provider/`` prefix, Bedrock regional inference-profile prefix
+# (``us.``/``eu.``/``apac.``/``global.``), and the ``anthropic.`` vendor segment.
+_TEMPERATURE_DEPRECATED_CLAUDE_RE = re.compile(
+    r"^claude-(?:"
+    r"opus-4-(?:[7-9]|\d{2,})"  # opus 4.7, 4.8, 4.9, 4.10+
+    r"|opus-[5-9]"  # opus 5+
+    r"|sonnet-[5-9]"  # sonnet 5+
+    r"|fable-[5-9]"  # fable 5+
+    r")",
+    re.IGNORECASE,
+)
+
+_BEDROCK_REGION_PREFIX_RE = re.compile(
+    r"^(?:us|eu|apac|global)\.", re.IGNORECASE
+)
+
+
+def _leaf_model_id(model_id: str) -> str:
+    """Normalize *model_id* to a bare leaf for capability regexes.
+
+    Drops any ``provider/`` prefix, then any Bedrock regional inference-profile
+    prefix (``us.``/``eu.``/``apac.``/``global.``), then a leading
+    ``anthropic.`` vendor segment, so ``bedrock/us.anthropic.claude-opus-4-8``
+    and ``claude-opus-4-8`` both reduce to ``claude-opus-4-8``.
+    """
+    leaf = model_id.rsplit("/", 1)[-1].strip()
+    leaf = _BEDROCK_REGION_PREFIX_RE.sub("", leaf)
+    if leaf.lower().startswith("anthropic."):
+        leaf = leaf[len("anthropic."):]
+    return leaf
+
 
 def _is_reasoning_model(model_id: str) -> bool:
     """True for OpenAI reasoning-class models (o-series, gpt-5.x).
@@ -44,8 +80,97 @@ def _is_reasoning_model(model_id: str) -> bool:
     These models do not accept ``max_tokens`` or a custom ``temperature``.
     Detection is on the leaf model id with any ``provider/`` prefix stripped.
     """
-    leaf = model_id.rsplit("/", 1)[-1].strip()
-    return bool(_REASONING_MODEL_RE.match(leaf))
+    return bool(_REASONING_MODEL_RE.match(_leaf_model_id(model_id)))
+
+
+def _rejects_explicit_temperature(
+    model_id: str, resolved_provider: str | None
+) -> bool:
+    """True when passing an explicit ``temperature`` would be rejected.
+
+    Covers OpenAI/Azure reasoning models (o-series, gpt-5.x) on any provider,
+    and the newer Claude generation (Opus 4.7+, Sonnet 5+, Fable 5+) on the
+    ``anthropic`` / ``bedrock`` providers (and their variants, and the
+    LangChain-inferred ``provider=None`` path for a bare ``claude-…`` id).
+    Everywhere else ``temperature=0.0`` is accepted and kept for determinism.
+    """
+    leaf = _leaf_model_id(model_id)
+    if _REASONING_MODEL_RE.match(leaf):
+        return True
+    claude_capable_provider = resolved_provider is None or (
+        "anthropic" in resolved_provider or "bedrock" in resolved_provider
+    )
+    if claude_capable_provider and _TEMPERATURE_DEPRECATED_CLAUDE_RE.match(leaf):
+        return True
+    return False
+
+
+def _provider_family(resolved_provider: str | None, model_id: str) -> str:
+    """Coarse provider family for request-param mapping.
+
+    Explicit provider wins; otherwise infer from the leaf model id. Returns one
+    of ``openai`` / ``anthropic`` / ``bedrock`` / ``google`` / ``ollama``.
+    ``openai`` also covers Azure and OpenAI-compatible (vLLM) endpoints.
+    """
+    prov = (resolved_provider or "").lower()
+    leaf = _leaf_model_id(model_id).lower()
+    if "bedrock" in prov:
+        return "bedrock"
+    if "anthropic" in prov or (not prov and leaf.startswith("claude")):
+        return "anthropic"
+    if "google" in prov or (not prov and leaf.startswith("gemini")):
+        return "google"
+    if "ollama" in prov:
+        return "ollama"
+    return "openai"
+
+
+def _reasoning_control_kwargs(
+    resolved_provider: str | None, model_id: str, reasoning: str
+) -> dict[str, Any]:
+    """Provider-correct kwargs to disable/enable model "thinking".
+
+    ``reasoning`` is ``auto`` (default — inject nothing), ``off`` (disable), or
+    ``on`` (enable where a toggle exists). The disable kwarg differs per
+    provider, so it is keyed on the provider family and an OpenAI-only key
+    (``extra_body``) never leaks to another provider:
+
+    * openai / azure_openai (and vLLM): native reasoning models →
+      ``reasoning_effort='minimal'``; OpenAI-compatible open models →
+      ``extra_body={'chat_template_kwargs': {'enable_thinking': <bool>}}``.
+    * anthropic → ``thinking={'type': 'disabled'}``.
+    * bedrock → ``model_kwargs={'thinking': {'type': 'disabled'}}`` (InvokeModel body).
+    * google_genai → ``thinking_budget=0``.
+    * ollama → no toggle (no-op).
+    """
+    if reasoning not in ("off", "on"):
+        return {}
+    family = _provider_family(resolved_provider, model_id)
+
+    if reasoning == "off":
+        if family == "openai":
+            if _is_reasoning_model(model_id):
+                return {"reasoning_effort": "minimal"}
+            return {"extra_body": {"chat_template_kwargs": {"enable_thinking": False}}}
+        if family == "bedrock":
+            # ChatBedrock drives Claude over the InvokeModel path, whose body is
+            # the Anthropic Messages format — the thinking control belongs in the
+            # request body via ``model_kwargs``. ``additional_model_request_fields``
+            # is Converse-only and the InvokeModel API rejects it with
+            # "Extra inputs are not permitted" (verified live on Opus 4.8).
+            return {"model_kwargs": {"thinking": {"type": "disabled"}}}
+        if family == "anthropic":
+            return {"thinking": {"type": "disabled"}}
+        if family == "google":
+            return {"thinking_budget": 0}
+        return {}
+
+    # reasoning == "on": only the vLLM/OpenAI-compatible chat-template toggle is
+    # safe to force on generically; native reasoners and other providers reason
+    # by default, so leave them untouched.
+    if family == "openai" and not _is_reasoning_model(model_id):
+        return {"extra_body": {"chat_template_kwargs": {"enable_thinking": True}}}
+    return {}
 
 
 try:
@@ -113,6 +238,8 @@ def build_chat_model(
     temperature: float = 0.0,
     max_tokens: int | None = None,
     rate_limiter: Any | None = None,
+    reasoning: str = "auto",
+    init_kwargs_extra: dict[str, Any] | None = None,
 ) -> Any:
     """Build a LangChain ``BaseChatModel`` with unified provider routing.
 
@@ -141,6 +268,16 @@ def build_chat_model(
         choose its own default.
     rate_limiter:
         Optional ``langchain_core.rate_limiters.BaseRateLimiter``.
+    reasoning:
+        ``auto`` (default, no change), ``off``, or ``on``. ``off`` emits the
+        provider-correct thinking-disable parameter (see
+        :func:`_reasoning_control_kwargs`) so reasoning-class models can be
+        driven without every batch timing out.
+    init_kwargs_extra:
+        Optional dict of provider-specific init kwargs merged verbatim into the
+        ``init_chat_model`` call, LAST, so it overrides everything above. Keys
+        are provider-specific (e.g. ``extra_body``, ``model_kwargs``,
+        ``additional_model_request_fields``, ``reasoning_effort``).
     """
     resolved_provider = ensure_llm_runtime_available(
         model_string,
@@ -170,18 +307,36 @@ def build_chat_model(
     if api_version and resolved_provider == "azure_openai":
         init_kwargs["api_version"] = api_version
 
-    # Reasoning-class models (o-series, gpt-5.x) reject ``max_tokens`` and a
-    # non-default ``temperature``; emit ``max_completion_tokens`` instead and
-    # omit ``temperature`` so the provider applies its required default.
-    if _is_reasoning_model(model_id):
-        if max_tokens is not None:
+    # ``max_tokens`` and ``temperature`` are independent axes.
+    #
+    # max_tokens: OpenAI reasoning-class models (o-series, gpt-5.x) reject
+    # ``max_tokens`` and require ``max_completion_tokens``; every other
+    # provider uses ``max_tokens``.
+    if max_tokens is not None:
+        if _is_reasoning_model(model_id):
             init_kwargs["max_completion_tokens"] = max_tokens
-    else:
-        init_kwargs["temperature"] = temperature
-        if max_tokens is not None:
+        else:
             init_kwargs["max_tokens"] = max_tokens
+
+    # temperature: pin 0.0 for determinism (BOM reproducibility) wherever the
+    # provider/model accepts it, but OMIT it where an explicit temperature is
+    # rejected — OpenAI/Azure reasoning models and newer Claude (Opus 4.7+,
+    # Sonnet 5+, Fable 5+) on the anthropic/bedrock providers.
+    # Omission lets the provider apply its own required default.
+    if not _rejects_explicit_temperature(model_id, resolved_provider):
+        init_kwargs["temperature"] = temperature
 
     if rate_limiter is not None:
         init_kwargs["rate_limiter"] = rate_limiter
+
+    # Provider-correct reasoning/thinking control (--llm-reasoning).
+    init_kwargs.update(
+        _reasoning_control_kwargs(resolved_provider, model_id, reasoning)
+    )
+
+    # Generic per-provider passthrough (--llm-init-kwargs): merged verbatim and
+    # LAST so power users can override anything above. Keys are provider-specific.
+    if init_kwargs_extra:
+        init_kwargs.update(init_kwargs_extra)
 
     return init_chat_model(model_id, **init_kwargs)

--- a/aibom/src/aibom/llm_factory.py
+++ b/aibom/src/aibom/llm_factory.py
@@ -125,8 +125,28 @@ def _provider_family(resolved_provider: str | None, model_id: str) -> str:
     return "openai"
 
 
+def _is_openai_compatible_endpoint(
+    resolved_provider: str | None, api_base: str | None
+) -> bool:
+    """True for a self-hosted OpenAI-compatible backend (e.g. vLLM, SGLang).
+
+    The ``chat_template_kwargs`` / ``enable_thinking`` toggle is a self-hosted
+    extension passed through to the server's tokenizer chat template — native
+    OpenAI (``api.openai.com``) and Azure OpenAI both reject it. A custom
+    ``api_base`` is the signal that we are talking to such a compatible server;
+    Azure also sets a custom endpoint but is explicitly excluded because it is
+    not compatible with this field.
+    """
+    if not api_base:
+        return False
+    return (resolved_provider or "").lower() != "azure_openai"
+
+
 def _reasoning_control_kwargs(
-    resolved_provider: str | None, model_id: str, reasoning: str
+    resolved_provider: str | None,
+    model_id: str,
+    reasoning: str,
+    api_base: str | None = None,
 ) -> dict[str, Any]:
     """Provider-correct kwargs to disable/enable model "thinking".
 
@@ -135,8 +155,10 @@ def _reasoning_control_kwargs(
     provider, so it is keyed on the provider family and an OpenAI-only key
     (``extra_body``) never leaks to another provider:
 
-    * openai / azure_openai (and vLLM): native reasoning models →
-      ``reasoning_effort='minimal'``; OpenAI-compatible open models →
+    * openai / azure_openai: native reasoning models →
+      ``reasoning_effort='minimal'``; non-reasoning native OpenAI/Azure models
+      have no thinking toggle → no-op.
+    * vLLM / OpenAI-compatible self-hosted (custom ``api_base``) open models →
       ``extra_body={'chat_template_kwargs': {'enable_thinking': <bool>}}``.
     * anthropic → ``thinking={'type': 'disabled'}``.
     * bedrock → ``model_kwargs={'thinking': {'type': 'disabled'}}`` (InvokeModel body).
@@ -146,12 +168,22 @@ def _reasoning_control_kwargs(
     if reasoning not in ("off", "on"):
         return {}
     family = _provider_family(resolved_provider, model_id)
+    # The chat-template toggle is only valid for a self-hosted OpenAI-compatible
+    # server; native OpenAI/Azure reject the field (and their non-reasoning
+    # models have nothing to toggle), so gate it on the endpoint.
+    compat_toggle = family == "openai" and _is_openai_compatible_endpoint(
+        resolved_provider, api_base
+    )
 
     if reasoning == "off":
         if family == "openai":
             if _is_reasoning_model(model_id):
                 return {"reasoning_effort": "minimal"}
-            return {"extra_body": {"chat_template_kwargs": {"enable_thinking": False}}}
+            if compat_toggle:
+                return {
+                    "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}
+                }
+            return {}
         if family == "bedrock":
             # ChatBedrock drives Claude over the InvokeModel path, whose body is
             # the Anthropic Messages format — the thinking control belongs in the
@@ -168,7 +200,7 @@ def _reasoning_control_kwargs(
     # reasoning == "on": only the vLLM/OpenAI-compatible chat-template toggle is
     # safe to force on generically; native reasoners and other providers reason
     # by default, so leave them untouched.
-    if family == "openai" and not _is_reasoning_model(model_id):
+    if compat_toggle and not _is_reasoning_model(model_id):
         return {"extra_body": {"chat_template_kwargs": {"enable_thinking": True}}}
     return {}
 
@@ -329,9 +361,13 @@ def build_chat_model(
     if rate_limiter is not None:
         init_kwargs["rate_limiter"] = rate_limiter
 
-    # Provider-correct reasoning/thinking control (--llm-reasoning).
+    # Provider-correct reasoning/thinking control (--llm-reasoning). ``api_base``
+    # distinguishes a self-hosted OpenAI-compatible endpoint (vLLM) from native
+    # OpenAI/Azure, which reject the chat-template toggle.
     init_kwargs.update(
-        _reasoning_control_kwargs(resolved_provider, model_id, reasoning)
+        _reasoning_control_kwargs(
+            resolved_provider, model_id, reasoning, api_base=api_base
+        )
     )
 
     # Generic per-provider passthrough (--llm-init-kwargs): merged verbatim and

--- a/aibom/src/aibom/scan_pipeline.py
+++ b/aibom/src/aibom/scan_pipeline.py
@@ -1186,6 +1186,8 @@ class ScanPipeline:
         agentic_concurrency: int = 1,
         agentic_fast_model: str | None = None,
         agentic_timeout: int = 120,
+        agentic_max_consecutive_failures: int = 3,
+        agentic_max_retry_seconds: int = 1200,
         agentic_cache_dir: str | Path | None = None,
         include_code_snippets: bool = False,
         progress_callback: Callable[[dict[str, Any]], None] | None = None,
@@ -1205,6 +1207,8 @@ class ScanPipeline:
         self.agentic_concurrency = agentic_concurrency
         self.agentic_fast_model = agentic_fast_model
         self.agentic_timeout = agentic_timeout
+        self.agentic_max_consecutive_failures = agentic_max_consecutive_failures
+        self.agentic_max_retry_seconds = agentic_max_retry_seconds
         self.agentic_cache_dir = (
             Path(agentic_cache_dir) if agentic_cache_dir is not None else None
         )
@@ -1507,6 +1511,8 @@ class ScanPipeline:
                     max_concurrent=self.agentic_concurrency,
                     fast_model=self.agentic_fast_model,
                     timeout_s=self.agentic_timeout,
+                    max_consecutive_failures=self.agentic_max_consecutive_failures,
+                    max_retry_seconds=self.agentic_max_retry_seconds,
                     cache_dir=self.agentic_cache_dir,
                     include_code_snippets=self.include_code_snippets,
                     agent_signature_catalog=agent_catalog,

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -22,6 +22,7 @@ they test the helper functions and mock the external dependencies.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -36,6 +37,17 @@ from aibom.models import (
     DecisionAnnotation,
     EvidenceLocation,
 )
+
+# ``deepagents`` is an optional (agentic) extra and is NOT installed in CI's
+# ``uv sync --group dev`` env. Tests that exercise the real ``create_aibom_agent``
+# (which imports deepagents) are skipped there, matching this module's design of
+# not requiring deepagents/langchain; helper-level tests below run everywhere.
+_HAS_DEEPAGENTS = importlib.util.find_spec("deepagents") is not None
+# ``langchain_core`` ships with the same agentic extra. A few helper-level tests
+# call ``_coerce_structured`` directly, which imports ``langchain_core.messages``
+# at call time, so they are gated the same way (skipped in the CI ``--group dev``
+# env). The pure-Python helper tests around them still run everywhere.
+_HAS_LANGCHAIN = importlib.util.find_spec("langchain_core") is not None
 
 
 @pytest.fixture(autouse=True)
@@ -2303,6 +2315,9 @@ class TestTwoPhaseStructuredOutput:
             self.response_metadata = None
             self.content = content
 
+    @pytest.mark.skipif(
+        not _HAS_DEEPAGENTS, reason="requires deepagents (agentic extra)"
+    )
     @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
     @patch("deepagents.create_deep_agent")
     def test_create_agent_defaults_to_unforced_phase1(self, mock_cda, _mb):
@@ -2321,6 +2336,9 @@ class TestTwoPhaseStructuredOutput:
         bundle.invoke("x")
         graph.invoke.assert_called_once_with("x")
 
+    @pytest.mark.skipif(
+        not _HAS_DEEPAGENTS, reason="requires deepagents (agentic extra)"
+    )
     @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
     @patch("deepagents.create_deep_agent")
     def test_explicit_response_format_not_coerced(self, mock_cda, _mb):
@@ -2332,6 +2350,9 @@ class TestTwoPhaseStructuredOutput:
         assert mock_cda.call_args.kwargs["response_format"] is sentinel
         assert bundle.needs_coercion is False
 
+    @pytest.mark.skipif(
+        not _HAS_LANGCHAIN, reason="requires langchain_core (agentic extra)"
+    )
     def test_coerce_structured_returns_dict_and_counts_tokens(self):
         from aibom.agentic import agent as agent_mod
         from aibom.agentic.agent import AgentResponse, _coerce_structured
@@ -2365,6 +2386,9 @@ class TestTwoPhaseStructuredOutput:
         # with_structured_output must be tool-less (single coercion call).
         model.with_structured_output.assert_called_once()
 
+    @pytest.mark.skipif(
+        not _HAS_LANGCHAIN, reason="requires langchain_core (agentic extra)"
+    )
     def test_coerce_structured_none_on_failure(self):
         from aibom.agentic.agent import _coerce_structured
 

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -1975,3 +1975,473 @@ class TestAgenticResultCacheAtomicWrite:
         # Good entry loads; truncated entry is skipped (cache miss), not fatal.
         assert cache.get("good") == {"ok": True}
         assert cache.get("partial") is None
+
+
+class TestApplyBatchFindingsFailOpen:
+    """applying a batch's structured output must fail OPEN per
+    batch. Any unexpected middleware error degrades only that batch instead of
+    propagating up and aborting the whole agentic stage."""
+
+    def _batch(self):
+        return [
+            AIComponent(
+                name="c",
+                component_type=AIComponentType.MODEL,
+                file_path="a.py",
+                line_number=1,
+                instance_id="c_a.py_1",
+            )
+        ]
+
+    def test_degrades_when_middleware_raises(self):
+        from aibom.agentic import agent as agent_mod
+        from aibom.agentic.agent import _apply_batch_findings
+
+        batch = self._batch()
+        mw = MagicMock()
+        mw.extract_findings_from_dict.side_effect = AttributeError(
+            "'str' object has no attribute 'get'"
+        )
+
+        enriched, new_c, new_r, rf, degraded = _apply_batch_findings(
+            mw, batch, {"enriched_components": ["stray"]}, batch_num=1
+        )
+
+        assert degraded is True
+        assert new_c == [] and new_r == [] and rf == []
+        assert len(enriched) == 1
+        # Degraded with a retryable hint so _collect_failed re-queues it for
+        # the retry pass (mirrors batch_timeout / no_usable_output semantics).
+        assert enriched[0].agentic_hint == "structured_output_parse_error"
+        assert enriched[0].agentic_hint in agent_mod._RETRYABLE_HINTS
+
+    def test_happy_path_passes_through(self):
+        from aibom.agentic.agent import _apply_batch_findings
+
+        batch = self._batch()
+        mw = MagicMock()
+        mw.extract_findings_from_dict.return_value = ([], [], [])
+        mw.apply_enrichments_from_dict.return_value = batch
+
+        enriched, new_c, new_r, rf, degraded = _apply_batch_findings(
+            mw, batch, {"enriched_components": []}, batch_num=1
+        )
+
+        assert degraded is False
+        assert enriched == batch
+        assert new_c == [] and new_r == [] and rf == []
+
+
+class TestAccumulateTokenUsage:
+    """usage must be recovered from ``response_metadata`` for
+    providers that don't populate the standardized ``usage_metadata`` field
+    (Bedrock Invoke path; Azure gpt-5.3-codex)."""
+
+    class _Msg:
+        """Minimal AIMessage stand-in carrying the usage fields we read."""
+
+        def __init__(self, usage_metadata=None, response_metadata=None):
+            self.usage_metadata = usage_metadata
+            self.response_metadata = response_metadata
+
+    def _usage(self, *messages):
+        from aibom.agentic import agent as agent_mod
+
+        agent_mod._reset_token_usage()
+        agent_mod._accumulate_token_usage({"messages": list(messages)})
+        u = agent_mod.get_token_usage()
+        return (u.prompt_tokens, u.completion_tokens, u.total_tokens)
+
+    def test_usage_metadata_only(self):
+        msg = self._Msg(
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+            }
+        )
+        assert self._usage(msg) == (100, 20, 120)
+
+    def test_openai_azure_token_usage_fallback(self):
+        # gpt-5.3-codex: no usage_metadata; usage under response_metadata.
+        msg = self._Msg(
+            response_metadata={
+                "token_usage": {
+                    "prompt_tokens": 50,
+                    "completion_tokens": 10,
+                    "total_tokens": 60,
+                }
+            }
+        )
+        assert self._usage(msg) == (50, 10, 60)
+
+    def test_bedrock_response_metadata_usage_fallback(self):
+        # ChatBedrock Converse-style usage block.
+        msg = self._Msg(
+            response_metadata={"usage": {"input_tokens": 200, "output_tokens": 40}}
+        )
+        # total synthesized when the provider omits it.
+        assert self._usage(msg) == (200, 40, 240)
+
+    def test_bedrock_invocation_metrics_fallback(self):
+        # ChatBedrock Invoke-path metrics block.
+        msg = self._Msg(
+            response_metadata={
+                "amazon-bedrock-invocationMetrics": {
+                    "inputTokenCount": 300,
+                    "outputTokenCount": 60,
+                }
+            }
+        )
+        assert self._usage(msg) == (300, 60, 360)
+
+    def test_prefers_usage_metadata_no_double_count(self):
+        # Both carriers present (LangChain often derives one from the other):
+        # count only once.
+        msg = self._Msg(
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+            },
+            response_metadata={
+                "token_usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 20,
+                    "total_tokens": 120,
+                }
+            },
+        )
+        assert self._usage(msg) == (100, 20, 120)
+
+    def test_empty_usage_metadata_falls_back(self):
+        msg = self._Msg(
+            usage_metadata={},
+            response_metadata={
+                "token_usage": {"prompt_tokens": 7, "completion_tokens": 3}
+            },
+        )
+        assert self._usage(msg) == (7, 3, 10)
+
+    def test_mixed_messages_summed(self):
+        m1 = self._Msg(
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+            }
+        )
+        m2 = self._Msg(
+            response_metadata={
+                "amazon-bedrock-invocationMetrics": {
+                    "inputTokenCount": 300,
+                    "outputTokenCount": 60,
+                }
+            }
+        )
+        assert self._usage(m1, m2) == (400, 80, 480)
+
+
+class TestAllBatchesFailed:
+    """a total agentic failure (e.g. every batch rejected by the
+    provider) must be distinguishable from 'ran fine, found nothing to add' so
+    the run can report a degraded status instead of 'enrichment complete'."""
+
+    def _comp(self, iid, hint=""):
+        return AIComponent(
+            name=iid,
+            component_type=AIComponentType.MODEL,
+            file_path="a.py",
+            line_number=1,
+            instance_id=iid,
+            agentic_hint=hint,
+        )
+
+    def test_all_degraded_no_findings_is_failure(self):
+        from aibom.agentic.agent import _all_batches_failed
+
+        enriched = [
+            self._comp("c1", "batch_timeout"),
+            self._comp("c2", "batch_recursion_limit"),
+        ]
+        assert _all_batches_failed(enriched, [], [], []) is True
+
+    def test_partial_success_is_not_failure(self):
+        from aibom.agentic.agent import _all_batches_failed
+
+        enriched = [self._comp("c1", "batch_timeout"), self._comp("c2", "")]
+        assert _all_batches_failed(enriched, [], [], []) is False
+
+    def test_all_ok_is_not_failure(self):
+        from aibom.agentic.agent import _all_batches_failed
+
+        enriched = [self._comp("c1", ""), self._comp("c2", "")]
+        assert _all_batches_failed(enriched, [], [], []) is False
+
+    def test_findings_present_is_not_failure(self):
+        from aibom.agentic.agent import _all_batches_failed
+
+        # Even if all inputs degraded, discovering something means the layer
+        # produced usable output.
+        enriched = [self._comp("c1", "batch_timeout")]
+        new = [self._comp("new1", "")]
+        assert _all_batches_failed(enriched, new, [], []) is False
+
+    def test_empty_is_not_failure(self):
+        from aibom.agentic.agent import _all_batches_failed
+
+        assert _all_batches_failed([], [], [], []) is False
+
+    @patch("aibom.agentic.agent._RETRY_COOLDOWN_S", 0)
+    @patch("aibom.agentic.agent._close_model_clients")
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_run_reports_degraded_when_every_batch_fails(
+        self, mock_create, _mb, _mc, caplog
+    ):
+        """End-to-end: a run where the provider rejects every batch logs a
+        DEGRADED warning and NOT 'enrichment complete'."""
+        import logging
+
+        from aibom.agentic.agent import run_agentic_enrichment
+
+        mock_agent = MagicMock()
+        mock_agent.invoke.side_effect = RuntimeError("provider rejected request")
+        mock_create.return_value = mock_agent
+
+        comp = AIComponent(
+            name="x",
+            component_type=AIComponentType.AGENT,
+            file_path="b.py",
+            line_number=1,
+        )
+        with caplog.at_level(logging.WARNING, logger="aibom.agentic.agent"):
+            comps, _, _, _ = run_agentic_enrichment(
+                model_string="m",
+                deterministic_components=[comp],
+                deterministic_relationships=[],
+                scan_paths=["/tmp"],
+                timeout_s=5,
+            )
+
+        assert "DEGRADED" in caplog.text
+        assert "Agentic enrichment complete" not in caplog.text
+
+
+class TestDiscoveryWiringIsProviderAgnostic:
+    """Bedrock/Anthropic (Opus 4.8) report 0 new components on every
+    repo while the OpenAI path finds many. This asserts the discovery path IS
+    wired provider-agnostically — ``new_components`` are extracted from the SAME
+    tool-call carrier that ``enriched_components`` use, and enrichment demonstrably
+    works on Bedrock. So a uniform 0-discovery is a model-behavior signal (Opus
+    confirms/prunes but does not propose new components — consistent with the
+    benchmark, where every model except GPT-5.5 discovers 0), NOT an aibom
+    extraction gap. Definitive root cause requires a live Bedrock-vs-OpenAI probe
+    (see the e2e plan); this fixture guards against a real extraction regression.
+    """
+
+    class _ToolMsg:
+        """AIMessage stand-in for a function-calling (tool_use) response, the
+        carrier Anthropic/Bedrock use for structured output."""
+
+        def __init__(self, args):
+            self.tool_calls = [{"name": "AgentResponse", "args": args}]
+            self.content = ""
+            self.additional_kwargs = {}
+
+    def test_discovery_and_enrichment_share_the_same_carrier(self):
+        from aibom.agentic.agent import _extract_structured_response
+        from aibom.agentic.middleware import AIBOMScannerMiddleware
+
+        existing = [
+            AIComponent(
+                name="known",
+                component_type=AIComponentType.MODEL,
+                file_path="a.py",
+                line_number=1,
+                instance_id="known_a.py_1",
+            )
+        ]
+        # One AgentResponse tool call carrying BOTH an enrichment and a newly
+        # discovered component — exactly what Bedrock/Anthropic emit.
+        args = {
+            "enriched_components": [
+                {"instance_id": "known_a.py_1", "updates": {"model_name": "gpt-4o"}}
+            ],
+            "new_components": [
+                {
+                    "name": "secret-model",
+                    "component_type": "model",
+                    "file_path": "b.py",
+                    "line_number": 2,
+                    "model_name": "gpt-5",
+                }
+            ],
+        }
+        data = _extract_structured_response({"messages": [self._ToolMsg(args)]})
+        assert data is not None
+
+        mw = AIBOMScannerMiddleware()
+        new_comps, _, _ = mw.extract_findings_from_dict(data)
+        enriched = mw.apply_enrichments_from_dict(existing, data)
+
+        # Enrichment works on this carrier (proven on Bedrock in the eval) ...
+        assert enriched[0].model_name == "gpt-4o"
+        # ... and discovery is read from the very same dict — not dropped.
+        assert any(c.name == "secret-model" for c in new_comps)
+
+
+class TestTwoPhaseStructuredOutput:
+    """provider-general two-phase decouple. Phase 1 runs the tool
+    loop UNFORCED (no response_format -> tool_choice=auto -> natural termination
+    on every provider); Phase 2 coerces the transcript into AgentResponse via a
+    single tool-less with_structured_output call."""
+
+    class _Msg:
+        def __init__(self, usage_metadata=None, content=""):
+            self.usage_metadata = usage_metadata
+            self.response_metadata = None
+            self.content = content
+
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("deepagents.create_deep_agent")
+    def test_create_agent_defaults_to_unforced_phase1(self, mock_cda, _mb):
+        from aibom.agentic.agent import create_aibom_agent
+
+        graph = MagicMock()
+        mock_cda.return_value = graph
+        bundle = create_aibom_agent("m")
+
+        # Phase 1: no forced structured-output tool.
+        assert mock_cda.call_args.kwargs["response_format"] is None
+        # Bundle carries the chat model for Phase 2 and flags coercion needed.
+        assert bundle.needs_coercion is True
+        assert bundle.aibom_chat_model is not None
+        # Bundle transparently proxies invoke/ainvoke to the graph.
+        bundle.invoke("x")
+        graph.invoke.assert_called_once_with("x")
+
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("deepagents.create_deep_agent")
+    def test_explicit_response_format_not_coerced(self, mock_cda, _mb):
+        from aibom.agentic.agent import create_aibom_agent
+
+        mock_cda.return_value = MagicMock()
+        sentinel = object()
+        bundle = create_aibom_agent("m", model=MagicMock(), response_format=sentinel)
+        assert mock_cda.call_args.kwargs["response_format"] is sentinel
+        assert bundle.needs_coercion is False
+
+    def test_coerce_structured_returns_dict_and_counts_tokens(self):
+        from aibom.agentic import agent as agent_mod
+        from aibom.agentic.agent import AgentResponse, _coerce_structured
+
+        agent_mod._reset_token_usage()
+        model = MagicMock()
+        raw = self._Msg(
+            usage_metadata={
+                "input_tokens": 10,
+                "output_tokens": 2,
+                "total_tokens": 12,
+            }
+        )
+        parsed = AgentResponse(
+            new_components=[{"name": "x", "component_type": "model"}]
+        )
+        structured = MagicMock()
+        structured.invoke.return_value = {
+            "raw": raw,
+            "parsed": parsed,
+            "parsing_error": None,
+        }
+        model.with_structured_output.return_value = structured
+
+        data = _coerce_structured(model, [self._Msg(content="findings")])
+
+        assert isinstance(data, dict)
+        assert data["new_components"][0]["name"] == "x"
+        # include_raw lets us keep Phase-2 token accounting.
+        assert agent_mod.get_token_usage().total_tokens == 12
+        # with_structured_output must be tool-less (single coercion call).
+        model.with_structured_output.assert_called_once()
+
+    def test_coerce_structured_none_on_failure(self):
+        from aibom.agentic.agent import _coerce_structured
+
+        model = MagicMock()
+        model.with_structured_output.side_effect = RuntimeError("no structured out")
+        assert _coerce_structured(model, [self._Msg()]) is None
+
+    def test_resolve_batch_data_extractor_first_then_coerce(self):
+        from aibom.agentic.agent import _resolve_batch_data
+
+        # Phase-1 unforced agent whose transcript has NO parseable structured
+        # output -> falls through to Phase-2 coercion.
+        agent = MagicMock()
+        agent.needs_coercion = True
+        coerced = {"enriched_components": [], "new_components": []}
+        with patch(
+            "aibom.agentic.agent._coerce_structured", return_value=coerced
+        ) as mock_coerce:
+            data = _resolve_batch_data(agent, {"messages": [self._Msg(content="prose")]})
+        assert data == coerced
+        mock_coerce.assert_called_once()
+
+    def test_resolve_batch_data_skips_coercion_when_structured_present(self):
+        from aibom.agentic.agent import _resolve_batch_data
+
+        # A result that already carries a usable structured response (e.g. the
+        # ProviderStrategy fallback agent) must NOT trigger a Phase-2 call.
+        agent = MagicMock()
+        agent.needs_coercion = True
+        good = {"enriched_components": [{"instance_id": "a"}], "new_components": []}
+        result = {"structured_response": good, "messages": [self._Msg()]}
+        with patch("aibom.agentic.agent._coerce_structured") as mock_coerce:
+            data = _resolve_batch_data(agent, result)
+        assert data == good
+        mock_coerce.assert_not_called()
+
+
+class TestStructuredOutputCapabilityGate:
+    """capability gate: ProviderStrategy-capable OpenAI-family models
+    keep single-pass native structured output (baseline, full fidelity); every
+    other provider/model uses the two-phase decouple."""
+
+    import pytest as _pytest
+
+    @_pytest.mark.parametrize(
+        "provider,model_id,inloop",
+        [
+            ("openai", "gpt-5.5", True),
+            ("openai", "gpt-4o", True),
+            ("azure_openai", "gpt-5.3-codex", True),
+            ("openai", "o3-mini", True),
+            (None, "gpt-4o", True),  # LangChain-inferred OpenAI
+            ("openai", "zai-org/GLM-5.2-FP8", False),  # vLLM open model
+            ("openai", "mistral-7b-instruct", False),  # vLLM open model
+            ("bedrock", "us.anthropic.claude-opus-4-8", False),
+            ("anthropic", "claude-opus-4-8", False),
+            ("google_genai", "gemini-2.5-pro", False),
+            ("ollama", "llama3.1", False),
+        ],
+    )
+    def test_inloop_capability(self, provider, model_id, inloop):
+        from aibom.agentic.agent import _supports_inloop_structured_output
+
+        assert _supports_inloop_structured_output(provider, model_id) is inloop
+
+    def test_agent_response_format_gpt_is_native(self):
+        from aibom.agentic.agent import AgentResponse, _agent_response_format
+
+        assert _agent_response_format("gpt-5.5", {"provider": "openai"}) is AgentResponse
+
+    def test_agent_response_format_bedrock_is_two_phase(self):
+        from aibom.agentic.agent import _agent_response_format
+
+        # None -> create_aibom_agent runs unforced (two-phase).
+        assert (
+            _agent_response_format(
+                "us.anthropic.claude-opus-4-8", {"provider": "bedrock"}
+            )
+            is None
+        )

--- a/aibom/tests/test_agentic_cli.py
+++ b/aibom/tests/test_agentic_cli.py
@@ -199,6 +199,122 @@ class TestAgenticEnrichmentViaCLI:
         assert result.exit_code != 0
         assert "max-tokens" in clean.lower() or "range" in clean.lower()
 
+    # --- --llm-reasoning / --llm-init-kwargs -------------------
+
+    def test_llm_reasoning_and_init_kwargs_help_listed(self):
+        import re
+
+        result = runner.invoke(app, ["analyze", "--help"])
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+        assert "--llm-reasoning" in clean
+        assert "--llm-init-kwargs" in clean
+
+    def test_agentic_breaker_and_retry_budget_help_listed(self):
+        import re
+
+        # Wide width so Rich doesn't truncate the long option names.
+        result = runner.invoke(
+            app, ["analyze", "--help"], env={"COLUMNS": "200"}
+        )
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+        assert "--agentic-max-consecutive-failures" in clean
+        assert "--agentic-max-retry-seconds" in clean
+
+    @patch("aibom.scan_pipeline.ensure_llm_runtime_available", return_value=None)
+    @patch("aibom.cli.ensure_llm_runtime_available", return_value=None)
+    @patch("aibom.agentic.agent._close_model_clients")
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_llm_reasoning_and_init_kwargs_threaded_into_config(
+        self,
+        mock_create,
+        mock_build,
+        _mock_close,
+        _mock_cli_preflight,
+        _mock_pipeline_preflight,
+        sample_dir,
+        tmp_path,
+    ):
+        out = tmp_path / "report.txt"
+        mock_msg = MagicMock()
+        mock_msg.content = json.dumps({"enriched_components": [], "new_components": []})
+        mock_agent = MagicMock()
+        mock_agent.invoke.return_value = {"messages": [mock_msg]}
+        mock_create.return_value = mock_agent
+
+        result = runner.invoke(
+            app,
+            [
+                "analyze",
+                str(sample_dir),
+                "--output-format",
+                "plaintext",
+                "--output-file",
+                str(out),
+                "--llm-model",
+                "test-model",
+                "--llm-api-base",
+                "http://localhost:11434",
+                "--llm-reasoning",
+                "off",
+                "--llm-init-kwargs",
+                '{"top_p": 0.9}',
+            ],
+        )
+        assert result.exit_code == 0
+        reasoning_ok = False
+        init_kwargs_ok = False
+        for call in mock_build.call_args_list:
+            for arg in list(call.args) + list(call.kwargs.values()):
+                if isinstance(arg, dict) and arg.get("reasoning") == "off":
+                    reasoning_ok = True
+                if isinstance(arg, dict) and arg.get("init_kwargs") == {"top_p": 0.9}:
+                    init_kwargs_ok = True
+        assert reasoning_ok, "llm_config['reasoning']='off' not passed to _build_model"
+        assert init_kwargs_ok, "llm_config['init_kwargs'] not passed to _build_model"
+
+    def test_llm_reasoning_rejects_invalid_value(self, sample_dir, tmp_path):
+        result = runner.invoke(
+            app,
+            [
+                "analyze",
+                str(sample_dir),
+                "--llm-model",
+                "test-model",
+                "--llm-reasoning",
+                "bogus",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_llm_init_kwargs_rejects_invalid_json(self, sample_dir, tmp_path):
+        result = runner.invoke(
+            app,
+            [
+                "analyze",
+                str(sample_dir),
+                "--llm-model",
+                "test-model",
+                "--llm-init-kwargs",
+                "not json",
+            ],
+        )
+        assert result.exit_code != 0
+
+    def test_llm_init_kwargs_rejects_non_object(self, sample_dir, tmp_path):
+        result = runner.invoke(
+            app,
+            [
+                "analyze",
+                str(sample_dir),
+                "--llm-model",
+                "test-model",
+                "--llm-init-kwargs",
+                "[1, 2, 3]",
+            ],
+        )
+        assert result.exit_code != 0
+
     @patch("aibom.repo_triage.RepoTriager")
     def test_triage_config_includes_max_tokens(self, mock_triager_cls):
         from aibom.cli import _gather_analysis_sources

--- a/aibom/tests/test_agentic_middleware.py
+++ b/aibom/tests/test_agentic_middleware.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import pytest
 
@@ -912,3 +913,23 @@ class TestMalformedListItems:
         assert [c.name for c in comps] == ["secret-model"]
         assert len(rels) == 1
         assert len(flags) == 1
+
+    def test_skipped_non_dict_items_are_logged(self, mw, caplog):
+        # Silently dropping malformed items hides a provider emitting garbage;
+        # each skip must be observable at debug level, naming the field.
+        data = {
+            "new_components": ["stray string"],
+            "new_relationships": [42],
+            "risk_findings": [None],
+        }
+        with caplog.at_level(logging.DEBUG, logger="aibom.agentic.middleware"):
+            mw.extract_findings_from_dict(data)
+        skipped = [
+            r.getMessage()
+            for r in caplog.records
+            if "non-dict" in r.getMessage().lower()
+        ]
+        # One debug line per malformed field, each identifying the field name.
+        assert any("new_components" in m for m in skipped)
+        assert any("new_relationships" in m for m in skipped)
+        assert any("risk_findings" in m for m in skipped)

--- a/aibom/tests/test_agentic_middleware.py
+++ b/aibom/tests/test_agentic_middleware.py
@@ -834,3 +834,81 @@ class TestParseJson:
 
     def test_returns_none_for_no_json(self, mw):
         assert mw._parse_json("no json here") is None
+
+
+class TestMalformedListItems:
+    """partial/malformed structured output can put a bare string
+    (or other non-dict) into a list the middleware iterates. Every ``for item
+    in data.get(...)`` loop must skip non-dict elements instead of raising
+    ``AttributeError: 'str' object has no attribute 'get'`` (which previously
+    aborted the whole agentic stage)."""
+
+    def _existing(self):
+        return [
+            AIComponent(
+                name="my-model",
+                component_type=AIComponentType.MODEL,
+                file_path="app.py",
+                line_number=10,
+                instance_id="comp1_app.py_10",
+            )
+        ]
+
+    def test_apply_enrichments_skips_non_dict_enriched_items(self, mw):
+        # Mirrors the exact malformed shape from the ticket: stray string
+        # elements interleaved with one valid enrichment dict.
+        data = {
+            "enriched_components": [
+                "agent_evidence: null},{",
+                {
+                    "instance_id": "comp1_app.py_10",
+                    "updates": {"model_name": "gpt-4o-2024-08-06"},
+                },
+                "instance_id:langchain-op...pyproject.toml_13",
+            ]
+        }
+        enriched = mw.apply_enrichments_from_dict(self._existing(), data)
+        assert len(enriched) == 1
+        assert enriched[0].model_name == "gpt-4o-2024-08-06"
+
+    def test_apply_enrichments_skips_non_dict_remove_and_reclassify(self, mw):
+        data = {
+            "remove_components": ["stray", 123, {"instance_id": "comp1_app.py_10"}],
+            "reclassify_components": [
+                "stray",
+                {"instance_id": "comp1_app.py_10", "new_type": "embedding"},
+            ],
+        }
+        # Must not raise; the valid removal wins so the component is dropped.
+        enriched = mw.apply_enrichments_from_dict(self._existing(), data)
+        assert enriched == []
+
+    def test_extract_findings_skips_non_dict_items(self, mw):
+        data = {
+            "new_components": [
+                "stray string",
+                {
+                    "name": "secret-model",
+                    "component_type": "model",
+                    "file_path": "hidden.py",
+                    "line_number": 5,
+                    "model_name": "gpt-5",
+                },
+            ],
+            "new_relationships": [
+                42,
+                {
+                    "source_name": "my_agent",
+                    "target_name": "search_tool",
+                    "relationship_type": "USES_TOOL",
+                },
+            ],
+            "risk_findings": [
+                None,
+                {"flag": "deprecated_model", "description": "x", "severity": "medium"},
+            ],
+        }
+        comps, rels, flags = mw.extract_findings_from_dict(data)
+        assert [c.name for c in comps] == ["secret-model"]
+        assert len(rels) == 1
+        assert len(flags) == 1

--- a/aibom/tests/test_agentic_timeout.py
+++ b/aibom/tests/test_agentic_timeout.py
@@ -190,6 +190,50 @@ class TestAgenticAsyncTimeout:
         assert all(c.agentic_hint == "batch_timeout" for c in out)
 
 
+class TestAgenticRetryBudget:
+    @patch("aibom.agentic.agent._RETRY_COOLDOWN_S", 0)
+    @patch("aibom.agentic.agent._close_model_clients")
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_retry_budget_exhausted_finishes_and_degrades(
+        self, mock_create: MagicMock, _mb: MagicMock, _mc: MagicMock, caplog
+    ) -> None:
+        """an exhausted retry budget aborts further retries — the
+        remaining components are degraded (retry_budget_exhausted) and the scan
+        finishes instead of looping for hours, even with the breaker relaxed."""
+        import logging
+
+        from aibom.agentic.agent import run_agentic_enrichment
+
+        mock_agent = MagicMock()
+        mock_agent.invoke.side_effect = RuntimeError("always fails")
+        mock_create.return_value = mock_agent
+
+        comp = AIComponent(
+            name="x",
+            component_type=AIComponentType.AGENT,
+            file_path="b.py",
+            line_number=1,
+        )
+        with caplog.at_level(logging.WARNING, logger="aibom.agentic.agent"):
+            out, _, _, _ = run_agentic_enrichment(
+                model_string="m",
+                deterministic_components=[comp],
+                deterministic_relationships=[],
+                scan_paths=["/tmp"],
+                timeout_s=5,
+                max_consecutive_failures=99,  # breaker relaxed: budget is the bound
+                max_retry_seconds=0,  # zero budget -> retries abort immediately
+            )
+
+        assert len(out) == 1
+        assert out[0].agentic_hint == "retry_budget_exhausted"
+        assert "budget exhausted" in caplog.text.lower()
+        # A budget-exhausted component is NOT "recovered" — the retry-pass
+        # summary must not mislabel it (accuracy of the operator log).
+        assert "1/1 recovered" not in caplog.text
+
+
 class TestInvokeAgentBounded:
     """Unit tests for the shared daemon-thread deadline helper used by every
     synchronous ``agent.invoke`` site."""

--- a/aibom/tests/test_llm_factory.py
+++ b/aibom/tests/test_llm_factory.py
@@ -367,7 +367,12 @@ def test_reasoning_off_openai_vllm_uses_chat_template_kwargs(
     from aibom.llm_factory import build_chat_model
 
     mock_init.return_value = MagicMock()
-    build_chat_model("zai-org/GLM-5.2-FP8", provider="openai", reasoning="off")
+    build_chat_model(
+        "zai-org/GLM-5.2-FP8",
+        provider="openai",
+        api_base="http://localhost:8000/v1",
+        reasoning="off",
+    )
     _, kwargs = mock_init.call_args
     assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": False}}
 
@@ -384,6 +389,68 @@ def test_reasoning_off_openai_native_reasoning_uses_reasoning_effort(
     _, kwargs = mock_init.call_args
     assert kwargs.get("reasoning_effort") == "minimal"
     assert "extra_body" not in kwargs
+
+
+# ``chat_template_kwargs`` is a vLLM / self-hosted OpenAI-compatible extension
+# (signalled by a custom ``api_base``). Native OpenAI (api.openai.com) and Azure
+# OpenAI reject it, and their non-reasoning models have no thinking to toggle, so
+# --llm-reasoning off/on must be a no-op there — never emit ``extra_body``.
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_reasoning_off_native_openai_nonreasoning_is_noop(mock_init, _mock_preflight):
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    # Native OpenAI: no custom api_base -> not a vLLM-compatible endpoint.
+    build_chat_model("gpt-4o", provider="openai", reasoning="off")
+    _, kwargs = mock_init.call_args
+    assert "extra_body" not in kwargs
+    assert "reasoning_effort" not in kwargs
+
+
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_reasoning_off_azure_nonreasoning_is_noop(mock_init, _mock_preflight):
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    # Azure has a custom endpoint but is NOT an OpenAI-compatible/vLLM backend.
+    build_chat_model(
+        "gpt-4o",
+        provider="azure_openai",
+        api_base="https://example.openai.azure.com",
+        api_version="2024-12-01-preview",
+        reasoning="off",
+    )
+    _, kwargs = mock_init.call_args
+    assert "extra_body" not in kwargs
+
+
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_reasoning_on_native_openai_nonreasoning_is_noop(mock_init, _mock_preflight):
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    build_chat_model("gpt-4o", provider="openai", reasoning="on")
+    _, kwargs = mock_init.call_args
+    assert "extra_body" not in kwargs
+
+
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_reasoning_on_openai_vllm_uses_chat_template_kwargs(mock_init, _mock_preflight):
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    build_chat_model(
+        "zai-org/GLM-5.2-FP8",
+        provider="openai",
+        api_base="http://localhost:8000/v1",
+        reasoning="on",
+    )
+    _, kwargs = mock_init.call_args
+    assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": True}}
 
 
 @patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
@@ -491,6 +558,7 @@ def test_init_kwargs_extra_overrides_reasoning(mock_init, _mock_preflight):
     build_chat_model(
         "zai-org/GLM-5.2-FP8",
         provider="openai",
+        api_base="http://localhost:8000/v1",
         reasoning="off",
         init_kwargs_extra={"extra_body": {"custom": 1}},
     )

--- a/aibom/tests/test_llm_factory.py
+++ b/aibom/tests/test_llm_factory.py
@@ -248,5 +248,255 @@ class TestBuildChatModel(unittest.TestCase):
         self.assertNotIn("max_completion_tokens", kwargs)
 
 
+import pytest
+
+
+def _preflight(model_string, *, provider=None):
+    from aibom.llm_factory import resolve_provider
+
+    return resolve_provider(model_string, provider)
+
+
+# temperature must be sent ONLY where the provider/model accepts an
+# explicit value. Determinism (0.0) is preserved everywhere it is accepted;
+# omitted for OpenAI/Azure reasoning models and newer Claude (Opus 4.7+, Sonnet
+# 5+, Fable 5+) on both bedrock and native anthropic. Matrix verified against
+# installed langchain source (router does no kwarg filtering).
+_TEMPERATURE_MATRIX = [
+    # OpenAI (native + vLLM via base_url)
+    ("gpt-4o", "openai", True),
+    ("gpt-4o-mini", "openai", True),
+    ("o1", "openai", False),
+    ("o3-mini", "openai", False),
+    ("o4-mini", "openai", False),
+    ("gpt-5.4", "openai", False),
+    ("gpt-5-chat", "openai", False),
+    ("qwen2.5-coder", "openai", True),  # vLLM-served open model
+    ("mistral-7b-instruct", "openai", True),
+    # Azure (deployment names carrying the model family)
+    ("gpt-4o", "azure_openai", True),
+    ("o3", "azure_openai", False),
+    ("gpt-5.3-codex", "azure_openai", False),
+    # Bedrock — older Claude / Titan / Nova keep temperature
+    ("us.anthropic.claude-sonnet-4-20250514-v1:0", "bedrock", True),
+    ("anthropic.claude-3-5-sonnet-20241022-v2:0", "bedrock", True),
+    ("amazon.titan-text-express-v1", "bedrock", True),
+    ("us.amazon.nova-pro-v1:0", "bedrock", True),
+    # Bedrock — newer Claude reject explicit temperature (incl. regional prefixes)
+    ("us.anthropic.claude-opus-4-8", "bedrock", False),
+    ("anthropic.claude-opus-4-7", "bedrock", False),
+    ("eu.anthropic.claude-sonnet-5", "bedrock", False),
+    ("apac.anthropic.claude-fable-5", "bedrock", False),
+    # Native Anthropic
+    ("claude-3-5-sonnet-20241022", "anthropic", True),
+    ("claude-opus-4-1", "anthropic", True),  # 4.1 < 4.7 boundary
+    ("claude-opus-4-8", "anthropic", False),
+    ("claude-sonnet-5", "anthropic", False),
+    ("claude-fable-5", "anthropic", False),
+    # Google + Ollama accept temperature for every model
+    ("gemini-2.5-pro", "google_genai", True),
+    ("gemini-3-pro", "google_genai", True),
+    ("llama3.1", "ollama", True),
+    # Inference / slash paths with no explicit provider
+    ("bedrock/us.anthropic.claude-opus-4-8", None, False),
+    ("claude-opus-4-8", None, False),
+]
+
+
+@pytest.mark.parametrize("model_string,provider,temp_present", _TEMPERATURE_MATRIX)
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_temperature_presence_matrix(
+    mock_init, _mock_preflight, model_string, provider, temp_present
+):
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    build_chat_model(model_string, provider=provider)
+    _, kwargs = mock_init.call_args
+    if temp_present:
+        assert kwargs.get("temperature") == 0.0, f"{model_string}/{provider}"
+    else:
+        assert "temperature" not in kwargs, f"{model_string}/{provider}"
+
+
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_temperature_and_max_tokens_are_orthogonal_reasoning(
+    mock_init, _mock_preflight
+):
+    """Reasoning model: max_completion_tokens set, temperature + max_tokens
+    absent — the two axes are handled independently."""
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    build_chat_model("o3", provider="openai", max_tokens=4096)
+    _, kwargs = mock_init.call_args
+    assert kwargs.get("max_completion_tokens") == 4096
+    assert "temperature" not in kwargs
+    assert "max_tokens" not in kwargs
+
+
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_temperature_and_max_tokens_are_orthogonal_bedrock_new_claude(
+    mock_init, _mock_preflight
+):
+    """Newer Bedrock Claude: temperature omitted but max_tokens still sent
+    under its normal name (not max_completion_tokens)."""
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    build_chat_model(
+        "us.anthropic.claude-opus-4-8", provider="bedrock", max_tokens=4096
+    )
+    _, kwargs = mock_init.call_args
+    assert "temperature" not in kwargs
+    assert kwargs.get("max_tokens") == 4096
+    assert "max_completion_tokens" not in kwargs
+
+
+# --llm-reasoning off must emit the CORRECT per-provider
+# thinking-disable kwarg, keyed on the resolved provider so an OpenAI-only key
+# (extra_body) never leaks to a non-OpenAI provider.
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_reasoning_off_openai_vllm_uses_chat_template_kwargs(
+    mock_init, _mock_preflight
+):
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    build_chat_model("zai-org/GLM-5.2-FP8", provider="openai", reasoning="off")
+    _, kwargs = mock_init.call_args
+    assert kwargs["extra_body"] == {"chat_template_kwargs": {"enable_thinking": False}}
+
+
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_reasoning_off_openai_native_reasoning_uses_reasoning_effort(
+    mock_init, _mock_preflight
+):
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    build_chat_model("gpt-5.5", provider="openai", reasoning="off")
+    _, kwargs = mock_init.call_args
+    assert kwargs.get("reasoning_effort") == "minimal"
+    assert "extra_body" not in kwargs
+
+
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_reasoning_off_anthropic_uses_thinking_disabled(mock_init, _mock_preflight):
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    build_chat_model(
+        "claude-3-5-sonnet-20241022", provider="anthropic", reasoning="off"
+    )
+    _, kwargs = mock_init.call_args
+    assert kwargs["thinking"] == {"type": "disabled"}
+    assert "extra_body" not in kwargs
+
+
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_reasoning_off_bedrock_uses_model_kwargs_thinking(mock_init, _mock_preflight):
+    # ChatBedrock uses the InvokeModel path (Anthropic body) — the thinking
+    # control goes in model_kwargs; additional_model_request_fields is
+    # Converse-only and the InvokeModel API rejects it (verified live on Opus 4.8).
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    build_chat_model(
+        "us.anthropic.claude-opus-4-8", provider="bedrock", reasoning="off"
+    )
+    _, kwargs = mock_init.call_args
+    assert kwargs["model_kwargs"] == {"thinking": {"type": "disabled"}}
+    # OpenAI-only kwarg must NOT leak to bedrock, nor the Converse-only field.
+    assert "extra_body" not in kwargs
+    assert "additional_model_request_fields" not in kwargs
+
+
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_reasoning_off_google_uses_thinking_budget(mock_init, _mock_preflight):
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    build_chat_model("gemini-2.5-pro", provider="google_genai", reasoning="off")
+    _, kwargs = mock_init.call_args
+    assert kwargs.get("thinking_budget") == 0
+    assert "extra_body" not in kwargs
+
+
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_reasoning_off_ollama_is_noop(mock_init, _mock_preflight):
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    build_chat_model("llama3.1", provider="ollama", reasoning="off")
+    _, kwargs = mock_init.call_args
+    for key in (
+        "extra_body",
+        "thinking",
+        "additional_model_request_fields",
+        "thinking_budget",
+    ):
+        assert key not in kwargs
+
+
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_reasoning_auto_is_unchanged(mock_init, _mock_preflight):
+    """Default reasoning=auto injects nothing (no behavior change)."""
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    build_chat_model("zai-org/GLM-5.2-FP8", provider="openai")
+    _, kwargs = mock_init.call_args
+    for key in (
+        "extra_body",
+        "thinking",
+        "additional_model_request_fields",
+        "thinking_budget",
+        "reasoning_effort",
+    ):
+        assert key not in kwargs
+
+
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_init_kwargs_extra_merged_verbatim(mock_init, _mock_preflight):
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    build_chat_model(
+        "gpt-4o", provider="openai", init_kwargs_extra={"top_p": 0.9, "seed": 7}
+    )
+    _, kwargs = mock_init.call_args
+    assert kwargs["top_p"] == 0.9
+    assert kwargs["seed"] == 7
+
+
+@patch("aibom.llm_factory.ensure_llm_runtime_available", side_effect=_preflight)
+@patch("aibom.llm_factory.init_chat_model")
+def test_init_kwargs_extra_overrides_reasoning(mock_init, _mock_preflight):
+    """User passthrough is merged last and wins over auto-derived kwargs."""
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.return_value = MagicMock()
+    build_chat_model(
+        "zai-org/GLM-5.2-FP8",
+        provider="openai",
+        reasoning="off",
+        init_kwargs_extra={"extra_body": {"custom": 1}},
+    )
+    _, kwargs = mock_init.call_args
+    assert kwargs["extra_body"] == {"custom": 1}
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/aibom/tests/test_scan_pipeline.py
+++ b/aibom/tests/test_scan_pipeline.py
@@ -188,6 +188,40 @@ class TestAgenticScope:
         mock_runtime.assert_called_once()
         assert mock_enrich.call_args.kwargs["include_code_snippets"] is True
 
+    def test_max_consecutive_failures_is_forwarded(self, tmp_path: Path) -> None:
+        # the configurable circuit-breaker threshold must reach
+        # run_agentic_enrichment (previously it was never passed -> stuck at 3).
+        (tmp_path / "app.py").write_text(
+            'from openai import OpenAI\nclient = OpenAI(model="gpt-4o")\n'
+        )
+        llm_cfg = {"model": "test/model", "api_key": "fake", "api_base": "http://x"}
+        pipeline = ScanPipeline(
+            scan_paths=[str(tmp_path)],
+            llm_config=llm_cfg,
+            agentic_max_consecutive_failures=7,
+        )
+        with patch("aibom.scan_pipeline.ensure_llm_runtime_available"):
+            with patch("aibom.agentic.agent.run_agentic_enrichment") as mock_enrich:
+                mock_enrich.return_value = ([], [], [], _stub_token_usage())
+                pipeline.run()
+        assert mock_enrich.call_args.kwargs["max_consecutive_failures"] == 7
+
+    def test_max_retry_seconds_is_forwarded(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text(
+            'from openai import OpenAI\nclient = OpenAI(model="gpt-4o")\n'
+        )
+        llm_cfg = {"model": "test/model", "api_key": "fake", "api_base": "http://x"}
+        pipeline = ScanPipeline(
+            scan_paths=[str(tmp_path)],
+            llm_config=llm_cfg,
+            agentic_max_retry_seconds=42,
+        )
+        with patch("aibom.scan_pipeline.ensure_llm_runtime_available"):
+            with patch("aibom.agentic.agent.run_agentic_enrichment") as mock_enrich:
+                mock_enrich.return_value = ([], [], [], _stub_token_usage())
+                pipeline.run()
+        assert mock_enrich.call_args.kwargs["max_retry_seconds"] == 42
+
 
 class TestFileCache:
     def test_cache_deduplicates(self, tmp_path: Path) -> None:

--- a/docs/AGENTIC_MODE.md
+++ b/docs/AGENTIC_MODE.md
@@ -154,10 +154,12 @@ indistinguishable from "the model found nothing to add."
 - **Disable/limit thinking first.** Reasoning verbosity is the number-one cause
   of batch timeouts: a model that emits pages of reasoning per batch blows past
   `--agentic-timeout`. Use `--llm-reasoning off`; it emits the correct parameter
-  for each provider (OpenAI/vLLM chat-template flag, `reasoning_effort` for
-  native OpenAI reasoners, Anthropic/Bedrock `thinking` disable, Gemini
-  `thinking_budget=0`). For anything the flag doesn't cover, drop to
-  `--llm-init-kwargs '<json>'`.
+  for each provider: the `chat_template_kwargs` flag for self-hosted
+  OpenAI-compatible endpoints (vLLM — detected by a custom `--llm-api-base`),
+  `reasoning_effort` for native OpenAI/Azure reasoners, Anthropic/Bedrock
+  `thinking` disable, and Gemini `thinking_budget=0`. Non-reasoning native
+  OpenAI/Azure models have no thinking to toggle, so the flag is a no-op there.
+  For anything the flag doesn't cover, drop to `--llm-init-kwargs '<json>'`.
 - **Raise `--agentic-concurrency`** (1–8) when the endpoint has spare capacity
   (e.g. a multi-GPU self-host). The default `1` is sequential/conservative.
 - **Raise `--agentic-timeout`** for verbose models — they emit many tokens and

--- a/docs/AGENTIC_MODE.md
+++ b/docs/AGENTIC_MODE.md
@@ -130,6 +130,10 @@ Environment variables set in the shell take precedence over `.env` values.
 | `--agentic-concurrency` | `1` | Max parallel LLM batches. Increase for faster scans if your provider allows concurrent requests. |
 | `--agentic-timeout` | `120` | Wall-clock timeout in seconds per batch. Batches exceeding this are marked as `batch_timeout` and skipped. |
 | `--agentic-fast-model` | — | A cheaper/faster model for simple confirmations (e.g. registry lookups, dependency checks). The primary `--llm-model` is used for complex reasoning. |
+| `--agentic-max-consecutive-failures` | `3` | Circuit-breaker threshold: skip the rest of a tier after this many consecutive batch failures. Raise it to push through a flaky endpoint (env `AIBOM_AGENTIC_MAX_FAILURES`). |
+| `--agentic-max-retry-seconds` | `1200` | Aggregate wall-clock budget for all retry activity in a run. Bounds a persistently-failing model so the scan finishes with degraded components instead of retrying for hours; `0` disables the retry pass (env `AIBOM_AGENTIC_MAX_RETRY_SECONDS`). |
+| `--llm-reasoning` | `auto` | `auto` / `off` / `on`. `off` disables model "thinking" using the correct per-provider parameter (env `AIBOM_LLM_REASONING`). See [Self-hosted & reasoning-model tuning](#self-hosted--reasoning-model-tuning). |
+| `--llm-init-kwargs` | — | JSON object of provider-specific init kwargs merged verbatim into the model constructor — an escape hatch for advanced tuning (env `AIBOM_LLM_INIT_KWARGS`). |
 | `--progress` | `auto` | Show live per-stage and per-scanner progress in interactive terminals. |
 | `--include-code-snippets` | `off` | Include raw code snippets inside per-finding decision annotations. |
 
@@ -138,6 +142,49 @@ Environment variables set in the shell take precedence over `.env` values.
 - **Small repos (< 50 components):** Default settings work well.
 - **Medium repos (50–200 components):** Consider `--agentic-concurrency 2` and `--agentic-batch-size 20`.
 - **Large repos (200+ components):** Use `--agentic-concurrency 4` and `--agentic-fast-model` for a two-tier approach.
+
+### Self-hosted & reasoning-model tuning
+
+The defaults (`--agentic-concurrency 1`, `--agentic-timeout 120`) are tuned for
+fast hosted APIs. A slow self-hosted endpoint or a verbose reasoning ("thinking")
+model needs different settings — otherwise batches silently time out, the circuit
+breaker trips, and the run produces **0 agentic enrichment**, which is
+indistinguishable from "the model found nothing to add."
+
+- **Disable/limit thinking first.** Reasoning verbosity is the number-one cause
+  of batch timeouts: a model that emits pages of reasoning per batch blows past
+  `--agentic-timeout`. Use `--llm-reasoning off`; it emits the correct parameter
+  for each provider (OpenAI/vLLM chat-template flag, `reasoning_effort` for
+  native OpenAI reasoners, Anthropic/Bedrock `thinking` disable, Gemini
+  `thinking_budget=0`). For anything the flag doesn't cover, drop to
+  `--llm-init-kwargs '<json>'`.
+- **Raise `--agentic-concurrency`** (1–8) when the endpoint has spare capacity
+  (e.g. a multi-GPU self-host). The default `1` is sequential/conservative.
+- **Raise `--agentic-timeout`** for verbose models — they emit many tokens and
+  tool calls per batch. The symptom of "too low" is repeated `Batch N timed out`
+  log lines, the circuit breaker tripping, and an `Agentic enrichment DEGRADED`
+  summary.
+- **Bound worst-case runtime** with `--agentic-max-retry-seconds` and tune the
+  breaker via `--agentic-max-consecutive-failures` (see the table above) so a
+  persistently-failing endpoint degrades those components and the scan still
+  finishes.
+
+**Worked example** — an open reasoning model served on vLLM (e.g.
+`zai-org/GLM-5.2-FP8`) needed thinking disabled **plus**
+`--agentic-concurrency 8` **plus** `--agentic-timeout 300` to complete at all;
+with thinking left on, every batch exceeded the 120 s default and the run fell
+back to the deterministic-only floor:
+
+```bash
+cisco-aibom analyze ./my-repo \
+  --output-file report.json \
+  --llm-provider openai \
+  --llm-api-base http://localhost:8000/v1 \
+  --llm-model zai-org/GLM-5.2-FP8 \
+  --llm-reasoning off \
+  --agentic-concurrency 8 \
+  --agentic-timeout 300
+```
 
 ## How Agentic Classification Works
 


### PR DESCRIPTION
## Summary

Makes agentic enrichment **correct and robust across every supported LLM provider**, not just the OpenAI/Azure path. Several providers (AWS Bedrock Claude, Azure reasoning deployments, self-hosted/vLLM models) were previously broken or silently degraded; this fixes the underlying causes and adds the tuning knobs needed to run non-OpenAI models reliably. The LangGraph `recursion_limit` safety net and all existing defaults are unchanged.

## What's fixed

**Malformed structured output no longer aborts the stage.** Every `data.get(...)` loop in the middleware extractor now guards against non-dict list elements. Previously a single stray element in a partial/malformed model response raised `AttributeError: 'str' object has no attribute 'get'`, which propagated out of the batch runner and silently degraded the whole repo to deterministic-only output.

**Provider/model-aware `temperature`.** `build_chat_model` sent `temperature=0.0` to every non-OpenAI-reasoning model. Newer Anthropic Claude (Opus 4.7+, Sonnet 5+, Fable 5+) — via `bedrock` or native `anthropic` — reject an explicit temperature (`ValidationException: temperature is deprecated for this model`), so every batch failed. Temperature is now omitted where the provider/model rejects it and pinned to `0.0` (for determinism) everywhere it's accepted. Verified against the installed provider classes.

**Token accounting for all providers.** Usage is now recovered from `response_metadata` (`amazon-bedrock-invocationMetrics` / `usage` for Bedrock; `token_usage` for Azure reasoning deployments) when a provider doesn't populate the standardized `usage_metadata`. Previously those providers reported `tokens=0` despite making real calls.

**No more silent total-degradation.** When every batch fails and nothing is enriched or discovered, the run now logs a `DEGRADED` status instead of "enrichment complete", so a misconfiguration can't masquerade as "found nothing".

**Configurable circuit breaker + bounded retries.** `--agentic-max-consecutive-failures` is now configurable *and* actually forwarded to the enrichment stage (it was previously never passed, so it was stuck at 3). `--agentic-max-retry-seconds` adds an aggregate retry wall-clock budget so a persistently-failing model degrades the affected components and the scan finishes, instead of retrying in ever-smaller batches for hours.

**Per-provider reasoning control + request-param passthrough.** `--llm-reasoning {auto,off,on}` disables/limits model "thinking" using the correct parameter for each provider family (OpenAI/vLLM chat-template or `reasoning_effort`, Anthropic `thinking`, Bedrock `model_kwargs`, Google `thinking_budget`), and `--llm-init-kwargs '<json>'` is a generic escape hatch. Needed for verbose reasoning / self-hosted models that otherwise time out every batch.

## Provider-general structured output (two-phase decouple)

The most significant change. `create_agent` selects its structured-output strategy by model name/profile: a native `ProviderStrategy` (clean terminal) for the OpenAI family, but `ToolStrategy` — which binds `tool_choice="any"` on **every** turn — for everyone else. Tool-eager models (Claude on Bedrock in particular) then never elect the terminal structured-output tool and run to the recursion/timeout with **zero output**, while GPT terminates cleanly. This asymmetry made Bedrock Claude effectively unusable for agentic enrichment.

Fix, **capability-gated and provider-general**:

- Models with reliable native in-loop structured output (OpenAI family) keep the single-pass path unchanged.
- Every other provider runs the tool loop **unforced** (no `response_format` → `tool_choice=auto` → natural termination on every provider), then a separate, **tool-less** `with_structured_output` call coerces the transcript into the schema (each provider uses its native mechanism). With no tools bound, the coercion cannot loop, so it always terminates.

This keeps the OpenAI path at full fidelity while making Bedrock/Anthropic/Google/Ollama terminate cleanly, without touching `recursion_limit` or imposing any per-call budget.

## Docs

Adds a "Self-hosted & reasoning-model tuning" section (disable thinking, raise concurrency/timeout, bound retries) and documents the new flags. Docs-only; no default changes.

## Testing

- **Full unit suite passes (1963 tests)**; all new behavior is unit-tested with mocked model construction / agents (no live LLM required). New coverage includes the per-provider temperature matrix, token-carrier fallbacks, the degradation-status detector, retry-budget exhaustion, the two-phase helpers, and the capability gate.
- **Live-validated end to end** across AWS Bedrock (Claude Opus 4.8), Azure OpenAI (GPT-5.5 and a gpt-5.x reasoning deployment), Google Vertex AI (Gemini 3.5 Flash), and local Ollama: Bedrock Claude went from *unable to complete* (hung / timed out with zero output) to completing cleanly and enriching; the OpenAI path shows no regression.

## Notes

- No changes to any default value; `recursion_limit` stays at its safety-net default.
- Fixes compose with the earlier structured-output recovery and strategy-fallback work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI and configuration options to better control agentic runs, including retry limits, circuit-breaking, and LLM reasoning behavior.
  * Expanded model setup options so users can fine-tune provider-specific settings during scans.

* **Bug Fixes**
  * Improved handling of agent output so malformed list items no longer interrupt enrichment.
  * Made agentic processing more resilient with better token tracking, safer retries, and clearer degraded-run reporting.

* **Documentation**
  * Updated the agentic tuning guide with the new options and added guidance for self-hosted and reasoning-heavy models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->