### PR TITLE
fix(agentic): tolerate explicit null on defaulted structured-output fields

### DIFF
--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -33,7 +33,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic_core import PydanticUndefined
 
 from ..agent_signatures import AgentSignatureCatalog
 from ..cache_paths import cache_read_dirs, ensure_cache_dir
@@ -190,21 +191,61 @@ def _accumulate_token_usage(result: Any) -> None:
         _token_accumulator.cached_tokens += cached
 
 
-class _EvidenceLocation(BaseModel):
+class _NullTolerantModel(BaseModel):
+    """Base for the agent's structured-output schemas.
+
+    LLMs routinely emit an explicit ``null`` for a field that carries a
+    default (e.g. ``{"evidence_snippet": null}``) instead of omitting it.
+    Pydantic rejects ``null`` for a non-Optional defaulted field, and because
+    an entire batch reply is validated against a single ``AgentResponse``
+    schema, one stray ``null`` from the model would invalidate the whole
+    response — discarding every component in the batch and forcing a
+    cooldown retry.
+
+    This validator drops any explicit ``null`` for a field that has a
+    non-``None`` default, so the field falls back to that default. Fields
+    that are genuinely ``Optional`` with a ``None`` default keep the ``null``,
+    and any provided non-null value is left untouched.
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def _drop_null_for_defaulted_fields(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        cleaned = data
+        for name, field in cls.model_fields.items():
+            if data.get(name, PydanticUndefined) is not None:
+                continue
+            has_default = field.default is not PydanticUndefined
+            has_factory = field.default_factory is not None
+            if not (has_default or has_factory):
+                continue
+            # A ``None`` default means the field is legitimately nullable;
+            # preserve the explicit ``null`` rather than dropping it.
+            if has_default and field.default is None:
+                continue
+            if cleaned is data:
+                cleaned = dict(data)
+            cleaned.pop(name)
+        return cleaned
+
+
+class _EvidenceLocation(_NullTolerantModel):
     file_path: str = ""
     start_line: int = 0
     end_line: int = 0
     role: str = ""
 
 
-class _DecisionAnnotation(BaseModel):
+class _DecisionAnnotation(_NullTolerantModel):
     decision: str = ""
     justification: str = ""
     evidence_kinds: list[str] = Field(default_factory=list)
     evidence_locations: list[_EvidenceLocation] = Field(default_factory=list)
 
 
-class AgentEvidence(BaseModel):
+class AgentEvidence(_NullTolerantModel):
     """Structured evidence that a component is truly an agent.
 
     Every classification that results in ``component_type == "agent"`` MUST
@@ -252,14 +293,14 @@ class AgentEvidence(BaseModel):
     justification: str = ""
 
 
-class _EnrichedComponent(BaseModel):
+class _EnrichedComponent(_NullTolerantModel):
     instance_id: str = Field(default="", description=_IID_DESC)
     updates: dict[str, Any] = Field(default_factory=dict)
     decision_annotation: _DecisionAnnotation | None = None
     agent_evidence: AgentEvidence | None = None
 
 
-class _NewComponent(BaseModel):
+class _NewComponent(_NullTolerantModel):
     name: str = ""
     component_type: str = "other"
     file_path: str = ""
@@ -271,19 +312,19 @@ class _NewComponent(BaseModel):
     agent_evidence: AgentEvidence | None = None
 
 
-class _RemoveComponent(BaseModel):
+class _RemoveComponent(_NullTolerantModel):
     instance_id: str = Field(default="", description=_IID_DESC)
     reason: str = ""
 
 
-class _ReclassifyComponent(BaseModel):
+class _ReclassifyComponent(_NullTolerantModel):
     instance_id: str = Field(default="", description=_IID_DESC)
     new_type: str = ""
     reason: str = ""
     agent_evidence: AgentEvidence | None = None
 
 
-class _Relationship(BaseModel):
+class _Relationship(_NullTolerantModel):
     source_name: str = ""
     target_name: str = ""
     relationship_type: str = ""
@@ -292,7 +333,7 @@ class _Relationship(BaseModel):
     decision_annotation: _DecisionAnnotation | None = None
 
 
-class _RiskFinding(BaseModel):
+class _RiskFinding(_NullTolerantModel):
     flag: str = ""
     description: str = ""
     file_path: str = ""
@@ -301,7 +342,7 @@ class _RiskFinding(BaseModel):
     decision_annotation: _DecisionAnnotation | None = None
 
 
-class AgentResponse(BaseModel):
+class AgentResponse(_NullTolerantModel):
     """Structured output schema for the AIBOM agent."""
 
     enriched_components: list[_EnrichedComponent] = Field(default_factory=list)
