### PR TITLE
feat(agentic): cost and rate controls + degraded-run visibility

### DIFF
--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -594,6 +594,21 @@ _RETRYABLE_HINTS = frozenset(
     }
 )
 
+# Degraded hints that indicate the provider/deployment couldn't keep up with the
+# offered load (timeouts, 429s, tripped circuit breaker, exhausted retry budget).
+# When these dominate a partial degradation, lowering --agentic-concurrency /
+# --agentic-rate-limit is the actionable remedy.
+_DEGRADED_LOAD_HINTS = frozenset(
+    {
+        "batch_timeout",
+        "rate_limited",
+        "provider_outage",
+        "circuit_breaker_tripped",
+        "retry_budget_exhausted",
+        "retry_failed",
+    }
+)
+
 
 def _classify_failure_hint(exc: Exception) -> str:
     """Classify a batch-invocation exception into a precise agentic hint.
@@ -1238,6 +1253,23 @@ def _all_batches_failed(
     if not considered:
         return False
     return all(c.agentic_hint for c in considered)
+
+
+def _count_degraded(components: list[AIComponent]) -> int:
+    """Number of components left degraded (a non-empty ``agentic_hint`` in the
+    agentic-output set marks a failed enrichment — same convention as
+    ``_all_batches_failed``). Successful enrichment clears the hint to ``""``.
+    """
+    return sum(1 for c in components if c.agentic_hint)
+
+
+def _dominant_degraded_hint(components: list[AIComponent]) -> str | None:
+    """Most common degraded ``agentic_hint`` among *components*, or ``None`` when
+    none are degraded. Used to pick the remediation message."""
+    from collections import Counter
+
+    hints = Counter(c.agentic_hint for c in components if c.agentic_hint)
+    return hints.most_common(1)[0][0] if hints else None
 
 
 def _coerce_structured(model: Any, messages: list[Any]) -> dict[str, Any] | None:
@@ -2590,6 +2622,23 @@ def run_agentic_enrichment(
             usage.prompt_tokens,
             usage.completion_tokens,
         )
+        degraded = _count_degraded(all_enriched)
+        if degraded:
+            dominant = _dominant_degraded_hint(all_enriched)
+            remedy = (
+                " Consider lowering --agentic-concurrency / --agentic-rate-limit "
+                "(or raising --agentic-timeout) if your provider is overloaded."
+                if dominant in _DEGRADED_LOAD_HINTS
+                else ""
+            )
+            _LOGGER.warning(
+                "%d component(s) left degraded after enrichment "
+                "(dominant hint: %s); the BOM may be incomplete for those "
+                "components.%s",
+                degraded,
+                dominant,
+                remedy,
+            )
 
     return all_components, all_rels, all_flags, usage
 

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -65,11 +65,16 @@ class TokenUsage:
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    # Subset of prompt_tokens served from the provider's prompt cache (cache
+    # read). Lets us measure prompt-caching savings — Azure/OpenAI cache stable
+    # prompts automatically, but the win is invisible without this.
+    cached_tokens: int = 0
 
     def add(self, other: "TokenUsage") -> None:
         self.prompt_tokens += other.prompt_tokens
         self.completion_tokens += other.completion_tokens
         self.total_tokens += other.total_tokens
+        self.cached_tokens += other.cached_tokens
 
 
 _token_accumulator = TokenUsage()
@@ -87,6 +92,15 @@ def get_token_usage() -> TokenUsage:
 def _as_int(value: Any) -> int:
     """Coerce a token count to int, treating missing/invalid as 0."""
     return value if isinstance(value, int) else 0
+
+
+def _nested_int(d: Any, *path: str) -> int:
+    """Read a nested int (e.g. cache-read tokens), 0 if any level is missing."""
+    for key in path:
+        if not isinstance(d, dict):
+            return 0
+        d = d.get(key)
+    return _as_int(d)
 
 
 def _resolve_message_usage(msg: Any) -> tuple[int, int, int]:
@@ -114,8 +128,9 @@ def _resolve_message_usage(msg: Any) -> tuple[int, int, int]:
         prompt = _as_int(um.get("input_tokens"))
         completion = _as_int(um.get("output_tokens"))
         total = _as_int(um.get("total_tokens"))
+        cached = _nested_int(um, "input_token_details", "cache_read")
         if prompt or completion or total:
-            return prompt, completion, total or (prompt + completion)
+            return prompt, completion, total or (prompt + completion), cached
 
     rm = getattr(msg, "response_metadata", None)
     if isinstance(rm, dict):
@@ -124,25 +139,27 @@ def _resolve_message_usage(msg: Any) -> tuple[int, int, int]:
             prompt = _as_int(token_usage.get("prompt_tokens"))
             completion = _as_int(token_usage.get("completion_tokens"))
             total = _as_int(token_usage.get("total_tokens"))
+            cached = _nested_int(token_usage, "prompt_tokens_details", "cached_tokens")
             if prompt or completion or total:
-                return prompt, completion, total or (prompt + completion)
+                return prompt, completion, total or (prompt + completion), cached
 
         usage = rm.get("usage")
         if isinstance(usage, dict):
             prompt = _as_int(usage.get("input_tokens"))
             completion = _as_int(usage.get("output_tokens"))
             total = _as_int(usage.get("total_tokens"))
+            cached = _as_int(usage.get("cache_read_input_tokens"))
             if prompt or completion or total:
-                return prompt, completion, total or (prompt + completion)
+                return prompt, completion, total or (prompt + completion), cached
 
         metrics = rm.get("amazon-bedrock-invocationMetrics")
         if isinstance(metrics, dict):
             prompt = _as_int(metrics.get("inputTokenCount"))
             completion = _as_int(metrics.get("outputTokenCount"))
             if prompt or completion:
-                return prompt, completion, prompt + completion
+                return prompt, completion, prompt + completion, 0
 
-    return 0, 0, 0
+    return 0, 0, 0, 0
 
 
 def _accumulate_token_usage(result: Any) -> None:
@@ -154,7 +171,7 @@ def _accumulate_token_usage(result: Any) -> None:
     """
     messages = result.get("messages", []) if isinstance(result, dict) else []
     for msg in messages:
