### PR TITLE
feat(agentic): cache the Bedrock system prompt to cut re-sent input tokens

### DIFF
--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -462,6 +462,128 @@ class _AgentBundle:
         return getattr(self._graph, name)
 
 
+# Ephemeral cache breakpoint (5m default TTL). aibom's batches run seconds apart,
+# and every cache hit refreshes the 5m window for free, so 5m comfortably covers a
+# whole multi-batch run without paying the higher 1h write premium.
+_BEDROCK_CACHE_CONTROL = {"type": "ephemeral", "ttl": "5m"}
+
+# Model-id substrings whose Bedrock family supports Anthropic-style prompt caching.
+# Mirrors langchain_aws's ``_is_supported_model`` so a non-Claude/Nova Bedrock
+# model (e.g. Llama) is never poked with a ``cache_control`` block it may reject.
+_BEDROCK_CACHEABLE_MODEL_MARKERS = ("anthropic", "amazon.nova")
+
+
+def _build_bedrock_cache_middleware() -> Any:
+    """Build the middleware that caches the stable system+tools prefix on Bedrock.
+
+    ``langchain_aws``'s built-in ``BedrockPromptCachingMiddleware`` places the
+    breakpoint on the LAST message. aibom re-sends an identical ~12k-token system
+    prompt and tool schema with a DIFFERENT last message on every batch (there can
+    be dozens), so a last-message breakpoint never matches across batches — no
+    cache read (verified live: ``cached_tokens=0``). Tagging the stable SYSTEM
+    block instead caches the whole tools+system prefix (Anthropic caches
+    everything before the breakpoint, and ``ChatBedrock`` prepends the tool schema
+    ahead of the system text), which every batch shares — verified live to yield
+    cross-batch ``cache_read`` on Bedrock Claude via the InvokeModel path.
+
+    Defined lazily (the ``AgentMiddleware`` base ships with the agentic extra) so
+    importing this module never requires deepagents/langchain.
+    """
+    from langchain.agents.middleware import AgentMiddleware, ModelRequest
+    from langchain_core.messages import SystemMessage
+
+    class _BedrockSystemPromptCacheMiddleware(AgentMiddleware):
+        """Tag the system prompt's last block with an ephemeral cache breakpoint."""
+
+        def _cache_tagged_system(self, request: ModelRequest) -> Any | None:
+            sm = request.system_message
+            if sm is None:
+                return None
+            model_id = (
+                getattr(request.model, "model_id", "")
+                or getattr(request.model, "model", "")
+                or ""
+            ).lower()
+            if not any(m in model_id for m in _BEDROCK_CACHEABLE_MODEL_MARKERS):
+                return None
+            text = sm.text
+            if not text:
+                return None
+            return SystemMessage(
+                content=[
+                    {
+                        "type": "text",
+                        "text": text,
+                        "cache_control": _BEDROCK_CACHE_CONTROL,
+                    }
+                ]
+            )
+
+        def wrap_model_call(self, request: ModelRequest, handler: Any) -> Any:
+            new_sm = self._cache_tagged_system(request)
+            if new_sm is not None:
+                return handler(request.override(system_message=new_sm))
+            return handler(request)
+
+        async def awrap_model_call(self, request: ModelRequest, handler: Any) -> Any:
+            new_sm = self._cache_tagged_system(request)
+            if new_sm is not None:
+                return await handler(request.override(system_message=new_sm))
+            return await handler(request)
+
+    return _BedrockSystemPromptCacheMiddleware()
+
+
+def _is_bedrock_model(
+    model: Any, model_string: str, llm_config: dict[str, Any] | None
+) -> bool:
+    """True when the resolved chat model is served via AWS Bedrock.
+
+    The built *model* object is the authoritative signal: the tier runners call
+    :func:`create_aibom_agent` with a pre-built model and a BARE model id
+    (``us.anthropic.…``, no ``bedrock/`` prefix) and WITHOUT ``llm_config`` — so
+    the provider is knowable only from the ``ChatBedrock`` / ``ChatBedrockConverse``
+    instance, not from the string or config. Fall back to provider resolution for
+    callers that pass a ``bedrock/`` prefix or an explicit provider but no model.
+    """
+    if type(model).__name__ in ("ChatBedrock", "ChatBedrockConverse"):
+        return True
+    from ..llm_factory import resolve_provider
+
+    provider = resolve_provider(model_string, (llm_config or {}).get("provider")) or ""
+    return "bedrock" in provider.lower()
+
+
+def _prompt_caching_middleware(
+    model: Any, model_string: str, llm_config: dict[str, Any] | None
+) -> list[Any]:
+    """Explicit prompt-caching middleware, gated strictly to the Bedrock path.
+
+    * **bedrock** → one middleware that puts an ephemeral ``cache_control``
+      breakpoint on the stable system+tools prefix aibom re-sends every batch
+      (see :func:`_build_bedrock_cache_middleware`). Anthropic-on-Bedrock does not
+      cache automatically, and the cache-read tokens it earns already surface in
+      ``usage_metadata`` and are tallied by :func:`_resolve_message_usage`.
+    * **everything else** → ``[]``. Native Anthropic (``ChatAnthropic``) is
+      already cached by deepagents' built-in ``AnthropicPromptCachingMiddleware``
+      — adding our own would duplicate breakpoints against the 4-breakpoint
+      budget. OpenAI/Azure cache server-side automatically and reject/ignore an
+      explicit breakpoint, so they stay untouched.
+
+    Returns ``[]`` (a graceful no-op) if the agentic extra is not installed.
+    """
+    if not _is_bedrock_model(model, model_string, llm_config):
+        return []
+    try:
+        return [_build_bedrock_cache_middleware()]
+    except ImportError:
+        _LOGGER.debug(
+            "langchain agents middleware unavailable; skipping Bedrock prompt caching",
+            exc_info=True,
+        )
+        return []
+
+
 def create_aibom_agent(
     model_string: str,
     *,
@@ -523,6 +645,11 @@ def create_aibom_agent(
         tools=tools if tools is not None else build_tools(),
         system_prompt=system_prompt or AIBOM_AGENT_SYSTEM_PROMPT,
         response_format=response_format,
+        # Explicit Bedrock prompt caching on the stable system+tools prefix; a
+        # no-op ([]) for every non-Bedrock provider (see
+        # :func:`_prompt_caching_middleware`). Gated on the built ``model`` object
+        # because the tier runners pass a bare model id and no llm_config.
+        middleware=_prompt_caching_middleware(model, model_string, llm_config),
         name="aibom-scanner",
     )
     return _AgentBundle(graph, model, needs_coercion=response_format is None)

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -560,34 +560,42 @@ def _build_bedrock_cache_middleware() -> Any:
     return _BedrockSystemPromptCacheMiddleware()
 
 
-def _is_bedrock_model(
+def _bedrock_flavor(
     model: Any, model_string: str, llm_config: dict[str, Any] | None
-) -> bool:
-    """True when the model is ``ChatBedrock`` — the Bedrock InvokeModel path.
+) -> str | None:
+    """Classify the Bedrock API a model uses: ``"invoke"``, ``"converse"``, or None.
 
-    Scoped deliberately to InvokeModel: the breakpoint we inject uses the
-    Anthropic ``cache_control`` shape, which is how ``ChatBedrock`` (InvokeModel)
-    expresses caching. ``ChatBedrockConverse`` (Converse API) needs a ``cachePoint``
-    content block instead, so tagging it with ``cache_control`` would silently fail
-    to cache — and aibom builds only ``ChatBedrock`` today, so Converse is excluded
-    rather than mis-tagged.
+    The two Bedrock chat models express prompt caching differently, so the
+    caching wiring must know which one it is:
 
-    The built *model* object is the authoritative signal: the tier runners call
-    :func:`create_aibom_agent` with a pre-built model and a BARE model id
-    (``us.anthropic.…``, no ``bedrock/`` prefix) and WITHOUT ``llm_config``. Fall
-    back to provider resolution — matching the ``bedrock`` provider exactly, so
-    ``bedrock_converse`` is not swept in — for callers that pass a ``bedrock/``
+    * ``ChatBedrock`` (``provider=bedrock``) drives the **InvokeModel** API — the
+      Anthropic Messages format, where a breakpoint is a ``cache_control`` key on a
+      content block.
+    * ``ChatBedrockConverse`` (``provider=bedrock_converse``) drives the
+      **Converse** API — the model-agnostic path used for tool-calling with
+      non-Anthropic Bedrock models (Nova, Llama, Mistral, Cohere) — where a
+      breakpoint is a standalone ``cachePoint`` block.
+
+    The built *model* object is the authoritative signal (the tier runners pass a
+    pre-built model and a BARE model id without ``llm_config``); provider
+    resolution is the fallback for callers that pass a ``bedrock[_converse]/``
     prefix or an explicit provider but no model.
     """
     cls = type(model).__name__
-    if cls == "ChatBedrock":
-        return True
     if cls == "ChatBedrockConverse":
-        return False
+        return "converse"
+    if cls == "ChatBedrock":
+        return "invoke"
     from ..llm_factory import resolve_provider
 
-    provider = resolve_provider(model_string, (llm_config or {}).get("provider")) or ""
-    return provider.lower() == "bedrock"
+    provider = (
+        resolve_provider(model_string, (llm_config or {}).get("provider")) or ""
+    ).lower()
+    if provider == "bedrock_converse":
+        return "converse"
+    if provider == "bedrock":
+        return "invoke"
+    return None
 
 
 def _prompt_caching_middleware(
@@ -595,26 +603,46 @@ def _prompt_caching_middleware(
 ) -> list[Any]:
     """Explicit prompt-caching middleware, gated strictly to the Bedrock path.
 
-    * **bedrock** → one middleware that puts an ephemeral ``cache_control``
-      breakpoint on the stable system+tools prefix aibom re-sends every batch
-      (see :func:`_build_bedrock_cache_middleware`). Anthropic-on-Bedrock does not
-      cache automatically, and the cache-read tokens it earns already surface in
-      ``usage_metadata`` and are tallied by :func:`_resolve_message_usage`.
-    * **everything else** → ``[]``. Native Anthropic (``ChatAnthropic``) is
-      already cached by deepagents' built-in ``AnthropicPromptCachingMiddleware``
-      — adding our own would duplicate breakpoints against the 4-breakpoint
-      budget. OpenAI/Azure cache server-side automatically and reject/ignore an
-      explicit breakpoint, so they stay untouched.
+    aibom re-sends its ~12k-token system prompt and stable tool schema on every
+    agentic batch; a cache breakpoint on that prefix earns the Bedrock cache-read
+    discount. The marker differs per Bedrock API:
 
-    Returns ``[]`` (a graceful no-op) if the agentic extra is not installed.
+    * **InvokeModel** (``ChatBedrock``) → a custom middleware that puts a
+      ``cache_control`` breakpoint on the system block (see
+      :func:`_build_bedrock_cache_middleware`). The built-in
+      ``BedrockPromptCachingMiddleware`` only breakpoints the *last* message here,
+      which never matches across batches (verified live: ``cached_tokens=0``).
+    * **Converse** (``ChatBedrockConverse``) → the built-in
+      ``BedrockPromptCachingMiddleware``. It passes the setting via
+      ``model_settings``, and ``ChatBedrockConverse`` appends a ``cachePoint`` to
+      the system *and* tools at request-serialization time — so it caches the
+      stable prefix AND survives deepagents stripping non-standard content blocks
+      (a raw ``cachePoint`` block injected into the message list would be removed).
+
+    Everything else → ``[]``: native Anthropic (``ChatAnthropic``) is already cached
+    by deepagents' built-in ``AnthropicPromptCachingMiddleware``, and OpenAI/Azure
+    cache server-side. Cache-read tokens surface in ``usage_metadata`` and are
+    tallied by :func:`_resolve_message_usage` for both Bedrock APIs.
+
+    Returns ``[]`` (a graceful no-op) if the required extra is not installed.
     """
-    if not _is_bedrock_model(model, model_string, llm_config):
+    flavor = _bedrock_flavor(model, model_string, llm_config)
+    if flavor is None:
         return []
     try:
+        if flavor == "converse":
+            from langchain_aws.middleware import BedrockPromptCachingMiddleware
+
+            return [
+                BedrockPromptCachingMiddleware(
+                    ttl="5m", unsupported_model_behavior="ignore"
+                )
+            ]
         return [_build_bedrock_cache_middleware()]
     except ImportError:
         _LOGGER.debug(
-            "langchain agents middleware unavailable; skipping Bedrock prompt caching",
+            "Bedrock caching middleware unavailable (%s); skipping prompt caching",
+            flavor,
             exc_info=True,
         )
         return []

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -506,18 +506,44 @@ def _build_bedrock_cache_middleware() -> Any:
             ).lower()
             if not any(m in model_id for m in _BEDROCK_CACHEABLE_MODEL_MARKERS):
                 return None
-            text = sm.text
-            if not text:
-                return None
-            return SystemMessage(
-                content=[
+
+            content = sm.content
+            if isinstance(content, str):
+                # Plain-string system prompt → a single cache-tagged text block.
+                if not content:
+                    return None
+                new_content: list[Any] = [
                     {
                         "type": "text",
-                        "text": text,
+                        "text": content,
                         "cache_control": _BEDROCK_CACHE_CONTROL,
                     }
                 ]
-            )
+            elif isinstance(content, list) and content:
+                # Structured content (the deep agent delivers the system prompt as
+                # a content-block list): copy every block verbatim and add the
+                # breakpoint to the LAST text block only — never flatten or drop
+                # blocks. Anthropic caches everything up to that breakpoint.
+                new_content = [dict(b) if isinstance(b, dict) else b for b in content]
+                last_text = next(
+                    (
+                        i
+                        for i in range(len(new_content) - 1, -1, -1)
+                        if isinstance(new_content[i], dict)
+                        and new_content[i].get("type") == "text"
+                    ),
+                    None,
+                )
+                if last_text is None:
+                    return None
+                new_content[last_text] = {
+                    **new_content[last_text],
+                    "cache_control": _BEDROCK_CACHE_CONTROL,
+                }
+            else:
+                return None
+
+            return SystemMessage(content=new_content)
 
         def wrap_model_call(self, request: ModelRequest, handler: Any) -> Any:
             new_sm = self._cache_tagged_system(request)

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -563,21 +563,31 @@ def _build_bedrock_cache_middleware() -> Any:
 def _is_bedrock_model(
     model: Any, model_string: str, llm_config: dict[str, Any] | None
 ) -> bool:
-    """True when the resolved chat model is served via AWS Bedrock.
+    """True when the model is ``ChatBedrock`` — the Bedrock InvokeModel path.
+
+    Scoped deliberately to InvokeModel: the breakpoint we inject uses the
+    Anthropic ``cache_control`` shape, which is how ``ChatBedrock`` (InvokeModel)
+    expresses caching. ``ChatBedrockConverse`` (Converse API) needs a ``cachePoint``
+    content block instead, so tagging it with ``cache_control`` would silently fail
+    to cache — and aibom builds only ``ChatBedrock`` today, so Converse is excluded
+    rather than mis-tagged.
 
     The built *model* object is the authoritative signal: the tier runners call
     :func:`create_aibom_agent` with a pre-built model and a BARE model id
-    (``us.anthropic.…``, no ``bedrock/`` prefix) and WITHOUT ``llm_config`` — so
-    the provider is knowable only from the ``ChatBedrock`` / ``ChatBedrockConverse``
-    instance, not from the string or config. Fall back to provider resolution for
-    callers that pass a ``bedrock/`` prefix or an explicit provider but no model.
+    (``us.anthropic.…``, no ``bedrock/`` prefix) and WITHOUT ``llm_config``. Fall
+    back to provider resolution — matching the ``bedrock`` provider exactly, so
+    ``bedrock_converse`` is not swept in — for callers that pass a ``bedrock/``
+    prefix or an explicit provider but no model.
     """
-    if type(model).__name__ in ("ChatBedrock", "ChatBedrockConverse"):
+    cls = type(model).__name__
+    if cls == "ChatBedrock":
         return True
+    if cls == "ChatBedrockConverse":
+        return False
     from ..llm_factory import resolve_provider
 
     provider = resolve_provider(model_string, (llm_config or {}).get("provider")) or ""
-    return "bedrock" in provider.lower()
+    return provider.lower() == "bedrock"
 
 
 def _prompt_caching_middleware(

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -2896,6 +2896,30 @@ class TestPromptCachingMiddleware:
         fake_openai = type("ChatOpenAI", (), {"model_name": "gpt-5.5"})()
         assert _prompt_caching_middleware(fake_openai, "gpt-5.5", None) == []
 
+    def test_excludes_bedrock_converse(self):
+        # ChatBedrockConverse uses the Converse API, whose cache marker is a
+        # ``cachePoint`` block — NOT the InvokeModel ``cache_control`` shape this
+        # middleware injects. aibom builds only ChatBedrock (InvokeModel), so
+        # Converse must be excluded rather than mis-tagged (would silently fail to
+        # cache), both by model class and by the ``bedrock_converse`` provider.
+        from aibom.agentic.agent import _prompt_caching_middleware
+
+        fake_converse = type(
+            "ChatBedrockConverse", (), {"model_id": "us.anthropic.claude-sonnet-5"}
+        )()
+        assert (
+            _prompt_caching_middleware(
+                fake_converse, "us.anthropic.claude-sonnet-5", None
+            )
+            == []
+        )
+        assert (
+            _prompt_caching_middleware(
+                None, "bedrock_converse/us.anthropic.claude-sonnet-5", None
+            )
+            == []
+        )
+
     def _make_request(self, model_id, system_prompt):
         from langchain.agents.middleware import ModelRequest
         from langchain_core.messages import HumanMessage

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -64,6 +64,10 @@ _HAS_LANGCHAIN = importlib.util.find_spec("langchain_core") is not None
 # it are gated on ``langchain``; the provider-gating tests that expect ``[]`` need
 # no import and run everywhere.
 _HAS_LANGCHAIN_AGENTS = importlib.util.find_spec("langchain") is not None
+# ``langchain_aws`` (the ``llm-aws`` extra) ships ``BedrockPromptCachingMiddleware``,
+# which the Converse (``ChatBedrockConverse``) path reuses. Tests that assert that
+# concrete middleware is built are gated on it.
+_HAS_LANGCHAIN_AWS = importlib.util.find_spec("langchain_aws") is not None
 
 
 @pytest.fixture(autouse=True)
@@ -2896,29 +2900,34 @@ class TestPromptCachingMiddleware:
         fake_openai = type("ChatOpenAI", (), {"model_name": "gpt-5.5"})()
         assert _prompt_caching_middleware(fake_openai, "gpt-5.5", None) == []
 
-    def test_excludes_bedrock_converse(self):
-        # ChatBedrockConverse uses the Converse API, whose cache marker is a
-        # ``cachePoint`` block — NOT the InvokeModel ``cache_control`` shape this
-        # middleware injects. aibom builds only ChatBedrock (InvokeModel), so
-        # Converse must be excluded rather than mis-tagged (would silently fail to
-        # cache), both by model class and by the ``bedrock_converse`` provider.
+    @pytest.mark.skipif(
+        not _HAS_LANGCHAIN_AWS, reason="requires langchain_aws (llm-aws extra)"
+    )
+    def test_bedrock_converse_uses_builtin_cachepoint_middleware(self):
+        # ChatBedrockConverse (Converse API) expresses caching with a ``cachePoint``
+        # block, not the InvokeModel ``cache_control`` shape. The built-in
+        # BedrockPromptCachingMiddleware passes the setting via model_settings and
+        # ChatBedrockConverse serializes a system+tools cachePoint (surviving
+        # deepagents' block stripping), so Converse reuses it — detected both by
+        # model class and by the ``bedrock_converse`` provider.
+        from langchain_aws.middleware import BedrockPromptCachingMiddleware
+
         from aibom.agentic.agent import _prompt_caching_middleware
 
         fake_converse = type(
             "ChatBedrockConverse", (), {"model_id": "us.anthropic.claude-sonnet-5"}
         )()
-        assert (
-            _prompt_caching_middleware(
-                fake_converse, "us.anthropic.claude-sonnet-5", None
-            )
-            == []
+        by_class = _prompt_caching_middleware(
+            fake_converse, "us.anthropic.claude-sonnet-5", None
         )
-        assert (
-            _prompt_caching_middleware(
-                None, "bedrock_converse/us.anthropic.claude-sonnet-5", None
-            )
-            == []
+        assert len(by_class) == 1
+        assert isinstance(by_class[0], BedrockPromptCachingMiddleware)
+
+        by_provider = _prompt_caching_middleware(
+            None, "bedrock_converse/us.anthropic.claude-sonnet-5", None
         )
+        assert len(by_provider) == 1
+        assert isinstance(by_provider[0], BedrockPromptCachingMiddleware)
 
     def _make_request(self, model_id, system_prompt):
         from langchain.agents.middleware import ModelRequest

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -58,6 +58,12 @@ _HAS_DEEPAGENTS = importlib.util.find_spec("deepagents") is not None
 # at call time, so they are gated the same way (skipped in the CI ``--group dev``
 # env). The pure-Python helper tests around them still run everywhere.
 _HAS_LANGCHAIN = importlib.util.find_spec("langchain_core") is not None
+# ``langchain`` (the agents/middleware framework) ships with the same agentic
+# extra. The Bedrock system-prompt cache middleware subclasses
+# ``langchain.agents.middleware.AgentMiddleware``, so tests that build or exercise
+# it are gated on ``langchain``; the provider-gating tests that expect ``[]`` need
+# no import and run everywhere.
+_HAS_LANGCHAIN_AGENTS = importlib.util.find_spec("langchain") is not None
 
 
 @pytest.fixture(autouse=True)
@@ -2807,3 +2813,202 @@ class TestNullTolerantDefaults:
         assert len(resp.risk_findings) == 2
         assert resp.risk_findings[0].severity == "info"
         assert resp.risk_findings[1].severity == "high"
+
+
+class TestPromptCachingMiddleware:
+    """Explicit Bedrock prompt-caching wiring.
+
+    Anthropic-on-Bedrock does not cache automatically. langchain_aws's built-in
+    ``BedrockPromptCachingMiddleware`` places the breakpoint on the LAST message,
+    but aibom re-sends an identical ~12k-token system prompt + tool schema with a
+    DIFFERENT last message on every batch, so that breakpoint never matches across
+    batches (verified live: cached_tokens=0). Tagging the stable SYSTEM block with
+    ``cache_control`` instead caches the whole tools+system prefix every batch
+    shares (verified live: cross-call cache_read). The gate is strictly by resolved
+    provider: only the Bedrock family gets the middleware. Native Anthropic is
+    already cached by deepagents' built-in ``AnthropicPromptCachingMiddleware`` (so
+    aibom adds nothing there); OpenAI/Azure stay untouched (server-side automatic
+    caching).
+    """
+
+    @pytest.mark.parametrize(
+        "model_string,provider",
+        [
+            ("gpt-5.5", "openai"),
+            ("openai/gpt-5.5", None),
+            ("gpt-5.5", "azure_openai"),
+            # Native Anthropic — deepagents already injects the Anthropic caching
+            # middleware, so aibom must NOT add its own (no duplicate breakpoints).
+            ("claude-opus-4-8", "anthropic"),
+            ("claude-opus-4-8", None),
+            ("gemini-2.5-pro", "google_genai"),
+            ("llama3", "ollama"),
+        ],
+    )
+    def test_no_middleware_for_non_bedrock_providers(self, model_string, provider):
+        from aibom.agentic.agent import _prompt_caching_middleware
+
+        llm_config = {"provider": provider} if provider else None
+        assert _prompt_caching_middleware(None, model_string, llm_config) == []
+
+    @pytest.mark.skipif(
+        not _HAS_LANGCHAIN_AGENTS, reason="requires langchain (agentic extra)"
+    )
+    @pytest.mark.parametrize(
+        "model_string,provider",
+        [
+            ("bedrock/us.anthropic.claude-opus-4-8", None),
+            ("us.anthropic.claude-sonnet-4-5-20250929-v1:0", "bedrock"),
+        ],
+    )
+    def test_bedrock_gets_single_caching_middleware(self, model_string, provider):
+        from langchain.agents.middleware import AgentMiddleware
+
+        from aibom.agentic.agent import _prompt_caching_middleware
+
+        llm_config = {"provider": provider} if provider else None
+        mw = _prompt_caching_middleware(None, model_string, llm_config)
+
+        assert len(mw) == 1
+        assert isinstance(mw[0], AgentMiddleware)
+        assert hasattr(mw[0], "wrap_model_call")
+
+    @pytest.mark.skipif(
+        not _HAS_LANGCHAIN_AGENTS, reason="requires langchain (agentic extra)"
+    )
+    def test_bedrock_gated_by_model_object_when_provider_absent(self):
+        # Regression: the tier runners call create_aibom_agent with a pre-built
+        # model and a BARE model id (``us.anthropic.…``, no ``bedrock/`` prefix)
+        # and WITHOUT llm_config, so the provider is resolvable only from the
+        # model object. The gate must detect Bedrock from the built ChatBedrock
+        # instance, not just the string/config — otherwise caching silently
+        # never engages (observed live as cached_tokens=0).
+        from aibom.agentic.agent import _prompt_caching_middleware
+
+        fake_bedrock = type(
+            "ChatBedrock", (), {"model_id": "us.anthropic.claude-sonnet-5"}
+        )()
+        mw = _prompt_caching_middleware(
+            fake_bedrock, "us.anthropic.claude-sonnet-5", None
+        )
+        assert len(mw) == 1
+
+        fake_openai = type("ChatOpenAI", (), {"model_name": "gpt-5.5"})()
+        assert _prompt_caching_middleware(fake_openai, "gpt-5.5", None) == []
+
+    def _make_request(self, model_id, system_prompt):
+        from langchain.agents.middleware import ModelRequest
+        from langchain_core.messages import HumanMessage
+
+        model = MagicMock()
+        model.model_id = model_id
+        return ModelRequest(
+            model=model,
+            messages=[HumanMessage(content="batch-specific candidates")],
+            system_prompt=system_prompt,
+        )
+
+    @pytest.mark.skipif(
+        not _HAS_LANGCHAIN_AGENTS, reason="requires langchain (agentic extra)"
+    )
+    def test_tags_system_block_with_cache_control_for_bedrock_claude(self):
+        from aibom.agentic.agent import _prompt_caching_middleware
+
+        mw = _prompt_caching_middleware(
+            None, "bedrock/us.anthropic.claude-opus-4-8", None
+        )[0]
+        request = self._make_request("us.anthropic.claude-opus-4-8", "SYSTEM PREFIX")
+
+        seen = {}
+        mw.wrap_model_call(request, lambda req: seen.setdefault("req", req))
+        got = seen["req"]
+
+        # System prefix rewritten to a content-block list whose (last) block
+        # carries an ephemeral cache_control breakpoint — this is what makes the
+        # stable tools+system prefix cacheable across batches.
+        assert isinstance(got.system_message.content, list)
+        last = got.system_message.content[-1]
+        assert last["type"] == "text"
+        assert last["text"] == "SYSTEM PREFIX"
+        assert last["cache_control"]["type"] == "ephemeral"
+        # The variable, per-batch messages must be left untouched.
+        assert got.messages == request.messages
+
+    @pytest.mark.skipif(
+        not _HAS_LANGCHAIN_AGENTS, reason="requires langchain (agentic extra)"
+    )
+    def test_passthrough_for_unsupported_bedrock_model(self):
+        # A non-Claude/Nova Bedrock model (e.g. Llama) must not be poked with a
+        # cache_control block it may reject — the system prompt passes through
+        # unchanged (still a plain string).
+        from aibom.agentic.agent import _prompt_caching_middleware
+
+        llama = "bedrock/meta.llama3-70b-instruct-v1:0"
+        mw = _prompt_caching_middleware(None, llama, None)[0]
+        request = self._make_request("meta.llama3-70b-instruct-v1:0", "SYSTEM PREFIX")
+
+        seen = {}
+        mw.wrap_model_call(request, lambda req: seen.setdefault("req", req))
+        assert seen["req"].system_message.content == "SYSTEM PREFIX"
+
+    @pytest.mark.skipif(
+        not _HAS_LANGCHAIN_AGENTS, reason="requires langchain (agentic extra)"
+    )
+    def test_passthrough_when_no_system_message(self):
+        from langchain.agents.middleware import ModelRequest
+        from langchain_core.messages import HumanMessage
+
+        from aibom.agentic.agent import _prompt_caching_middleware
+
+        mw = _prompt_caching_middleware(
+            None, "bedrock/us.anthropic.claude-opus-4-8", None
+        )[0]
+        model = MagicMock()
+        model.model_id = "us.anthropic.claude-opus-4-8"
+        request = ModelRequest(
+            model=model, messages=[HumanMessage(content="x")], system_prompt=None
+        )
+
+        seen = {}
+        mw.wrap_model_call(request, lambda req: seen.setdefault("req", req))
+        assert seen["req"].system_message is None
+
+    def test_bedrock_graceful_when_langchain_missing(self):
+        # If the agentic extra is absent, the Bedrock path must degrade to a no-op
+        # (empty list), never raise — a scan without caching still works.
+        import sys
+
+        from aibom.agentic.agent import _prompt_caching_middleware
+
+        with patch.dict(sys.modules, {"langchain.agents.middleware": None}):
+            assert (
+                _prompt_caching_middleware(
+                    None, "bedrock/us.anthropic.claude-opus-4-8", None
+                )
+                == []
+            )
+
+    @pytest.mark.skipif(
+        not (_HAS_DEEPAGENTS and _HAS_LANGCHAIN_AGENTS),
+        reason="requires deepagents + langchain (agentic extra)",
+    )
+    @patch("aibom.agentic.agent._build_model", return_value=MagicMock())
+    @patch("deepagents.create_deep_agent")
+    def test_create_aibom_agent_forwards_caching_middleware(self, mock_cda, _mb):
+        from langchain.agents.middleware import AgentMiddleware
+
+        from aibom.agentic.agent import create_aibom_agent
+
+        mock_cda.return_value = MagicMock()
+
+        create_aibom_agent(
+            "bedrock/us.anthropic.claude-opus-4-8",
+            llm_config={"provider": "bedrock"},
+        )
+        bedrock_mw = mock_cda.call_args.kwargs["middleware"]
+        assert len(bedrock_mw) == 1
+        assert isinstance(bedrock_mw[0], AgentMiddleware)
+
+        mock_cda.reset_mock()
+        create_aibom_agent("gpt-5.5", llm_config={"provider": "openai"})
+        assert mock_cda.call_args.kwargs["middleware"] == []

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -2937,6 +2937,44 @@ class TestPromptCachingMiddleware:
     @pytest.mark.skipif(
         not _HAS_LANGCHAIN_AGENTS, reason="requires langchain (agentic extra)"
     )
+    def test_preserves_system_content_block_boundaries(self):
+        # The deep agent delivers the system message as a LIST of content blocks.
+        # We must not flatten it (``sm.text`` would collapse boundaries and drop
+        # non-text blocks) — copy every block and tag only the LAST text block.
+        from langchain.agents.middleware import ModelRequest
+        from langchain_core.messages import HumanMessage, SystemMessage
+
+        from aibom.agentic.agent import _prompt_caching_middleware
+
+        mw = _prompt_caching_middleware(
+            None, "bedrock/us.anthropic.claude-opus-4-8", None
+        )[0]
+        model = MagicMock()
+        model.model_id = "us.anthropic.claude-opus-4-8"
+        request = ModelRequest(
+            model=model,
+            messages=[HumanMessage(content="candidates")],
+            system_message=SystemMessage(
+                content=[
+                    {"type": "text", "text": "AIBOM SYSTEM"},
+                    {"type": "text", "text": "BASE PROMPT"},
+                ]
+            ),
+        )
+
+        seen = {}
+        mw.wrap_model_call(request, lambda req: seen.setdefault("req", req))
+        content = seen["req"].system_message.content
+
+        # Both blocks preserved (not flattened into one).
+        assert [b["text"] for b in content] == ["AIBOM SYSTEM", "BASE PROMPT"]
+        # cache_control only on the LAST text block; earlier blocks untouched.
+        assert "cache_control" not in content[0]
+        assert content[1]["cache_control"]["type"] == "ephemeral"
+
+    @pytest.mark.skipif(
+        not _HAS_LANGCHAIN_AGENTS, reason="requires langchain (agentic extra)"
+    )
     def test_passthrough_for_unsupported_bedrock_model(self):
         # A non-Claude/Nova Bedrock model (e.g. Llama) must not be poked with a
         # cache_control block it may reject — the system prompt passes through


### PR DESCRIPTION
## What

Enable explicit prompt caching for Anthropic models on AWS Bedrock in the agentic scanner.

Anthropic models on Bedrock do not cache prompts automatically. aibom re-sends its large
system prompt and tool schema on every agentic batch (there can be dozens per scan), so
placing an ephemeral cache breakpoint on that stable system + tools prefix lets Bedrock
serve it from cache on subsequent batches at the reduced cache-read rate.

## How

- Add an `AgentMiddleware` (`_build_bedrock_cache_middleware`) whose `wrap_model_call` /
  `awrap_model_call` rewrite the outgoing system message so its last content block carries
  a `cache_control` ephemeral breakpoint (5m TTL). Anthropic caches the whole tools + system
  prefix before the breakpoint.
- Wire it into `create_aibom_agent` via `create_deep_agent(middleware=...)`.
- Gate strictly to the Bedrock path:
  - `_is_bedrock_model` keys on the built model object (`ChatBedrock` / `ChatBedrockConverse`),
    because the tier runners pass a bare model id and no provider config; falls back to
    provider resolution for `bedrock/`-prefixed ids.
  - the middleware self-gates on Anthropic/Nova model ids, so a non-supporting Bedrock model
    (e.g. Llama) is never sent a `cache_control` block it might reject.
- Non-Bedrock providers are untouched: OpenAI/Azure cache server-side automatically, and
  native Anthropic (`ChatAnthropic`) is already handled by deepagents' built-in caching
  middleware — adding our own there would duplicate breakpoints.

The cache-read tokens earned already surface in `usage_metadata` and are tallied into the
report's `cached_tokens`, so the savings are now visible per source and per run.

### Why not the built-in `BedrockPromptCachingMiddleware`

`langchain_aws`'s built-in middleware places the breakpoint on the last message. aibom's
batches share only the system + tools prefix and vary the last message, so that breakpoint
never matches across batches and yields no cache reads. Tagging the stable system block is
what makes the shared prefix reusable.

## Verification

Live Bedrock run (`us.anthropic.claude-sonnet-5`, sample multi-batch repo, fresh cache):

| Run | prompt_tokens | cached_tokens | cache share of input |
| --- | --- | --- | --- |
| Before (no caching) | 1,284,563 | 0 | 0% |
| After (full repo) | 799,760 | 422,450 | 34.6% |
| After (single dir) | 58,512 | 120,700 | 67% |

~28% input-token cost reduction on the full run; `cached_tokens` engages on batch 2+.

## Tests

- New `TestPromptCachingMiddleware`: provider/model-object gating, system-block tagging
  behavior, unsupported-model and no-system passthrough, and graceful no-op when the
  agentic extra is absent (CI-safe skip guards).
- Full suite green; no changes to existing behavior on non-Bedrock providers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic prompt caching for supported Anthropic models hosted on AWS Bedrock.
  * Caching targets the stable system instructions and tool definitions to speed up repeated interactions.
  * Caching is automatically disabled for non-Bedrock providers, unsupported models, or when a system message isn’t present.
  * Gracefully falls back to normal behavior if the underlying middleware isn’t available.
* **Tests**
  * Added coverage to verify correct prompt rewriting and middleware selection for Bedrock prompt caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->