### PR TITLE
docs: add AI-agent contributor rules (CLAUDE.md + .claude/rules)

### DIFF
--- a/.claude/rules/oss-contributions.md
+++ b/.claude/rules/oss-contributions.md
@@ -1,0 +1,50 @@
+---
+description: Conventions for contributing to the public cisco-ai-defense/aibom repository
+---
+
+# Contributing to this public repository
+
+`cisco-ai-defense/aibom` is a **public, Apache-2.0-licensed** project. Everything committed
+here is world-readable. Apply these rules to every commit, code change, test, and pull
+request.
+
+## Commit messages
+
+- Use **Conventional Commits**: `feat`, `fix`, `docs`, `chore`, `test`, optionally scoped
+  (e.g. `feat(agentic): …`), matching the existing `main` history.
+- Reference work by **pull-request number**. Do not reference internal issue trackers.
+- Do **not** add AI-attribution trailers such as `Co-Authored-By: <AI tool>` or
+  "Generated with …" lines.
+
+## Keep the repository public-clean
+
+Because this repository is public, never include internal-only identifiers or details
+anywhere they would ship — commit messages, code, comments, docstrings, user-facing strings
+(CLI help, log messages), test names, or pull-request titles and descriptions. This includes:
+
+- **Internal issue identifiers and tracking systems.** Some PRs from Cisco contributors
+  originate from issues or enhancements tracked in Cisco-internal systems. Keep those
+  internal references out of the repository and track intent by PR number instead.
+- **Internal infrastructure details** — cloud project or account identifiers, private
+  endpoints or deployment names, internal hostnames.
+- **Secrets** — credentials, API keys, or tokens of any kind.
+- **Internal-only anecdotes or figures** — generalize them if they add value publicly.
+
+The scrub applies to **code, comments, docstrings, user-facing strings, and tests** — not
+just commit messages. Before committing, review the diff *and* the message for anything in
+the list above.
+
+## Tests
+
+- Use **synthetic fixtures only**. Never commit real data, credentials, or live endpoints.
+
+## Licensing
+
+- New source files carry the **Apache-2.0 license header**, matching the sibling files in
+  the same directory.
+
+## Formatting
+
+- The code base is **Black-formatted** with an 88-column target. There is no lint or format
+  gate in CI, so keep new and modified code lines within the limit by hand and match the
+  surrounding style.

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,8 @@ node_modules
 
 # Benchmark cloned repos
 aibom/benchmarks/_repos/
+
+# Claude Code personal config #
+###############################
+.claude/settings.local.json
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# Contributor guidance for AI coding agents
+
+`cisco-ai-defense/aibom` is a **public, Apache-2.0-licensed** project. This file gives AI
+coding agents (Claude Code and others) — and their humans — the conventions to follow when
+proposing changes here. Everything committed to this repository is world-readable, so keep
+it clean of anything internal.
+
+Detailed rules live in [`.claude/rules/`](.claude/rules/) and load automatically alongside
+this file.
+
+## Summary
+
+- **Conventional commits** — `feat` / `fix` / `docs` / `chore` / `test`, with an optional
+  scope (e.g. `feat(agentic): …`), matching `main`'s history. Reference work by pull-request
+  number.
+- **Keep the repository public-clean** — no internal-only identifiers of any kind in commit
+  messages, code, comments, docstrings, user-facing strings, tests, or PR text. Some PRs
+  from Cisco contributors originate from issues or enhancements tracked in Cisco-internal
+  systems; keep those internal references out of this repository and link work by PR number
+  instead.
+- **No AI-attribution trailers** — don't add "Generated with …" lines or `Co-Authored-By`
+  trailers for AI tools.
+- **Synthetic test fixtures only** — never commit real data, credentials, or live endpoints.
+- **Apache-2.0 license headers** on new source files, matching sibling files.
+- **Formatting** — the code base is Black-formatted with an 88-column target. There is no
+  lint/format gate in CI, so keep new code within the limit by hand and match the
+  surrounding style.
+
+See [`.claude/rules/oss-contributions.md`](.claude/rules/oss-contributions.md) for the full
+detail, and [`CONTRIBUTING.md`](CONTRIBUTING.md) for the human-facing contribution guide.


### PR DESCRIPTION
## What

Adds contributor guidance for AI coding agents (Claude Code and others) working in this repository:

- **`CLAUDE.md`** — a short summary at the repo root, auto-loaded by Claude Code for anyone working in the repo.
- **`.claude/rules/oss-contributions.md`** — the full ruleset; every `.md` under `.claude/rules/` is also auto-loaded.
- **`.gitignore`** — ignore personal Claude config so it isn't committed by mistake (`.claude/settings.local.json`, `CLAUDE.local.md`).

## Why

This is a public, Apache-2.0 project. Codifying the conventions we already follow makes them discoverable to contributors and to the AI agents that assist them:

- Conventional Commits, referencing work by PR number.
- Keeping the repository free of internal-only identifiers (issue references, infra details, secrets) in code, comments, docstrings, user-facing strings, tests, and PR text.
- Synthetic-only test fixtures.
- Apache-2.0 license headers on new source files.
- Black formatting with an 88-column target.

## Notes

- Docs and config only — no behavior or code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance covering commit conventions, licensing, formatting, test data, and repository cleanliness.
  * Added dedicated contribution rules for consistent open-source development practices.
* **Chores**
  * Updated repository exclusions to prevent local assistant configuration files from being included in version control.
  * These updates make contribution expectations clearer and help keep the repository clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->