### PR TITLE
chore: prepare 1.0.9 release

### DIFF
--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-aibom"
-version = "1.0.8"
+version = "1.0.9"
 description = "A tool to generate an AI BOM from source code."
 readme = "README.md"
 requires-python = ">=3.11.4,<3.14"

--- a/aibom/src/aibom/manifest.json
+++ b/aibom/src/aibom/manifest.json
@@ -1,8 +1,8 @@
 {
-  "analyzer_version": "1.0.8",
-  "schema_version": "1.0.8",
+  "analyzer_version": "1.0.9",
+  "schema_version": "1.0.9",
   "duckdb_sha256": "b1165384a646094aa6a4762d676f285c1c68b6d7f9367c90a129b529904a3268",
-  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.8.duckdb",
+  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.9.duckdb",
   "upload_mode": "direct",
   "max_direct_upload_mb": 25,
   "log_level": "INFO"

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -506,7 +506,7 @@ wheels = [
 
 [[package]]
 name = "cisco-aibom"
-version = "1.0.8"
+version = "1.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Prepare the 1.0.9 release by synchronizing the package, manifest, and lockfile
versions.

## Changes included since 1.0.8

- #68 adds opt-in, privacy-preserving Galileo observability and evaluation
  support for agentic scans.
- #69 updates vulnerable dependencies, raises the supported Python minimum to
  3.11.4, and corrects the Docker build context.
- #71 refreshes the locked dependency set, including pytest, LangChain,
  Anthropic, Requests, and Pydantic Settings updates.

## Release preparation

- update `aibom/pyproject.toml` from 1.0.8 to 1.0.9
- update `analyzer_version`, `schema_version`, and the versioned catalog
  filename in `aibom/src/aibom/manifest.json`
- update the `cisco-aibom` package version in `aibom/uv.lock`
- retain the existing catalog SHA-256 because the catalog content is unchanged

## Validation

- `uv sync`
- `uv lock --check`
- version synchronization check: 1.0.9
- `uv run pytest`: 2,428 passed, 13 skipped
- `git diff --check`

Repository-wide Black and isort checks continue to report pre-existing
formatting drift on Python files. This release-preparation commit changes only
TOML, JSON, and lockfile metadata and does not modify Python source.