@@ -3264,12 +3305,12 @@ def run_cross_repo_coordination(
 # ---------------------------------------------------------------------------
 
 
-class _SelectedDirectory(BaseModel):
+class _SelectedDirectory(_NullTolerantModel):
     path: str = ""
     reason: str = ""
 
 
-class ContainerLayoutResponse(BaseModel):
+class ContainerLayoutResponse(_NullTolerantModel):
     """Structured output for container app directory identification."""
 
     selected_directories: list[_SelectedDirectory] = Field(default_factory=list)

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -214,16 +214,16 @@ class _NullTolerantModel(BaseModel):
         if not isinstance(data, dict):
             return data
         cleaned = data
-        for name, field in cls.model_fields.items():
+        for name, field_info in cls.model_fields.items():
             if data.get(name, PydanticUndefined) is not None:
                 continue
-            has_default = field.default is not PydanticUndefined
-            has_factory = field.default_factory is not None
+            has_default = field_info.default is not PydanticUndefined
+            has_factory = field_info.default_factory is not None
             if not (has_default or has_factory):
                 continue
             # A ``None`` default means the field is legitimately nullable;
             # preserve the explicit ``null`` rather than dropping it.
-            if has_default and field.default is None:
+            if has_default and field_info.default is None:
                 continue
             if cleaned is data:
                 cleaned = dict(data)

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -2765,3 +2765,45 @@ class TestNullTolerantDefaults:
             }
         )
         assert resp.enriched_components[0].agent_evidence.evidence_snippet == ""
+
+    def test_mixed_batch_with_null_yields_all_finding_kinds(self):
+        # A realistic full batch: a stray ``null`` on a defaulted field in one
+        # entry must not discard the enrichments, new components, relationships,
+        # or risk findings that share the same response.
+        resp = AgentResponse.model_validate(
+            {
+                "enriched_components": [
+                    {"instance_id": "keep_me", "agent_evidence": None}
+                ],
+                "new_components": [{"name": "n1", "framework": None}],
+                "new_relationships": [
+                    {"source_name": "a", "target_name": "b", "source_type": None}
+                ],
+                "risk_findings": [{"flag": "leak", "severity": None}],
+            }
+        )
+        assert resp.enriched_components[0].instance_id == "keep_me"
+        assert resp.new_components[0].framework == ""
+        assert resp.new_relationships[0].source_type == ""
+        assert resp.risk_findings[0].severity == "info"
+
+    @pytest.mark.skipif(
+        not _HAS_LANGCHAIN, reason="requires langchain_core (agentic extra)"
+    )
+    def test_langchain_parser_tolerates_null_on_defaulted_field(self):
+        # The production structured-output path validates the model's raw JSON
+        # through langchain's parser (``response_format=AgentResponse``), not a
+        # direct ``model_validate`` call. Drive that real entrypoint to prove the
+        # before-validator is wired into it and a stray null no longer discards
+        # the sibling entries in the batch.
+        from langchain_core.output_parsers import PydanticOutputParser
+
+        parser = PydanticOutputParser(pydantic_object=AgentResponse)
+        resp = parser.parse(
+            '{"risk_findings": [{"flag": "a", "severity": null}, '
+            '{"flag": "b", "severity": "high"}]}'
+        )
+        assert isinstance(resp, AgentResponse)
+        assert len(resp.risk_findings) == 2
+        assert resp.risk_findings[0].severity == "info"
+        assert resp.risk_findings[1].severity == "high"

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -30,11 +30,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aibom.agentic.agent import (
+    AgentEvidence,
+    AgentResponse,
     TokenUsage,
     _build_context_message,
     _build_rate_limiter,
+    _EnrichedComponent,
     _extract_structured_response,
     _resolve_message_usage,
+    _RiskFinding,
 )
 from aibom.models import (
     AIComponent,
@@ -2691,3 +2695,73 @@ class TestCachedTokenAccounting:
         )
         _, _, _, cached = _resolve_message_usage(msg)
         assert cached == 0
