### PR TITLE
feat: stamp a shared co-scan batch id across per-source uploads

### DIFF
--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -978,6 +978,7 @@ def _build_submission_payload(
     )
     return {
         "run_id": metadata.get("run_id"),
+        "scan_batch_id": metadata.get("scan_batch_id"),
         "analyzer_version": metadata.get("analyzer_version") or ANALYZER_VERSION,
         "submitted_at": submitted_at,
         "source_kind": source_kind,
@@ -1053,6 +1054,13 @@ def _build_submission_payloads(
         return [_build_submission_payload(report, source_outcomes)]
 
     base_run_id = analysis.get("metadata", {}).get("run_id")
+    # One shared co-scan batch id for the whole invocation, stamped on every
+    # fanned-out upload so consumers can regroup them into one scan. Prefer the
+    # id the analyzer already recorded; mint one for legacy reports that predate
+    # the field so re-uploads still group.
+    scan_batch_id = analysis.get("metadata", {}).get("scan_batch_id") or str(
+        uuid.uuid4()
+    )
     total = len(sources)
     payloads: List[Dict[str, Any]] = []
     for source_key, entry in sources.items():
@@ -1064,6 +1072,9 @@ def _build_submission_payloads(
         run_id = base_run_id if total <= 1 else str(uuid.uuid4())
         scoped_report = _scope_report_to_source(report, source_key, entry, run_id)
         payload = _build_submission_payload(scoped_report)
+        # Every upload in this invocation carries the same batch id (run_id
+        # differs per source; batch id does not).
+        payload["scan_batch_id"] = scan_batch_id
         attribution = _attribution_from_source_entry(entry)
         if attribution is not None:
             payload["source_attribution"] = attribution
@@ -1853,6 +1864,10 @@ def analyze(
     source_outcomes: Dict[str, Dict[str, Any]] = {}
     run_metadata: Dict[str, Any] = {
         "run_id": str(uuid.uuid4()),
+        # One id per CLI invocation, shared across every per-source upload of
+        # this run (each upload keeps its own distinct run_id). Lets consumers
+        # regroup a multi-source run's fanned-out uploads back into one scan.
+        "scan_batch_id": str(uuid.uuid4()),
         "analyzer_version": ANALYZER_VERSION,
         "started_at": _utcnow_iso(),
         "output_format": output_format,

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -1050,8 +1050,13 @@ def _build_submission_payloads(
     sources = analysis.get("sources", {})
     if not isinstance(sources, dict) or not sources:
         # No per-source breakdown (e.g. a legacy report); fall back to a single
-        # combined submission so the upload still happens.
-        return [_build_submission_payload(report, source_outcomes)]
+        # combined submission so the upload still happens. Mint a batch id when
+        # the report predates the field so a re-upload still carries one,
+        # consistent with the fan-out path below.
+        payload = _build_submission_payload(report, source_outcomes)
+        if not payload.get("scan_batch_id"):
+            payload["scan_batch_id"] = str(uuid.uuid4())
+        return [payload]
 
     base_run_id = analysis.get("metadata", {}).get("run_id")
     # One shared co-scan batch id for the whole invocation, stamped on every

--- a/aibom/tests/test_reports.py
+++ b/aibom/tests/test_reports.py
@@ -90,3 +90,36 @@ def test_fan_out_mints_batch_id_for_legacy_report():
     batch_ids = {p["scan_batch_id"] for p in payloads}
     assert len(batch_ids) == 1
     assert batch_ids != {None}
+
+
+def _legacy_no_sources_report() -> dict:
+    return {
+        "aibom_analysis": {
+            "metadata": {
+                "run_id": "run-123",
+                "analyzer_version": "1.2.3",
+                "completed_at": "2025-01-01T12:00:00Z",
+            },
+            "sources": {},
+            "summary": {},
+        }
+    }
+
+
+def test_legacy_no_sources_report_mints_batch_id():
+    # A pre-field report with no per-source breakdown still gets a minted batch
+    # id on its single upload, consistent with the fan-out path.
+    payloads = _build_submission_payloads(_legacy_no_sources_report())
+
+    assert len(payloads) == 1
+    assert payloads[0]["scan_batch_id"]
+
+
+def test_legacy_no_sources_report_preserves_existing_batch_id():
+    report = _legacy_no_sources_report()
+    report["aibom_analysis"]["metadata"]["scan_batch_id"] = "batch-abc"
+
+    payloads = _build_submission_payloads(report)
+
+    assert len(payloads) == 1
+    assert payloads[0]["scan_batch_id"] == "batch-abc"

--- a/aibom/tests/test_reports.py
+++ b/aibom/tests/test_reports.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from aibom.cli import _build_submission_payload
+from aibom.cli import _build_submission_payload, _build_submission_payloads
 
 
 def test_submission_payload_wraps_report():
@@ -10,6 +10,7 @@ def test_submission_payload_wraps_report():
         "aibom_analysis": {
             "metadata": {
                 "run_id": "run-123",
+                "scan_batch_id": "batch-abc",
                 "analyzer_version": "1.2.3",
                 "completed_at": "2025-01-01T12:00:00Z",
             },
@@ -28,8 +29,64 @@ def test_submission_payload_wraps_report():
     payload = _build_submission_payload(report, source_outcomes)
 
     assert payload["run_id"] == "run-123"
+    assert payload["scan_batch_id"] == "batch-abc"
     assert payload["analyzer_version"] == "1.2.3"
     assert payload["submitted_at"] == "2025-01-01T12:00:00Z"
     assert payload["source_kind"] == "SOURCE_KIND_LOCAL_PATH"
     assert payload["sources"] == [{"name": "repo", "path": "/app"}]
     assert payload["report"] == report
+
+
+def _multi_source_report() -> dict:
+    return {
+        "aibom_analysis": {
+            "metadata": {
+                "run_id": "run-123",
+                "scan_batch_id": "batch-xyz",
+                "analyzer_version": "1.2.3",
+                "completed_at": "2025-01-01T12:00:00Z",
+            },
+            "sources": {
+                "repo-a": {
+                    "source_name": "repo-a",
+                    "source_path": "/a",
+                    "summary": {"source_kind": "local-path"},
+                    "components": [],
+                    "relationships": [],
+                    "metadata": {},
+                },
+                "repo-b": {
+                    "source_name": "repo-b",
+                    "source_path": "/b",
+                    "summary": {"source_kind": "local-path"},
+                    "components": [],
+                    "relationships": [],
+                    "metadata": {},
+                },
+            },
+            "summary": {},
+        }
+    }
+
+
+def test_fan_out_shares_batch_id_but_distinct_run_ids():
+    payloads = _build_submission_payloads(_multi_source_report())
+
+    assert len(payloads) == 2
+    # Every upload in the invocation carries the same co-scan batch id...
+    batch_ids = {p["scan_batch_id"] for p in payloads}
+    assert batch_ids == {"batch-xyz"}
+    # ...but each keeps its own distinct run_id.
+    run_ids = {p["run_id"] for p in payloads}
+    assert len(run_ids) == 2
+
+
+def test_fan_out_mints_batch_id_for_legacy_report():
+    report = _multi_source_report()
+    del report["aibom_analysis"]["metadata"]["scan_batch_id"]
+
+    payloads = _build_submission_payloads(report)
+
+    batch_ids = {p["scan_batch_id"] for p in payloads}
+    assert len(batch_ids) == 1
+    assert batch_ids != {None}


### PR DESCRIPTION
## Summary

A multi-source scan (`--discover-repos`, `--github-org`, or several sources on the command line) fans out **one upload per source**, each carrying its own distinct `run_id` — the backend's per-source ingest identity. That is correct for ingest, but it loses the fact that the N uploads all came from a **single CLI invocation**.

This adds a `scan_batch_id`: one value generated per invocation and stamped on **every** upload in the fan-out, while each upload keeps its own `run_id`. Consumers can then regroup a run's uploads into one logical scan (for audit and "did all N sources succeed?" views) without changing per-source ingest identity.

## What changed

- Generate `scan_batch_id` once per invocation (recorded in report metadata).
- `_build_submission_payloads` stamps that same batch id on each fanned-out upload; `run_id` still differs per source.
- Legacy reports that predate the field get a freshly minted batch id at upload time so re-uploads still group.

## Compatibility

Additive and backward-compatible. Single-source scans are unaffected (they get a batch id too, but ingest identity is unchanged). No change to the one-upload-per-source model or to `run_id` semantics.

## Testing

`tests/test_reports.py`:
- Fan-out shares one `scan_batch_id` while each payload keeps a distinct `run_id`.
- Legacy report without the field gets a single minted batch id across the fan-out.
- Existing envelope test extended to assert the field is surfaced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Multi-source scans now share a single batch identifier, making related per-source submissions easier to group together.
  * Uploads include the scan batch identifier from analysis metadata.
  * Legacy reports without a batch identifier are automatically assigned one during submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->