### PR TITLE
refactor(catalog): drop client-side parameter label workaround; keep stale-KB guard

### DIFF
--- a/aibom/src/aibom/catalog_db.py
+++ b/aibom/src/aibom/catalog_db.py
@@ -23,8 +23,6 @@ LOGGER = logging.getLogger(__name__)
 
 _CATALOG_COLS = "id, label, concept, framework, sig_name, type, catalog_label"
 
-_LABEL_BLOCKLIST: tuple[str, ...] = ("parameter",)
-
 
 def is_excluded(name: str, patterns: List[str]) -> bool:
     """Return True if *name* suffix-matches or equals any pattern in *patterns*."""
@@ -85,25 +83,25 @@ class CatalogDB:
 
         If the catalog already ships a pre-built
         ``component_catalog_last_seg`` table (new KBs), use it directly but
-        join against ``kb.component_catalog`` so we can filter out low-signal
-        ``label`` rows (currently ``parameter``) that pollute the suffix
-        index.  Otherwise build a temporary table from
-        ``kb.component_catalog`` with the blocklist applied.
+        join against ``kb.component_catalog`` so stale ``label='parameter'``
+        rows (only present in pre-M1 KBs) are ignored and never pollute the
+        suffix index.  Otherwise build a temporary table from
+        ``kb.component_catalog`` with the same guard applied.
 
         Returns the qualified table name to use in queries.
         """
         if self._token_table is not None:
             return self._token_table
 
-        label_filter_sql = self._label_filter_sql("cc")
-        build_filter_sql = self._label_filter_sql()
+        label_filter_sql = self._ignore_stale_parameter_sql("cc")
+        build_filter_sql = self._ignore_stale_parameter_sql()
 
         try:
             self._connection.execute(
                 "SELECT 1 FROM kb.component_catalog_last_seg LIMIT 1"
             )
             LOGGER.debug(
-                "Pre-built token table found; filtering blocklisted labels in temp view"
+                "Pre-built token table found; ignoring stale parameter rows in temp view"
             )
             self._connection.execute(
                 "CREATE TEMP TABLE _last_seg AS "
@@ -126,17 +124,18 @@ class CatalogDB:
         return self._token_table
 
     @staticmethod
-    def _label_filter_sql(alias: str = "") -> str:
-        """SQL fragment rejecting rows whose ``label`` is in the blocklist.
+    def _ignore_stale_parameter_sql(alias: str = "") -> str:
+        """SQL fragment that ignores stale ``label='parameter'`` rows.
 
-        Applying this filter at query time (rather than post-processing
-        Python-side) keeps the hot path off 1M+ parameter rows that never
-        represent top-level AI components and are a major source of
-        false positives during suffix matching.
+        The server-side KB pipeline now strips parameter rows at build time, so
+        a current KB never contains them and this guard is a no-op there. It is
+        retained purely as a defensive fallback: if a stale KB that still
+        carries parameter rows is loaded, those rows are silently ignored so
+        scan output matches a current KB. Parameter rows are never top-level AI
+        components and were a source of suffix-match false positives.
         """
         col = f"{alias}.label" if alias else "label"
-        literals = ",".join(f"'{lbl}'" for lbl in _LABEL_BLOCKLIST)
-        return f"COALESCE({col}, '') NOT IN ({literals})"
+        return f"COALESCE({col}, '') <> 'parameter'"
 
     # ------------------------------------------------------------------
     # Public API
@@ -217,7 +216,7 @@ class CatalogDB:
         if not concepts:
             return []
         placeholders = ",".join("?" for _ in concepts)
-        label_filter = self._label_filter_sql()
+        label_filter = self._ignore_stale_parameter_sql()
         query = f"""
             SELECT DISTINCT id FROM component_catalog
             WHERE id LIKE ? AND LOWER(concept) IN ({placeholders})
@@ -228,7 +227,8 @@ class CatalogDB:
         return [r[0] for r in rows]
 
     def find_components_by_suffixes(
-        self, suffixes: Sequence[str],
+        self,
+        suffixes: Sequence[str],
     ) -> List[Dict[str, Any]]:
         """Return catalog entries whose IDs match any of the provided suffixes.
 
@@ -256,7 +256,7 @@ class CatalogDB:
                 tokens.add(s)
 
         matched_ids: set[str] = set()