+
+
+class TestNullTolerantDefaults:
+    """LLMs routinely emit an explicit ``null`` for a field that has a default
+    instead of omitting it. Pydantic rejects ``null`` for a non-Optional
+    defaulted field, and because the whole batch is validated against a single
+    ``AgentResponse`` schema, one stray ``null`` would discard every component
+    in the batch and force a cooldown retry. The structured-output models must
+    coerce an explicit ``null`` on a defaulted field back to its default."""
+
+    def test_null_scalar_coerced_to_default(self):
+        ev = AgentEvidence(evidence_snippet=None, justification=None)
+        assert ev.evidence_snippet == ""
+        assert ev.justification == ""
+
+    def test_null_literal_coerced_to_default(self):
+        ev = AgentEvidence(pattern=None)
+        assert ev.pattern == "other"
+
+    def test_null_int_coerced_to_default(self):
+        ev = AgentEvidence(definition_start_line=None)
+        assert ev.definition_start_line == 0
+
+    def test_null_list_field_coerced_to_default(self):
+        resp = AgentResponse(enriched_components=None, risk_findings=None)
+        assert resp.enriched_components == []
+        assert resp.risk_findings == []
+
+    def test_null_dict_field_coerced_to_default(self):
+        comp = _EnrichedComponent(instance_id="x", updates=None)
+        assert comp.updates == {}
+
+    def test_explicitly_optional_field_still_accepts_none(self):
+        # ``model_name`` is genuinely ``str | None`` and its default is None,
+        # so an explicit null must be preserved, not coerced.
+        comp = _EnrichedComponent(instance_id="x", decision_annotation=None)
+        assert comp.decision_annotation is None
+
+    def test_provided_value_is_untouched(self):
+        finding = _RiskFinding(severity="high", flag="secret")
+        assert finding.severity == "high"
+        assert finding.flag == "secret"
+
+    def test_one_null_does_not_invalidate_whole_batch(self):
+        # A single component carrying a stray ``null`` must not discard the
+        # other components in the same batch response.
+        resp = AgentResponse.model_validate(
+            {
+                "risk_findings": [
+                    {"flag": "a", "severity": None},
+                    {"flag": "b", "severity": "high"},
+                ]
+            }
+        )
+        assert len(resp.risk_findings) == 2
+        assert resp.risk_findings[0].severity == "info"
+        assert resp.risk_findings[1].severity == "high"
+
+    def test_nested_null_in_batch_component_is_tolerated(self):
+        resp = AgentResponse.model_validate(
+            {
+                "enriched_components": [
+                    {
+                        "instance_id": "x",
+                        "agent_evidence": {"evidence_snippet": None},
+                    }
+                ]
+            }
+        )
+        assert resp.enriched_components[0].agent_evidence.evidence_snippet == ""


### PR DESCRIPTION
## Summary

Fixes #55.

The agent's structured-output models (`AgentResponse`, `AgentEvidence`, `_RiskFinding`, `_NewComponent`, etc.) declare their fields as defaulted but non-Optional (e.g. `evidence_snippet: str = ""`, `severity: str = "info"`, `list[...] = Field(default_factory=list)`). Pydantic v2 rejects an explicit `null` for such a field even though a default exists.

Because an entire batch reply is validated against a single `response_format=AgentResponse`, one stray `null` from the LLM invalidated the **whole** response — so every component in that batch was lost and a cooldown retry pass was triggered. LLMs routinely emit an explicit `null` instead of omitting an optional-looking field, so on a 20-component batch this wasted a full round-trip and its tokens on a single flaky field.

## Fix

Add a shared `_NullTolerantModel` base class with a `@model_validator(mode="before")` that drops an explicit `null` for any field carrying a non-`None` default, so the field falls back to that default:

- Fields with a scalar default (`""`, `0`, `"info"`, a `Literal` default) or a `default_factory` (lists/dicts) → an explicit `null` is dropped and the default applies.
- Fields that are genuinely `Optional` with a `None` default (e.g. `decision_annotation`, `model_name`) → the explicit `null` is **preserved**.
- Any provided non-null value is left untouched.

All 12 structured-output schemas now inherit this base, so the hardening applies uniformly (including the nested and container-layout models). This is the smaller of the two options suggested in the issue and directly removes the retry storm; per-entry salvage remains a possible future hardening.

## Testing

New `TestNullTolerantDefaults` class in `test_agentic_agent.py` covering:

- `null` coerced to default for scalar, `Literal`, int, list, and dict fields.
- Genuinely-Optional (`None`-default) fields still accept an explicit `null`.
- Provided values are untouched.
- A single stray `null` in one batch entry no longer discards the sibling entries (the original failure mode).
- A `null` nested inside a batch component is tolerated.

These tests are pure-pydantic (no agentic extra required), so they run in the standard CI environment.

```
tests/test_agentic_agent.py .................  131 passed, 8 skipped
full suite: 2001 passed, 11 skipped
```

## Notes

- No behavior change to the output contract — the wire schema is simply more forgiving of `null`.
- Backward compatible: valid payloads validate identically to before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when processing structured AI responses containing explicit `null` values.
  * Now tolerates `null` for fields with non-`None` defaults by falling back to the schema defaults.
  * Prevents a single bad field (or batch element) from causing validation failure or dropping sibling batch results.
* **Tests**
  * Added coverage to confirm default-preserving `null` handling across nested structured outputs and batch responses, including a gated integration check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->