### PR TITLE
chore: prepare 1.0.8 release

### DIFF
--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-aibom"
-version = "1.0.7"
+version = "1.0.8"
 description = "A tool to generate an AI BOM from source code."
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/aibom/src/aibom/manifest.json
+++ b/aibom/src/aibom/manifest.json
@@ -1,8 +1,8 @@
 {
-  "analyzer_version": "1.0.7",
-  "schema_version": "1.0.7",
+  "analyzer_version": "1.0.8",
+  "schema_version": "1.0.8",
   "duckdb_sha256": "b1165384a646094aa6a4762d676f285c1c68b6d7f9367c90a129b529904a3268",
-  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.7.duckdb",
+  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.8.duckdb",
   "upload_mode": "direct",
   "max_direct_upload_mb": 25,
   "log_level": "INFO"

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -497,7 +497,7 @@ wheels = [
 
 [[package]]
 name = "cisco-aibom"
-version = "1.0.7"
+version = "1.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Patch release capturing changes merged since 1.0.7.

## Included changes

- refactor(catalog): drop the client-side parameter label workaround; keep the stale-KB guard (#64)
- docs: add AI-agent contributor rules (#65)
- fix(agentic): add an actionable install hint when a model's LLM provider extra is missing (#66)

## Version bump

- `pyproject.toml` / `uv.lock`: 1.0.7 → 1.0.8
- `manifest.json`: `analyzer_version` / `schema_version` → 1.0.8, `duckdb_file` → `aibom_catalog-1.0.8.duckdb`
  - Catalog content is unchanged; `duckdb_sha256` remains identical.

## Impact

This prepares the package and bundled catalog metadata for publishing version 1.0.8. The catalog download will use the version-stamped `aibom_catalog-1.0.8.duckdb` asset.

## Verification

- `uv sync`
- `uv lock --check`
- `uv run pytest`: 2,042 passed, 21 skipped
- `jq empty aibom/src/aibom/manifest.json`
- `git diff --check`
- Release diff contains no Python changes; the repository-wide isort check reports existing import-order drift in untouched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package to version 1.0.8.
  * Updated analyzer and schema versions to 1.0.8.
  * Updated the catalog reference to the 1.0.8 catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->