### PR TITLE
chore: prepare 1.0.6 release

### DIFF
--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-aibom"
-version = "1.0.5"
+version = "1.0.6"
 description = "A tool to generate an AI BOM from source code."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/aibom/src/aibom/manifest.json
+++ b/aibom/src/aibom/manifest.json
@@ -1,8 +1,8 @@
 {
-  "analyzer_version": "1.0.5",
-  "schema_version": "1.0.5",
+  "analyzer_version": "1.0.6",
+  "schema_version": "1.0.6",
   "duckdb_sha256": "b1165384a646094aa6a4762d676f285c1c68b6d7f9367c90a129b529904a3268",
-  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.5.duckdb",
+  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.6.duckdb",
   "upload_mode": "direct",
   "max_direct_upload_mb": 25,
   "log_level": "INFO"

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "cisco-aibom"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Patch release **1.0.5 → 1.0.6**. Version-bump-only change (no source changes), capturing everything merged to `main` since the 1.0.5 tag.

### Changes since 1.0.5
- fix(agentic): tolerate explicit null on defaulted structured-output fields (#58)
- feat(agentic): cost and rate controls + degraded-run visibility (#56)
- feat: optional ATR security-enrichment source (ATLAS technique tagging) (#53)
- chore(ci): CodeQL advanced setup so fork PRs get code scanning (#57)
- Agentic enrichment: provider-robust temperature/tokens/retries + provider-general structured output (#54)

### Files bumped
| File | Change |
|------|--------|
| `aibom/pyproject.toml` | `version` 1.0.5 → 1.0.6 |
| `aibom/uv.lock` | `cisco-aibom` package version 1.0.5 → 1.0.6 |
| `aibom/src/aibom/manifest.json` | `analyzer_version` / `schema_version` → 1.0.6; `duckdb_file` → `aibom_catalog-1.0.6.duckdb` |

`duckdb_sha256` is unchanged (`b1165384…`) — the KB catalog content is identical; only the version-stamped filename changes.

### Verification
- `uv version 1.0.6` (bumps pyproject + relocks uv.lock)
- `uv lock --check` — consistent
- No test asserts the real manifest version (fixtures use synthetic versions), so the bump does not affect the suite.

### Post-merge publish
After merge, tag `1.0.6` and create the GitHub release with the `aibom_catalog-1.0.6.duckdb` asset (same content as prior releases, version-named copy).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package release version to 1.0.6.
  * Updated manifest metadata and schema versions to 1.0.6.
  * Updated the referenced catalog file for the 1.0.6 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->