### PR TITLE
chore: prepare 1.0.7 release

### DIFF
--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-aibom"
-version = "1.0.6"
+version = "1.0.7"
 description = "A tool to generate an AI BOM from source code."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/aibom/src/aibom/manifest.json
+++ b/aibom/src/aibom/manifest.json
@@ -1,8 +1,8 @@
 {
-  "analyzer_version": "1.0.6",
-  "schema_version": "1.0.6",
+  "analyzer_version": "1.0.7",
+  "schema_version": "1.0.7",
   "duckdb_sha256": "b1165384a646094aa6a4762d676f285c1c68b6d7f9367c90a129b529904a3268",
-  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.6.duckdb",
+  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.7.duckdb",
   "upload_mode": "direct",
   "max_direct_upload_mb": 25,
   "log_level": "INFO"

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "cisco-aibom"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Patch release capturing changes merged since 1.0.6.

## Included changes
- feat(agentic): cache the Bedrock system prompt to cut re-sent input tokens (#62)
- feat: stamp a shared co-scan batch id across per-source uploads (#61)
- feat: multi-source correlation for mixed repo + image scans (#60)

## Version bump
- `pyproject.toml` / `uv.lock`: 1.0.6 → 1.0.7
- `manifest.json`: `analyzer_version` / `schema_version` → 1.0.7, `duckdb_file` → `aibom_catalog-1.0.7.duckdb`
  - Catalog content unchanged; `duckdb_sha256` identical.

## Verification
- `uv lock --check` clean
- `uv run pytest`: 2029 passed, 21 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package release to version 1.0.7.
  - Updated bundled metadata and schema version information to match the new release.
  - Updated the referenced catalog file for version 1.0.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->