-        prompt, completion, total = _resolve_message_usage(msg)
+        prompt, completion, total, cached = _resolve_message_usage(msg)
         if not (prompt or completion or total):
             um = getattr(msg, "usage_metadata", None)
             rm = getattr(msg, "response_metadata", None)
@@ -170,6 +187,7 @@ def _accumulate_token_usage(result: Any) -> None:
         _token_accumulator.prompt_tokens += prompt
         _token_accumulator.completion_tokens += completion
         _token_accumulator.total_tokens += total
+        _token_accumulator.cached_tokens += cached
 
 
 class _EvidenceLocation(BaseModel):

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -301,7 +301,10 @@ class AgenticEnrichmentError(Exception):
     """Raised when the agentic enrichment pipeline fails."""
 
 
-def _build_rate_limiter() -> Any:
+def _build_rate_limiter(
+    requests_per_second: float = 1.0,
+    max_bucket_size: int = 10,
+) -> Any:
     """Return a client-side rate limiter for LLM calls.
 
     ``rate_limiter`` is a first-class field on LangChain's ``BaseChatModel``,
@@ -309,13 +312,18 @@ def _build_rate_limiter() -> Any:
     Ollama, etc.) without provider-specific branching.  It proactively
     throttles outgoing requests so the provider never sees a burst — preventing
     rate-limit errors rather than recovering from them after the fact.
+
+    ``requests_per_second`` / ``max_bucket_size`` default to a conservative
+    1 req/s (burst 10) — safe for the tightest provider quotas. Operators who
+    have confirmed a higher quota can raise the rate via ``--agentic-rate-limit``;
+    the default is intentionally left unchanged.
     """
     from langchain_core.rate_limiters import InMemoryRateLimiter
 
     return InMemoryRateLimiter(
-        requests_per_second=1.0,
+        requests_per_second=requests_per_second,
         check_every_n_seconds=0.1,
-        max_bucket_size=10,
+        max_bucket_size=max_bucket_size,
     )
 
 