-        label_filter = self._label_filter_sql()
+        label_filter = self._ignore_stale_parameter_sql()
 
         if full_paths:
             rows = self._connection.execute(
@@ -300,9 +300,7 @@ class CatalogDB:
                     seen_ids.add(entry_id)
 
         if self._excludes:
-            db_results = [
-                r for r in db_results if not self._is_excluded(r["id"])
-            ]
+            db_results = [r for r in db_results if not self._is_excluded(r["id"])]
 
         return db_results
 

--- a/aibom/tests/test_catalog_db.py
+++ b/aibom/tests/test_catalog_db.py
@@ -365,3 +365,17 @@ def test_find_ids_by_path_and_concept_ignores_parameter_rows():
 
         assert "pkg.Agent" in ids
         assert "pkg.Agent.name" not in ids
+
+
+def test_stale_parameter_ignored_full_path_branch():
+    """A full dotted suffix exercises the ``id IN (...)`` branch, which applies
+    the guard directly against kb.component_catalog (not the token table)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_file = Path(tmpdir) / "catalog.duckdb"
+        _create_catalog_with_parameter_rows(db_file)
+
+        with CatalogDB(db_file) as connector:
+            results = connector.find_components_by_suffixes(["pkg.Tool.run.query"])
+
+        ids = {row["id"] for row in results}
+        assert "pkg.Tool.run.query" not in ids

--- a/aibom/tests/test_catalog_db.py
+++ b/aibom/tests/test_catalog_db.py
@@ -95,17 +95,19 @@ def test_two_tier_precedence_duckdb_over_custom():
         _create_catalog(db_file)
 
         with CatalogDB(db_file) as connector:
-            connector.add_custom_entries([
-                {
-                    "id": "pkg.Agent",
-                    "label": "Agent",
-                    "concept": "tool",
-                    "framework": "custom",
-                    "sig_name": None,
-                    "type": None,
-                    "catalog_label": None,
-                }
-            ])
+            connector.add_custom_entries(
+                [
+                    {
+                        "id": "pkg.Agent",
+                        "label": "Agent",
+                        "concept": "tool",
+                        "framework": "custom",
+                        "sig_name": None,
+                        "type": None,
+                        "catalog_label": None,
+                    }
+                ]
+            )
             results = connector.find_components_by_suffixes(["Agent"])
 
         agent_results = [r for r in results if r["id"] == "pkg.Agent"]
@@ -120,17 +122,19 @@ def test_custom_entries_added_when_not_in_duckdb():
         _create_catalog(db_file)
 
         with CatalogDB(db_file) as connector:
-            connector.add_custom_entries([
-                {
-                    "id": "custom.MyModel",
-                    "label": "MyModel",
-                    "concept": "model",
-                    "framework": "custom",
-                    "sig_name": None,
-                    "type": None,
-                    "catalog_label": None,
-                }
-            ])
+            connector.add_custom_entries(
+                [
+                    {
+                        "id": "custom.MyModel",
+                        "label": "MyModel",
+                        "concept": "model",
+                        "framework": "custom",
+                        "sig_name": None,
+                        "type": None,
+                        "catalog_label": None,
+                    }
+                ]
+            )
             results = connector.find_components_by_suffixes(["MyModel"])
 
         ids = {row["id"] for row in results}
@@ -203,10 +207,17 @@ def test_large_suffix_list():
         )
         entries = []
         for i in range(500):
-            entries.append((
-                f"fw.mod{i}.Class{i}", f"Class{i}", "model",
-                "fw", None, "class", None,
-            ))
+            entries.append(
+                (
+                    f"fw.mod{i}.Class{i}",
+                    f"Class{i}",
+                    "model",
+                    "fw",
+                    None,
+                    "class",
+                    None,
+                )
+            )
         con.executemany(
             "INSERT INTO component_catalog VALUES (?, ?, ?, ?, ?, ?, ?)",
             entries,
@@ -242,3 +253,115 @@ def test_find_ids_by_path_and_concept():
             ids = connector.find_ids_by_path_and_concept("pkg", ["agent"])
 
         assert "pkg.Agent" in ids
+
+
+# ── Stale-KB parameter guard ──────────────────────────────────────────
+#
+# The server-side KB pipeline now strips ``label='parameter'`` rows at build
+# time, so the CLI no longer carries a blocklist. A defensive guard remains so
+# that a stale (pre-strip) KB still produces identical scan output: parameter
+# rows are silently ignored.
+
+
+def _create_catalog_with_parameter_rows(
+    path: Path, *, with_token_table: bool = True
+) -> None:
+    """Build a test catalog that also carries stale ``label='parameter'`` rows."""
+    con = duckdb.connect(str(path))
+    con.execute(
+        """
+        CREATE TABLE component_catalog (
+            id TEXT PRIMARY KEY,
+            label TEXT,
+            concept TEXT,
+            framework TEXT,
+            sig_name TEXT,
+            type TEXT,
+            catalog_label TEXT
+        );
+        """
+    )
+    con.execute(
+        """
+        INSERT INTO component_catalog
+        VALUES
+            ('pkg.Agent', 'class', 'agent', 'pkg', 'Agent', 'class', 'Agent'),
+            ('pkg.Tool.run', 'method', 'tool', 'pkg', 'Tool.run', 'method', 'ToolRun'),
+            ('other.Unused', 'class', NULL, 'other', 'Unused', 'class', 'Unused'),
+            ('pkg.Tool.run.query', 'parameter', 'tool', 'pkg', 'query', 'str', NULL),
+            ('pkg.Agent.name', 'parameter', 'agent', 'pkg', 'name', 'str', NULL);
+        """
+    )
+    if with_token_table:
+        con.execute(
+            """
+            CREATE TABLE component_catalog_last_seg AS
+            SELECT id, split_part(id, '.', -1) AS last_seg
+            FROM component_catalog;
+            """
+        )
+    con.close()
+
+
+def test_stale_parameter_rows_ignored_new_kb():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_file = Path(tmpdir) / "catalog.duckdb"
+        _create_catalog_with_parameter_rows(db_file)
+
+        with CatalogDB(db_file) as connector:
+            results = connector.find_components_by_suffixes(
+                ["Agent", "Tool.run", "query", "name"]
+            )
+
+        ids = {row["id"] for row in results}
+        assert "pkg.Agent" in ids
+        assert "pkg.Tool.run" in ids
+        assert "pkg.Tool.run.query" not in ids
+        assert "pkg.Agent.name" not in ids
+        assert all(row["label"] != "parameter" for row in results)
+
+
+def test_stale_parameter_rows_ignored_old_kb():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_file = Path(tmpdir) / "catalog.duckdb"
+        _create_catalog_with_parameter_rows(db_file, with_token_table=False)
+
+        with CatalogDB(db_file) as connector:
+            results = connector.find_components_by_suffixes(["Agent", "query"])
+
+        ids = {row["id"] for row in results}
+        assert "pkg.Agent" in ids
+        assert "pkg.Tool.run.query" not in ids
+
+
+def test_stale_kb_output_identical_to_clean_kb():
+    """A stale KB (with parameter rows) yields the same results as a clean KB."""
+    suffixes = ["Agent", "Tool.run", "query", "name"]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        clean_file = Path(tmpdir) / "clean.duckdb"
+        stale_file = Path(tmpdir) / "stale.duckdb"
+        _create_catalog(clean_file)
+        _create_catalog_with_parameter_rows(stale_file)
+
+        with CatalogDB(clean_file) as clean:
+            clean_ids = {
+                row["id"] for row in clean.find_components_by_suffixes(suffixes)
+            }
+        with CatalogDB(stale_file) as stale:
+            stale_ids = {
+                row["id"] for row in stale.find_components_by_suffixes(suffixes)
+            }
+
+        assert clean_ids == stale_ids
+
+
+def test_find_ids_by_path_and_concept_ignores_parameter_rows():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_file = Path(tmpdir) / "catalog.duckdb"
+        _create_catalog_with_parameter_rows(db_file)
+
+        with CatalogDB(db_file) as connector:
+            ids = connector.find_ids_by_path_and_concept("pkg", ["agent"])
+
+        assert "pkg.Agent" in ids
+        assert "pkg.Agent.name" not in ids


### PR DESCRIPTION
## What

The prebuilt knowledge base ships a row for every documented API symbol, including one per function/method **parameter** — over a million low-signal rows that never represent a top-level AI component and cause suffix-match false positives. The CLI has been hiding them at query time with a client-side blocklist (`_LABEL_BLOCKLIST = ("parameter",)`), injected into every catalog query.

The server-side KB build now strips those parameter rows at build time, so the client-side workaround is no longer needed. This PR removes it.

## Changes

- Remove the `_LABEL_BLOCKLIST` constant and the generic label filter it fed in `catalog_db.py`.
- Keep a **minimal defensive guard** (`_ignore_stale_parameter_sql`): if a stale KB that still carries `label='parameter'` rows is loaded, those rows are silently ignored, so scan output is identical to a current KB. This is a no-op against a current KB.

## Why keep a guard rather than delete outright

A current KB has no parameter rows, so the guard does nothing there. But a user pinned to an older KB bundle could still have them; without the guard those rows would leak into results as false positives. The guard keeps behavior identical across old and new KBs while removing the config-style blocklist mechanism.

## Testing

Added stale-KB coverage to `tests/test_catalog_db.py`:

- parameter rows are ignored on the new-KB (pre-built token table) path,
- and on the old-KB fallback path,
- `find_ids_by_path_and_concept` ignores them,
- and a stale KB (with parameter rows) yields results **identical** to a clean KB.

`black` clean; full suite green (**2054 passed**).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component catalog searches by ignoring stale parameter entries.
  * Ensured consistent search results across catalogs with and without token tables.
  * Prevented outdated parameter rows from affecting component lookup and filtering.

* **Tests**
  * Added coverage for stale catalog data across multiple search scenarios.
  * Verified that results match between clean catalogs and catalogs containing stale parameter entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->