### PR TITLE
fix(agentic): actionable install hint when a model's LLM provider extra is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,32 @@ The `analyze` command always runs the agentic pipeline, so it requires the `agen
 
 ## Quick Start
 
+The fastest path from install to seeing assets in AI Inventory:
+
+```bash
+# 1. Install with the agentic pipeline + your LLM provider (OpenAI shown)
+uv tool install --python 3.13 "cisco-aibom[agentic,llm-openai]"
+
+# 2. Scan a git repo or container image (--llm-model is always required)
+cisco-aibom analyze /path/to/repo \
+  --output-format json --output-file report.json \
+  --llm-model gpt-5.4 --llm-api-key $OPENAI_API_KEY
+
+# 3. Upload to AI Defense — assets appear in AI Inventory
+cisco-aibom report upload report.json --format json \
+  --post-url "$AIBOM_POST_URL" --ai-defense-api-key "$AI_DEFENSE_API_KEY"
+```
+
+> **What appears in AI Inventory?** A scan of a **git working tree** or a
+> **container image** is automatically attributed (repo URL + commit SHA, or
+> image ref + digest) and projected as an inventory asset — no extra flags
+> needed. A scan of a plain local directory that is *not* a git checkout still
+> uploads successfully, but has no stable identity to project, so it will
+> **not** appear in AI Inventory. To populate the inventory, scan a git repo or
+> a container image.
+
+More examples:
+
 ```bash
 # Scan a local project (--llm-model is required)
 cisco-aibom analyze /path/to/project -o json -O report.json \
@@ -501,7 +527,8 @@ uv run pytest tests -v
 - **DuckDB catalog errors:** Run `cisco-aibom kb download` to fetch the latest catalog, or set `AIBOM_DB_PATH` to point at an existing file. Use `cisco-aibom kb verify` to check integrity.
 - **Container extraction fails:** Ensure Docker or an alternative runtime is installed and running. Use `--container-extraction-tier` to force a specific tool. See [docs/CONTAINER_SCANNING.md](https://github.com/cisco-ai-defense/aibom/blob/main/docs/CONTAINER_SCANNING.md).
 - **Missing `--llm-model`:** The LLM agent is required. Install the agentic extra (`uv tool install "cisco-aibom[agentic,llm-openai]"`) and supply `--llm-model` or set `AIBOM_LLM_MODEL`. See [docs/AGENTIC_MODE.md](https://github.com/cisco-ai-defense/aibom/blob/main/docs/AGENTIC_MODE.md).
-- **LLM provider errors:** Ensure `--llm-provider` matches the installed LangChain integration package. For Azure OpenAI, `--llm-api-version` is required.
+- **LLM provider errors / missing provider package:** Each provider needs its integration extra (`llm-openai`, `llm-aws`, `llm-anthropic`, `llm-google`). If it is missing, the CLI fails fast with the exact `uv tool install "cisco-aibom[agentic,llm-…]"` command to run — including when the model is given by bare name (e.g. `--llm-model gpt-4o`). For Azure OpenAI, `--llm-api-version` is required.
 - **Slow scans on large repos:** Use `--timing` to identify bottlenecks. Use `--agentic-fast-model` for a cheaper model on simple confirmations, or increase `--agentic-concurrency` for parallel batches.
 - **Missing output files:** `--output-file` / `-O` is required for all file-based formats.
 - **Report submission:** Set `AIBOM_POST_URL` and `AI_DEFENSE_API_KEY`. Regional endpoints: US (`api.security.cisco.com`), APJ (`api.apj.security.cisco.com`), EU (`api.eu.security.cisco.com`), UAE (`api.uae.security.cisco.com`).
+- **Upload succeeded but nothing appears in AI Inventory:** Only **git** and **container-image** scans are projected into the inventory; the CLI auto-captures their source attribution (repo URL + commit SHA, or image ref + digest). A scan of a plain local path (not a git checkout) uploads successfully but is not projected, because it has no stable asset identity. Re-run the scan against a git working tree or a container image.

--- a/aibom/src/aibom/llm_factory.py
+++ b/aibom/src/aibom/llm_factory.py
@@ -218,6 +218,62 @@ _PROVIDER_IMPORT_HINTS: dict[str, tuple[str, str]] = {
     "google_genai": ("langchain_google_genai", "cisco-aibom[agentic,llm-google]"),
 }
 
+# Inverted view of the hints above, keyed by the integration *module* whose
+# import fails. This is how a missing provider binding is translated into the
+# right ``cisco-aibom`` extra WITHOUT this code inferring the provider from the
+# model name: ``init_chat_model`` performs the model->provider inference and
+# then imports the integration package, so a missing binding surfaces as an
+# ``ImportError`` naming the exact module (e.g. ``langchain_openai``). We map
+# that module back to its install target.
+_MODULE_INSTALL_TARGETS: dict[str, str] = {
+    module: install_target for module, install_target in _PROVIDER_IMPORT_HINTS.values()
+}
+
+
+def _missing_binding_module(exc: BaseException) -> str | None:
+    """Return the top-level module a failed import was looking for.
+
+    Walks the exception's cause/context chain for the original
+    ``ModuleNotFoundError`` (``init_chat_model`` re-raises ``ImportError``
+    ``from`` it) and returns its top-level module name — e.g. ``langchain_openai``
+    for a failed ``import langchain_openai.chat_models``. Returns ``None`` when no
+    module name can be recovered.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        name = getattr(current, "name", None)
+        if isinstance(current, ModuleNotFoundError) and name:
+            return name.split(".", 1)[0]
+        current = current.__cause__ or current.__context__
+    return None
+
+
+def _provider_runtime_hint(exc: ImportError) -> str:
+    """Translate a provider-binding import failure into an actionable message.
+
+    Maps the missing integration module to the ``cisco-aibom`` extra that ships
+    it. Falls back to listing the bundled provider extras when the module is one
+    this project does not package (a provider ``langchain`` supports but the AI
+    BOM CLI does not bundle an extra for).
+    """
+    module = _missing_binding_module(exc)
+    install_target = _MODULE_INSTALL_TARGETS.get(module or "")
+    if install_target:
+        return (
+            f"The LLM provider integration for this model is not installed "
+            f"(missing '{module}'). "
+            f'Install it with: uv tool install "{install_target}"'
+        )
+    bundled = ", ".join(sorted(set(_MODULE_INSTALL_TARGETS.values())))
+    missing = f" (missing '{module}')" if module else ""
+    return (
+        "The LLM provider integration for this model is not installed"
+        f"{missing}. Install the provider extra that matches your "
+        f"--llm-model — one of: {bundled}."
+    )
+
 
 def resolve_provider(model_string: str, provider: str | None = None) -> str | None:
     """Resolve the effective model provider from explicit or legacy syntax."""
@@ -242,22 +298,39 @@ def ensure_llm_runtime_available(
         )
 
     resolved_provider = resolve_provider(model_string, provider)
-    if not resolved_provider:
-        return None
 
-    provider_hint = _PROVIDER_IMPORT_HINTS.get(resolved_provider)
-    if not provider_hint:
+    if resolved_provider:
+        # Provider is known explicitly (``--llm-provider`` or a ``provider/``
+        # prefix). For a provider we bundle an extra for, do a cheap targeted
+        # import check with a precise hint. Providers we do not bundle (e.g.
+        # ``ollama``) are the caller's responsibility — don't second-guess them.
+        provider_hint = _PROVIDER_IMPORT_HINTS.get(resolved_provider)
+        if provider_hint:
+            module_name, install_target = provider_hint
+            try:
+                importlib.import_module(module_name)
+            except ImportError as exc:
+                raise ImportError(
+                    f"LLM provider '{resolved_provider}' requires additional "
+                    f"runtime support. "
+                    f'Install with: uv tool install "{install_target}"'
+                ) from exc
         return resolved_provider
 
-    module_name, install_target = provider_hint
+    # No provider we can resolve ourselves — a name-inferred model such as a
+    # bare ``gpt-4o``. Rather than re-implement langchain's model->provider
+    # inference here, let ``init_chat_model`` infer the provider and import its
+    # integration package; that import happens before the model is constructed,
+    # so no credentials are needed. Only a *missing binding* (ImportError) is
+    # ours to translate — any other error (e.g. an un-inferable name) means the
+    # binding is present and is surfaced later with the real configuration.
     try:
-        importlib.import_module(module_name)
+        init_chat_model(model_string, model_provider=provider)
     except ImportError as exc:
-        raise ImportError(
-            f"LLM provider '{resolved_provider}' requires additional runtime support. "
-            f'Install with: uv tool install "{install_target}"'
-        ) from exc
-    return resolved_provider
+        raise ImportError(_provider_runtime_hint(exc)) from exc
+    except Exception:  # noqa: BLE001 - binding imported; other failures handled later
+        pass
+    return None
 
 
 def build_chat_model(
@@ -375,4 +448,12 @@ def build_chat_model(
     if init_kwargs_extra:
         init_kwargs.update(init_kwargs_extra)
 
-    return init_chat_model(model_id, **init_kwargs)
+    try:
+        return init_chat_model(model_id, **init_kwargs)
+    except ImportError as exc:
+        # Definitive guard covering every resolution path: a name-inferred
+        # provider whose integration package is missing reaches us here. The
+        # pre-flight in ``ensure_llm_runtime_available`` catches the common case
+        # earlier, but translating here too keeps ``build_chat_model``
+        # self-contained. Map the missing module to the matching extra.
+        raise ImportError(_provider_runtime_hint(exc)) from exc

--- a/aibom/tests/test_llm_factory.py
+++ b/aibom/tests/test_llm_factory.py
@@ -566,5 +566,125 @@ def test_init_kwargs_extra_overrides_reasoning(mock_init, _mock_preflight):
     assert kwargs["extra_body"] == {"custom": 1}
 
 
+# --- Missing provider-binding translation (name-inferred models) ------------
+#
+# A bare model name like ``gpt-4o`` carries no provider prefix, so this code
+# never classifies it. ``init_chat_model`` infers the provider and imports the
+# integration package; when that package is absent it raises an ImportError
+# whose cause names the exact missing module. We translate that module into the
+# matching ``cisco-aibom`` extra — no model-name matching on our side.
+
+
+def _import_error_missing(module_name: str) -> ImportError:
+    """Build an ImportError shaped like langchain's missing-binding failure.
+
+    langchain's ``_import_module`` catches the ``ModuleNotFoundError`` and
+    re-raises an ``ImportError`` ``from`` it, so the original module name lives
+    on ``__cause__``.
+    """
+    cause = ModuleNotFoundError(f"No module named '{module_name}'", name=module_name)
+    pkg = module_name.replace("_", "-")
+    err = ImportError(
+        f"Initializing chat model requires the {pkg} package. "
+        f"Please install it with `pip install {pkg}`"
+    )
+    err.__cause__ = cause
+    return err
+
+
+def test_missing_binding_module_reads_cause_chain():
+    from aibom.llm_factory import _missing_binding_module
+
+    exc = _import_error_missing("langchain_openai")
+    assert _missing_binding_module(exc) == "langchain_openai"
+
+
+def test_missing_binding_module_returns_none_without_name():
+    from aibom.llm_factory import _missing_binding_module
+
+    assert _missing_binding_module(ImportError("no module name here")) is None
+
+
+def test_provider_runtime_hint_maps_known_module_to_extra():
+    from aibom.llm_factory import _provider_runtime_hint
+
+    msg = _provider_runtime_hint(_import_error_missing("langchain_openai"))
+    assert "cisco-aibom[agentic,llm-openai]" in msg
+
+
+def test_provider_runtime_hint_falls_back_for_unbundled_module():
+    from aibom.llm_factory import _provider_runtime_hint
+
+    # No bundled extra for cohere -> list the ones we do ship.
+    msg = _provider_runtime_hint(_import_error_missing("langchain_cohere"))
+    assert "cisco-aibom[agentic,llm-openai]" in msg
+    assert "cisco-aibom[agentic,llm-aws]" in msg
+
+
+@patch("aibom.llm_factory.ensure_llm_runtime_available", return_value=None)
+@patch("aibom.llm_factory.init_chat_model")
+def test_build_chat_model_translates_missing_binding(mock_init, _mock_preflight):
+    """A name-inferred model whose binding is missing yields the extra hint at
+    the construction site, not a raw ModuleNotFoundError."""
+    from aibom.llm_factory import build_chat_model
+
+    mock_init.side_effect = _import_error_missing("langchain_openai")
+    with pytest.raises(ImportError) as excinfo:
+        build_chat_model("gpt-4o")
+    assert "cisco-aibom[agentic,llm-openai]" in str(excinfo.value)
+
+
+@patch("aibom.llm_factory.init_chat_model")
+def test_preflight_name_inferred_missing_binding_raises_hint(mock_init):
+    """Pre-flight fails fast for a bare model whose binding is missing — it lets
+    langchain infer + import, then translates the ImportError."""
+    from aibom.llm_factory import ensure_llm_runtime_available
+
+    mock_init.side_effect = _import_error_missing("langchain_openai")
+    with pytest.raises(ImportError) as excinfo:
+        ensure_llm_runtime_available("gpt-4o")
+    assert "cisco-aibom[agentic,llm-openai]" in str(excinfo.value)
+
+
+@patch("aibom.llm_factory.init_chat_model")
+def test_preflight_name_inferred_present_binding_passes(mock_init):
+    """Binding present (no ImportError) -> pre-flight passes and returns None."""
+    from aibom.llm_factory import ensure_llm_runtime_available
+
+    mock_init.return_value = MagicMock()
+    assert ensure_llm_runtime_available("gpt-4o") is None
+
+
+def test_preflight_explicit_provider_missing_binding_raises_hint():
+    """Explicit provider keeps its precise, provider-named hint.
+
+    A delegating fake makes *only* ``langchain_openai`` fail to import — patching
+    ``importlib.import_module`` to raise unconditionally would break pytest's own
+    import machinery.
+    """
+    import importlib as _importlib
+
+    from aibom.llm_factory import ensure_llm_runtime_available
+
+    real_import = _importlib.import_module
+
+    def fake_import(name, *args, **kwargs):
+        if name == "langchain_openai":
+            raise ModuleNotFoundError(
+                "No module named 'langchain_openai'", name="langchain_openai"
+            )
+        return real_import(name, *args, **kwargs)
+
+    with (
+        patch("aibom.llm_factory.init_chat_model", new=MagicMock()),
+        patch("aibom.llm_factory.importlib.import_module", side_effect=fake_import),
+    ):
+        with pytest.raises(ImportError) as excinfo:
+            ensure_llm_runtime_available("gpt-4o", provider="openai")
+    msg = str(excinfo.value)
+    assert "openai" in msg
+    assert "cisco-aibom[agentic,llm-openai]" in msg
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Two related improvements to the first-run experience.

### Fix: actionable hint for a missing LLM provider extra

A bare model name such as `--llm-model gpt-4o`, installed with the `agentic`
extra but without the matching provider extra (`llm-openai`), previously
crashed with a raw `ModuleNotFoundError: No module named 'langchain_openai'`.
The fail-fast guard only covered explicit `--llm-provider` / `provider/model`
inputs, so name-inferred models slipped through and surfaced the raw import
error deep in the pipeline.

The CLI now translates the missing binding into the exact install command —
e.g. _"The LLM provider integration for this model is not installed (missing
'langchain_openai'). Install it with: uv tool install
cisco-aibom[agentic,llm-openai]"_ — **without** inferring the provider from the
model name. `init_chat_model` already performs model→provider inference and
imports the integration package, so a missing binding raises an `ImportError`
whose cause names the exact module; that module is read from the exception
chain and mapped to the matching extra (inverted from the existing hint table).
The real `init_chat_model` call is wrapped so every resolution path is covered
(explicit flag, `provider/model` slash, and name-inferred), and the pre-flight
runs the same inference + import for name-inferred models so it still fails
fast.

### Docs: onboarding and AI Inventory projection

Quick Start now opens with an end-to-end install → analyze → upload block, and
a callout documents that only git and container-image scans are attributed and
projected into AI Inventory (a plain local-path scan uploads successfully but
is not projected, by design). Troubleshooting gains an entry for an upload that
succeeds but shows no inventory asset, and a sharper provider-extra entry.

## Testing

- `pytest tests/test_llm_factory.py` — 70 passed (8 new)
- Full suite — 2042 passed, 21 skipped
- New provider-hint lines hand-kept ≤ 88 cols


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a step-by-step Quick Start workflow covering installation, LLM model selection, analysis, and AI Defense report uploads.
  - Clarified which scan types appear in AI Inventory and how to resolve missing attribution.
  - Expanded troubleshooting guidance for provider setup, Azure OpenAI configuration, and successful uploads that do not appear in inventory.

- **Bug Fixes**
  - Improved missing LLM provider errors with actionable installation commands and clearer guidance.
  - Added consistent validation for provider availability across supported model configuration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->