### PR TITLE
chore(ci): CodeQL advanced setup so fork PRs get code scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: "0 20 * * 3"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # required to upload code scanning results
+      security-events: write
+      # required to fetch internal or private CodeQL packs
+      packages: read
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,12 +24,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - language: actions
+            build-mode: none
           - language: python
             build-mode: none
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,7 +21,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install uv
         uses: astral-sh/setup-uv@v6.7.0
       - name: Install Python 3.13

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.7.0
+        uses: astral-sh/setup-uv@v8.3.2
       - name: Install Python 3.13
         run: uv python install 3.13
       - name: Stage README for package metadata

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python for uv
-        uses: astral-sh/setup-uv@v6.7.0
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
         working-directory: aibom
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python for uv
         uses: astral-sh/setup-uv@v6.7.0

--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Problem

Code scanning results do not appear on pull requests opened from **forks** (e.g. #53, from an external contributor using the fork workflow).

CodeQL on this repo is configured via **default setup** (the dynamic `github-code-scanning/codeql` workflow, not a committed file). Default setup writes results using the `GITHUB_TOKEN`'s `security-events: write` permission. For `pull_request` events **from a fork**, GitHub issues a **read-only `GITHUB_TOKEN` with no secrets**, so results can't be uploaded — and default setup therefore **never runs CodeQL on fork PRs**.

Evidence: same-repo branch PRs (#54, #56) each got a CodeQL run, but fork PR #53 has **zero** CodeQL runs and no CodeQL check at all.

## Fix

Switch from default setup to **advanced setup** by committing `.github/workflows/codeql.yml`. The `analyze` job explicitly grants `security-events: write`, which lets CodeQL run and report on fork PRs (the maintainer approval gate for first-time contributors still applies).

- Python-only (repo is 100% Python), `build-mode: none`
- `github/codeql-action@v4` (GitHub's recommended major-version tag for advanced setup)
- Triggers mirror the prior default-setup coverage: push to `main`, `pull_request`, and a weekly schedule

## ⚠️ Required manual step at merge

Advanced and default setup **cannot both be enabled**. When this merges, an admin must switch CodeQL from **Default** to **Advanced** (or disable default setup) in **Settings → Code security → Code scanning**. Otherwise GitHub rejects the new workflow's uploads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code scanning to help identify security issues on pushes, pull requests, and a weekly schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->