@@ -327,7 +335,10 @@ def _build_model(
     from ..llm_factory import build_chat_model
 
     cfg = llm_config or {}
-    rate_limiter = _build_rate_limiter()
+    rate_limiter = _build_rate_limiter(
+        requests_per_second=cfg.get("rate_limit_rps") or 1.0,
+        max_bucket_size=cfg.get("rate_limit_bucket") or 10,
+    )
     return build_chat_model(
         model_string,
         provider=cfg.get("provider"),

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -2032,6 +2032,14 @@ def analyze(
                 f"{len(result.agentic_risk_flags)} risk flags[/]"
             )
 
+        if llm_config and result.agentic_degraded_count:
+            console.print(
+                f"  [yellow]⚠ {result.agentic_degraded_count} component(s) left "
+                f"degraded — the BOM may be incomplete. If your provider is "
+                f"overloaded, lower --agentic-concurrency / --agentic-rate-limit "
+                f"or raise --agentic-timeout.[/]"
+            )
+
         _print_missing_repositories_panel(result)
 
         if timing and result.timings:

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -1821,6 +1821,7 @@ def analyze(
         "total_tokens": 0,
         "prompt_tokens": 0,
         "completion_tokens": 0,
+        "cached_tokens": 0,
     }
     explicit_config: Optional[CustomCatalogConfig] = None
     if custom_catalog:
@@ -2080,9 +2081,11 @@ def analyze(
         source_summary["prompt_tokens"] = result.prompt_tokens
         source_summary["completion_tokens"] = result.completion_tokens
         source_summary["total_tokens"] = result.total_tokens
+        source_summary["cached_tokens"] = result.cached_tokens
         run_metadata["total_tokens"] += result.total_tokens
         run_metadata["prompt_tokens"] += result.prompt_tokens
         run_metadata["completion_tokens"] += result.completion_tokens
+        run_metadata["cached_tokens"] += result.cached_tokens
         if source_summary["status"] == "in_progress":
             source_summary["status"] = "completed"
 

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -1463,6 +1463,17 @@ def analyze(
         min=1,
         max=8,
     ),
+    agentic_rate_limit: float = typer.Option(
+        1.0,
+        "--agentic-rate-limit",
+        envvar="AIBOM_AGENTIC_RATE_LIMIT",
+        min=0.1,
+        help=(
+            "Client-side LLM request rate cap in requests/second (default 1.0). "
+            "Raise ONLY if you have confirmed your provider/deployment quota "
+            "sustains it — a higher rate risks HTTP 429s."
+        ),
+    ),
     agentic_fast_model: Optional[str] = typer.Option(
         None,
         "--agentic-fast-model",
@@ -1727,6 +1738,7 @@ def analyze(
             "api_base": llm_api_base,
             "api_version": llm_api_version,
             "reasoning": reasoning_choice,
+            "rate_limit_rps": agentic_rate_limit,
         }
         if llm_max_tokens is not None:
             llm_config["max_tokens"] = llm_max_tokens

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -292,6 +292,7 @@ def _scan_cache_settings(
     agentic_max_consecutive_failures: int,
     agentic_max_retry_seconds: int,
     include_code_snippets: bool,
+    agentic_review_secrets: bool,
     container_tier: str,
     custom_catalog: Optional[Path],
     atr_enrichment: bool,
@@ -319,6 +320,7 @@ def _scan_cache_settings(
         "agentic_max_consecutive_failures": agentic_max_consecutive_failures,
         "agentic_max_retry_seconds": agentic_max_retry_seconds,
         "include_code_snippets": include_code_snippets,
+        "agentic_review_secrets": agentic_review_secrets,
         "container_tier": container_tier,
         "custom_catalog": _file_cache_fingerprint(custom_catalog),
         # ATR enrichment changes the output shape (security_enrichment metadata /
@@ -1474,6 +1476,17 @@ def analyze(
             "sustains it — a higher rate risks HTTP 429s."
         ),
     ),
+    agentic_review_secrets: bool = typer.Option(
+        False,
+        "--agentic-review-secrets",
+        envvar="AIBOM_AGENTIC_REVIEW_SECRETS",
+        help=(
+            "Send secret/high-entropy-string detections through the agentic LLM "
+            "for adjudication. Off by default: secrets are false-positive-prone "
+            "and not a core AI component, so they are held back from the LLM to "
+            "save cost."
+        ),
+    ),
     agentic_fast_model: Optional[str] = typer.Option(
         None,
         "--agentic-fast-model",
@@ -1829,6 +1842,7 @@ def analyze(
         agentic_max_consecutive_failures=agentic_max_consecutive_failures,
         agentic_max_retry_seconds=agentic_max_retry_seconds,
         include_code_snippets=include_code_snippets,
+        agentic_review_secrets=agentic_review_secrets,
         container_tier=container_tier,
         custom_catalog=custom_catalog,
         atr_enrichment=atr_enrichment,
@@ -2005,6 +2019,7 @@ def analyze(
             agentic_max_retry_seconds=agentic_max_retry_seconds,
             agentic_cache_dir=agentic_cache_dir,
             include_code_snippets=include_code_snippets,
+            agentic_review_secrets=agentic_review_secrets,
             custom_catalog=explicit_config,
             atr_enrichment=atr_enrichment,
         )

--- a/aibom/src/aibom/reporters/json_reporter.py
+++ b/aibom/src/aibom/reporters/json_reporter.py
@@ -200,7 +200,13 @@ def _aibom_payload(
             "source_ref_canonical": attribution["source_ref_canonical"],
             "source_ref_version": attribution["source_ref_version"],
         }
-        for mk in ("elapsed_s", "prompt_tokens", "completion_tokens", "total_tokens"):
+        for mk in (
+            "elapsed_s",
+            "prompt_tokens",
+            "completion_tokens",
+            "total_tokens",
+            "cached_tokens",
+        ):
             val = detail.get(mk)
             if val is not None:
                 per_source_meta[mk] = val

--- a/aibom/src/aibom/scan_pipeline.py
+++ b/aibom/src/aibom/scan_pipeline.py
@@ -145,6 +145,29 @@ _CONTEXT_FREE_TYPES: frozenset[str] = frozenset(
 )
 
 
+def _partition_agentic_secrets(
+    components: list["AIComponent"],
+    review_secrets: bool = False,
+) -> tuple[list["AIComponent"], list["AIComponent"]]:
+    """Split components into ``(to_agentic, held_back)``.
+
+    ``SECRET`` detections (e.g. detect-secrets high-entropy strings) are
+    false-positive-prone and are not a core AI component. By default they are
+    held back from the agentic LLM stage rather than spending frontier-LLM
+    budget adjudicating hundreds of high-entropy strings, which can be a
+    substantial cost on secret-heavy repos. Pass ``review_secrets=True`` to
+    route them through the agent as before.
+    """
+    if review_secrets:
+        return list(components), []
+    to_agentic: list["AIComponent"] = []
+    held: list["AIComponent"] = []
+    for c in components:
+        target = held if c.component_type == AIComponentType.SECRET else to_agentic
+        target.append(c)
+    return to_agentic, held
+
+
 def _dedup_for_agentic(
     components: list["AIComponent"],
 ) -> tuple[list["AIComponent"], dict[str, list["AIComponent"]]]:
@@ -1189,6 +1212,7 @@ class ScanPipeline:
         agentic_max_consecutive_failures: int = 3,
         agentic_max_retry_seconds: int = 1200,
         agentic_cache_dir: str | Path | None = None,
+        agentic_review_secrets: bool = False,
         include_code_snippets: bool = False,
         progress_callback: Callable[[dict[str, Any]], None] | None = None,
         custom_catalog: CustomCatalogConfig | None = None,
@@ -1214,6 +1238,7 @@ class ScanPipeline:
             Path(agentic_cache_dir) if agentic_cache_dir is not None else None
         )
         self.include_code_snippets = include_code_snippets
+        self.agentic_review_secrets = agentic_review_secrets
         self.progress_callback = progress_callback
         self.custom_catalog = custom_catalog
         self.atr_enrichment = atr_enrichment
@@ -1483,6 +1508,21 @@ class ScanPipeline:
             ) from exc
 
         try:
+            components, held_secrets = _partition_agentic_secrets(
+                components, review_secrets=self.agentic_review_secrets
+            )
+            if held_secrets:
+                # Held-back secrets are intentionally NOT merged back into the
+                # final BOM: the success path below returns the agentic-enriched
+                # set only. This preserves the prior post-agentic output, where
+                # the agent already pruned SECRET detections as false positives.
+                # Pass --agentic-review-secrets to route them through the agent
+                # (and keep any it confirms) instead.
+                _LOGGER.info(
+                    "Held %d secret candidate(s) back from the agentic stage "
+                    "(pass --agentic-review-secrets to include them).",
+                    len(held_secrets),
+                )
             deduped, fanout = _dedup_for_agentic(components)
             if len(deduped) < len(components):
                 _LOGGER.info(

--- a/aibom/src/aibom/scan_pipeline.py
+++ b/aibom/src/aibom/scan_pipeline.py
@@ -105,6 +105,7 @@ class PipelineResult:
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    cached_tokens: int = 0
 
 
 def _service_dir(file_path: str) -> str:
@@ -1380,6 +1381,7 @@ class ScanPipeline:
             prompt_tokens=tu.prompt_tokens if tu else 0,
             completion_tokens=tu.completion_tokens if tu else 0,
             total_tokens=tu.total_tokens if tu else 0,
+            cached_tokens=tu.cached_tokens if tu else 0,
         )
 
     # ------------------------------------------------------------------

--- a/aibom/src/aibom/scan_pipeline.py
+++ b/aibom/src/aibom/scan_pipeline.py
@@ -97,6 +97,7 @@ class PipelineResult:
     relationships: list[ComponentRelationship] = field(default_factory=list)
     agentic_risk_flags: list[Any] = field(default_factory=list)
     agentic_candidate_count: int = 0
+    agentic_degraded_count: int = 0
     env_index: CrossRefIndex | None = None
     pkg_index: CrossRefIndex | None = None
     external_deps: list[ExternalRepoDep] = field(default_factory=list)
@@ -1373,6 +1374,7 @@ class ScanPipeline:
             relationships=relationships,
             agentic_risk_flags=agentic_flags,
             agentic_candidate_count=agentic_count,
+            agentic_degraded_count=getattr(self, "_agentic_degraded_count", 0),
             env_index=env_idx,
             pkg_index=pkg_idx,
             external_deps=ext_deps,
@@ -1502,7 +1504,7 @@ class ScanPipeline:
         )
 
         try:
-            from .agentic.agent import run_agentic_enrichment
+            from .agentic.agent import _count_degraded, run_agentic_enrichment
         except ImportError as exc:
             raise ImportError(
                 "Agentic classification requires the agentic runtime. "
@@ -1567,6 +1569,10 @@ class ScanPipeline:
                     agent_signature_catalog=agent_catalog,
                 )
             )
+            # Count degraded components from the raw agentic output, before
+            # post-filters below may strip components (and their hints) from the
+            # BOM.
+            self._agentic_degraded_count = _count_degraded(enriched)
             deduped_ids = {c.instance_id for c in deduped}
             enriched_deduped_ids = {
                 c.instance_id for c in enriched if c.instance_id in deduped_ids

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -30,9 +30,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aibom.agentic.agent import (
+    TokenUsage,
     _build_context_message,
     _build_rate_limiter,
     _extract_structured_response,
+    _resolve_message_usage,
 )
 from aibom.models import (
     AIComponent,
@@ -2520,3 +2522,55 @@ class TestRateLimiterConfig:
         )
         _build_model("gpt-5.5", {})
         assert captured["rate_limiter"].requests_per_second == 1.0
+
+
+class TestCachedTokenAccounting:
+    """Cache-read tokens must be captured so prompt-cache savings
+    are measurable (Azure/OpenAI cache automatically for stable prompts)."""
+
+    def _msg(self, usage_metadata=None, response_metadata=None):
+        m = MagicMock()
+        m.usage_metadata = usage_metadata
+        m.response_metadata = response_metadata or {}
+        return m
+
+    def test_token_usage_sums_cached_tokens(self):
+        a = TokenUsage(prompt_tokens=100, cached_tokens=80)
+        b = TokenUsage(prompt_tokens=50, cached_tokens=30)
+        a.add(b)
+        assert a.cached_tokens == 110
+
+    def test_reads_cache_read_from_usage_metadata(self):
+        msg = self._msg(
+            usage_metadata={
+                "input_tokens": 12000,
+                "output_tokens": 40,
+                "total_tokens": 12040,
+                "input_token_details": {"cache_read": 8000},
+            }
+        )
+        prompt, completion, total, cached = _resolve_message_usage(msg)
+        assert prompt == 12000
+        assert cached == 8000
+
+    def test_reads_cached_tokens_from_response_metadata(self):
+        msg = self._msg(
+            response_metadata={
+                "token_usage": {
+                    "prompt_tokens": 5000,
+                    "completion_tokens": 20,
+                    "total_tokens": 5020,
+                    "prompt_tokens_details": {"cached_tokens": 3000},
+                }
+            }
+        )
+        prompt, completion, total, cached = _resolve_message_usage(msg)
+        assert prompt == 5000
+        assert cached == 3000
+
+    def test_no_cache_fields_yields_zero_cached(self):
+        msg = self._msg(
+            usage_metadata={"input_tokens": 100, "output_tokens": 10, "total_tokens": 110}
+        )
+        _, _, _, cached = _resolve_message_usage(msg)
+        assert cached == 0

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -2246,6 +2246,123 @@ class TestAllBatchesFailed:
         assert "Agentic enrichment complete" not in caplog.text
 
 
+class TestPartialDegradedWarning:
+    """When SOME (but not all) components fail enrichment, the run still logs
+    'enrichment complete' — but must ALSO warn that N components were left
+    degraded, so a raised --agentic-concurrency/--agentic-rate-limit that
+    silently drops components does not read as a clean run."""
+
+    def _comp(self, iid, hint=""):
+        return AIComponent(
+            name=iid,
+            component_type=AIComponentType.MODEL,
+            file_path="a.py",
+            line_number=1,
+            instance_id=iid,
+            agentic_hint=hint,
+        )
+
+    def test_count_degraded_counts_only_hinted(self):
+        from aibom.agentic.agent import _count_degraded
+
+        comps = [
+            self._comp("c1", "batch_timeout"),
+            self._comp("c2", ""),
+            self._comp("c3", "retry_failed"),
+        ]
+        assert _count_degraded(comps) == 2
+
+    def test_count_degraded_zero_when_all_clean(self):
+        from aibom.agentic.agent import _count_degraded
+
+        comps = [self._comp("c1", ""), self._comp("c2", "")]
+        assert _count_degraded(comps) == 0
+
+    def test_dominant_degraded_hint_returns_most_common(self):
+        from aibom.agentic.agent import _dominant_degraded_hint
+
+        comps = [
+            self._comp("c1", "batch_timeout"),
+            self._comp("c2", "batch_timeout"),
+            self._comp("c3", "retry_failed"),
+            self._comp("c4", ""),
+        ]
+        assert _dominant_degraded_hint(comps) == "batch_timeout"
+
+    def test_dominant_degraded_hint_none_when_all_clean(self):
+        from aibom.agentic.agent import _dominant_degraded_hint
+
+        assert _dominant_degraded_hint([self._comp("c1", "")]) is None
+
+    @patch("aibom.agentic.agent._RETRY_COOLDOWN_S", 0)
+    @patch("aibom.agentic.agent._close_model_clients")
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("aibom.agentic.agent.create_aibom_agent")
+    def test_run_warns_on_partial_degradation(self, mock_create, _mb, _mc, caplog):
+        """A run that enriches one component but leaves another degraded logs
+        BOTH 'enrichment complete' and a degraded-components warning."""
+        import logging
+
+        from aibom.agentic.agent import _DEGRADED_LOAD_HINTS, run_agentic_enrichment
+
+        # Batch 1 succeeds (discovers a component so the run is not a total
+        # failure); batch 2 raises -> its component is left degraded.
+        agent_response = json.dumps(
+            {
+                "enriched_components": [],
+                "new_components": [
+                    {
+                        "name": "discovered",
+                        "component_type": "tool",
+                        "file_path": "b.py",
+                        "line_number": 2,
+                    }
+                ],
+                "new_relationships": [],
+                "risk_findings": [],
+            }
+        )
+        good_msg = MagicMock()
+        good_msg.content = agent_response
+        mock_agent = MagicMock()
+        mock_agent.invoke.side_effect = [
+            {"messages": [good_msg]},
+            TimeoutError("batch 2 timed out"),
+        ]
+        mock_create.return_value = mock_agent
+
+        comps = [
+            AIComponent(
+                name="ok",
+                component_type=AIComponentType.AGENT,
+                file_path="b.py",
+                line_number=1,
+                instance_id="ok",
+            ),
+            AIComponent(
+                name="fails",
+                component_type=AIComponentType.AGENT,
+                file_path="b.py",
+                line_number=3,
+                instance_id="fails",
+            ),
+        ]
+        with caplog.at_level(logging.WARNING, logger="aibom.agentic.agent"):
+            run_agentic_enrichment(
+                model_string="m",
+                deterministic_components=comps,
+                deterministic_relationships=[],
+                scan_paths=["/tmp"],
+                batch_size=1,
+                timeout_s=5,
+                max_retry_seconds=0,
+            )
+
+        assert "left degraded" in caplog.text
+        # load-related hints belong to the remediation set
+        assert "batch_timeout" in _DEGRADED_LOAD_HINTS
+
+
 class TestDiscoveryWiringIsProviderAgnostic:
     """Bedrock/Anthropic (Opus 4.8) report 0 new components on every
     repo while the OpenAI path finds many. This asserts the discovery path IS

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -29,7 +29,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from aibom.agentic.agent import _build_context_message, _extract_structured_response
+from aibom.agentic.agent import (
+    _build_context_message,
+    _build_rate_limiter,
+    _extract_structured_response,
+)
 from aibom.models import (
     AIComponent,
     AIComponentType,
@@ -2469,3 +2473,50 @@ class TestStructuredOutputCapabilityGate:
             )
             is None
         )
+
+
+@pytest.mark.skipif(
+    not _HAS_LANGCHAIN, reason="requires langchain_core (agentic extra)"
+)
+class TestRateLimiterConfig:
+    """The agentic request rate must be configurable, default 1/sec."""
+
+    def test_defaults_unchanged(self):
+        rl = _build_rate_limiter()
+        assert rl.requests_per_second == 1.0
+        assert rl.max_bucket_size == 10
+
+    def test_accepts_configured_rate_and_bucket(self):
+        rl = _build_rate_limiter(requests_per_second=5.0, max_bucket_size=20)
+        assert rl.requests_per_second == 5.0
+        assert rl.max_bucket_size == 20
+
+    def test_build_model_threads_rate_from_llm_config(self, monkeypatch):
+        from aibom.agentic.agent import _build_model
+
+        captured = {}
+
+        def fake_build_chat_model(model_string, **kwargs):
+            captured["rate_limiter"] = kwargs.get("rate_limiter")
+            return MagicMock()
+
+        monkeypatch.setattr(
+            "aibom.llm_factory.build_chat_model", fake_build_chat_model
+        )
+        _build_model("gpt-5.5", {"rate_limit_rps": 5.0})
+        assert captured["rate_limiter"].requests_per_second == 5.0
+
+    def test_build_model_defaults_to_one_rps_when_unset(self, monkeypatch):
+        from aibom.agentic.agent import _build_model
+
+        captured = {}
+
+        def fake_build_chat_model(model_string, **kwargs):
+            captured["rate_limiter"] = kwargs.get("rate_limiter")
+            return MagicMock()
+
+        monkeypatch.setattr(
+            "aibom.llm_factory.build_chat_model", fake_build_chat_model
+        )
+        _build_model("gpt-5.5", {})
+        assert captured["rate_limiter"].requests_per_second == 1.0

--- a/aibom/tests/test_scan_pipeline.py
+++ b/aibom/tests/test_scan_pipeline.py
@@ -265,6 +265,54 @@ class TestAgenticScope:
                 pipeline.run()
         assert mock_enrich.call_args.kwargs["max_retry_seconds"] == 42
 
+    def test_degraded_count_propagates_to_result(self, tmp_path: Path) -> None:
+        # A component left degraded by the agentic stage (non-empty
+        # agentic_hint) must be counted onto PipelineResult so the CLI can warn
+        # the operator the BOM may be incomplete.
+        (tmp_path / "app.py").write_text(
+            'from openai import OpenAI\nclient = OpenAI(model="gpt-4o")\n'
+        )
+        llm_cfg = {"model": "test/model", "api_key": "fake", "api_base": "http://x"}
+        pipeline = ScanPipeline(scan_paths=[str(tmp_path)], llm_config=llm_cfg)
+        degraded = AIComponent(
+            name="gpt-4o",
+            component_type=AIComponentType.MODEL,
+            file_path=str(tmp_path / "app.py"),
+            line_number=2,
+            model_name="gpt-4o",
+            agentic_hint="batch_timeout",
+        )
+        with patch("aibom.scan_pipeline.ensure_llm_runtime_available"):
+            with patch("aibom.agentic.agent.run_agentic_enrichment") as mock_enrich:
+                mock_enrich.return_value = (
+                    [degraded],
+                    [],
+                    [],
+                    _stub_token_usage(),
+                )
+                result = pipeline.run()
+        assert result.agentic_degraded_count == 1
+
+    def test_degraded_count_zero_when_clean(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text(
+            'from openai import OpenAI\nclient = OpenAI(model="gpt-4o")\n'
+        )
+        llm_cfg = {"model": "test/model", "api_key": "fake", "api_base": "http://x"}
+        pipeline = ScanPipeline(scan_paths=[str(tmp_path)], llm_config=llm_cfg)
+        clean = AIComponent(
+            name="gpt-4o",
+            component_type=AIComponentType.MODEL,
+            file_path=str(tmp_path / "app.py"),
+            line_number=2,
+            model_name="gpt-4o",
+            agentic_hint="",
+        )
+        with patch("aibom.scan_pipeline.ensure_llm_runtime_available"):
+            with patch("aibom.agentic.agent.run_agentic_enrichment") as mock_enrich:
+                mock_enrich.return_value = ([clean], [], [], _stub_token_usage())
+                result = pipeline.run()
+        assert result.agentic_degraded_count == 0
+
 
 class TestFileCache:
     def test_cache_deduplicates(self, tmp_path: Path) -> None:

--- a/aibom/tests/test_scan_pipeline.py
+++ b/aibom/tests/test_scan_pipeline.py
@@ -138,6 +138,49 @@ class TestPipelineTiming:
 
 
 class TestAgenticScope:
+    def test_secrets_held_back_from_agentic_by_default(self) -> None:
+        """SECRET candidates are not sent to the LLM by default."""
+        from aibom.scan_pipeline import _partition_agentic_secrets
+
+        comps = [
+            AIComponent(
+                name="openai",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="app.py",
+                line_number=1,
+            ),
+            AIComponent(
+                name="base64_high_entropy_string",
+                component_type=AIComponentType.SECRET,
+                file_path="app.py",
+                line_number=2,
+            ),
+        ]
+        to_agentic, held = _partition_agentic_secrets(comps, review_secrets=False)
+        assert [c.name for c in to_agentic] == ["openai"]
+        assert [c.name for c in held] == ["base64_high_entropy_string"]
+
+    def test_secrets_sent_to_agentic_when_review_enabled(self) -> None:
+        from aibom.scan_pipeline import _partition_agentic_secrets
+
+        comps = [
+            AIComponent(
+                name="openai",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="app.py",
+                line_number=1,
+            ),
+            AIComponent(
+                name="sk-secret",
+                component_type=AIComponentType.SECRET,
+                file_path="app.py",
+                line_number=2,
+            ),
+        ]
+        to_agentic, held = _partition_agentic_secrets(comps, review_secrets=True)
+        assert len(to_agentic) == 2
+        assert held == []
+
     def test_all_components_sent_to_agent(self, tmp_path: Path) -> None:
         """All components are sent to the agent for classification."""
         (tmp_path / "app.py").write_text(


### PR DESCRIPTION
## Summary

Cost and rate controls for the agentic enrichment stage, plus visibility into
what those controls cost you. Four focused commits:

1. **Configurable LLM request rate** (`--agentic-rate-limit`, env
   `AIBOM_AGENTIC_RATE_LIMIT`, min 0.1). `_build_rate_limiter` /`_build_model`
   now thread `requests_per_second` / `max_bucket_size` from `llm_config`.
   Default behavior is byte-identical (1.0 req/s, burst 10) — opt-in only.

2. **Hold secret candidates back from the agentic stage.** `SECRET`-type
   detections (high-entropy strings, etc.) are false-positive-prone and not a
   core AI component, so they are partitioned out before the LLM stage by
   default rather than spending frontier-LLM budget adjudicating hundreds of
   them. New `--agentic-review-secrets` (env `AIBOM_AGENTIC_REVIEW_SECRETS`,
   default off) restores the prior behavior. Setting is in the scan-cache key;
   no-LLM scans are unaffected.

3. **Capture + surface prompt-cache-read tokens.** `TokenUsage.cached_tokens`
   reads cache-read counts from `usage_metadata`
   (`input_token_details.cache_read`), OpenAI/Azure `response_metadata`
   (`token_usage.prompt_tokens_details.cached_tokens`), and Bedrock Converse
   (`usage.cache_read_input_tokens`), threaded to per-source + run metadata in
   the JSON report. Makes prompt-caching savings measurable.

4. **Warn when components are left degraded after enrichment.** A run where
   some (but not all) batches fail previously logged only "enrichment
   complete", with no signal that components were silently dropped from the
   BOM. Raising `--agentic-concurrency` / `--agentic-rate-limit` past a
   provider's sustainable throughput degrades components (batch timeouts)
   *without* any 429s, so the run looked clean while the BOM was incomplete.
   Now a WARNING (and a yellow CLI notice) reports the count + dominant failure
   hint, and — when the cause is load-induced — suggests lowering
   concurrency/rate or raising the timeout.

## Verification

Exercised end-to-end against a public multi-model MCP agent sample
(`aws-samples/sample-Advanced-Strands-Agents-with-MCP`) on an Azure GPT
deployment:

- **Rate limit:** flag threads through to the client-side limiter (4.0 rps /
  bucket 20 when set; 1.0/10 default unchanged). A clean cache-cleared A/B
  (concurrency 1/rate 1.0 vs 4/4.0) showed the raised arm was only ~18% faster
  **and** left components degraded — empirically confirming why the default is
  conservative and motivating commit 4's warning.
- **Secret gating:** default run held heuristic secret candidates back (log +
  no `code_analysis`-sourced secrets in the BOM); `--agentic-review-secrets`
  routed the same candidates through the agent.
- **Cache-read tokens:** run + per-source `cached_tokens` populated in JSON
  (~60% of prompt tokens served from the provider's automatic prompt cache on a
  stable system prefix).
- **Degraded warning:** a fresh high-concurrency run degraded components and
  fired both the log WARNING and the CLI notice; a clean run emitted nothing.

## Tests

- `TestRateLimiterConfig` — defaults, configured rate, `_build_model` threading.
- `TestAgenticScope` — secret gating (held back by default; sent when enabled);
  `agentic_degraded_count` propagation (present + zero).
- `TestCachedTokenAccounting` — sums; reads from `usage_metadata` /
  `response_metadata`; zero when absent.
- `TestPartialDegradedWarning` — count/dominant-hint helpers; end-to-end
  partial-degradation warning.

Full agentic + pipeline suites: 233 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable agentic scan rate limiting and an option to include secret items in agent-assisted analysis.
  * Enhanced scan results with cached token usage and an agentic degraded-items count.
* **Bug Fixes**
  * Improved token accounting to track and report cached tokens reliably.
  * Added clearer “left degraded” warnings with guidance for tuning concurrency/rate limits/timeouts.
* **Documentation**
  * Updated JSON output to include cached token field in per-source details.
* **Tests**
  * Expanded coverage for secret handling, degraded reporting, rate limiting, and cached token extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->