### PR TITLE
feat(kb): add schema v2 compatibility guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,9 @@ cisco-aibom kb verify
 cisco-aibom kb info
 ```
 
+For the schema-v2 concept contract and its compatibility policy, see
+[Schema-v2 concept vocabulary](docs/concept-vocabulary.md).
+
 Manual download from GitHub Releases (replace `<VERSION>` with the desired KB version, e.g. the latest tag from [Releases](https://github.com/cisco-ai-defense/aibom/releases)):
 
 ```bash

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -56,6 +56,10 @@ from .custom_catalog import (
     CustomCatalogConfig,
     load_custom_catalog,
 )
+from .db_loader import (
+    UnsupportedDatabaseSchemaError,
+    require_supported_manifest_schema,
+)
 from .kb.manager import KBError, KBManager
 from .llm_factory import ensure_llm_runtime_available
 from .models.enums import Severity as SeverityEnum
@@ -1765,6 +1769,15 @@ def analyze(
     ),
 ):
     """Analyzes a Python codebase to generate an AI BOM."""
+    try:
+        require_supported_manifest_schema()
+    except UnsupportedDatabaseSchemaError as exc:
+        console.print(
+            f"[bold red]Knowledge base upgrade required:[/] {escape(str(exc))}",
+            highlight=False,
+        )
+        raise typer.Exit(code=1) from None
+
     if output_format not in _VALID_OUTPUT_FORMATS:
         valid = ", ".join(sorted(_VALID_OUTPUT_FORMATS))
         console.print(

--- a/aibom/src/aibom/db_loader.py
+++ b/aibom/src/aibom/db_loader.py
@@ -16,6 +16,8 @@ from typing import Optional, Tuple
 from importlib import resources as importlib_resources
 from rich.console import Console
 
+from .kb.vocabulary import SCHEMA_VERSION, schema_major
+
 _LOGGER = logging.getLogger(__name__)
 
 BUNDLED_DB_SHA256 = "0000000000000000000000000000000000000000000000000000000000000000"
@@ -23,6 +25,28 @@ BUNDLED_DB_SHA256 = "00000000000000000000000000000000000000000000000000000000000
 
 class DatabaseLoadError(RuntimeError):
     """Raised when the DuckDB knowledge base cannot be loaded or verified."""
+
+
+class UnsupportedDatabaseSchemaError(DatabaseLoadError):
+    """Raised when the configured KB requires a newer CLI generation."""
+
+
+def require_supported_manifest_schema(
+    manifest: Optional[dict] = None,
+) -> None:
+    """Reject a selected manifest that requires the next CLI generation."""
+
+    selected = manifest
+    if selected is None:
+        selected, _ = _load_manifest()
+    manifest_schema = schema_major((selected or {}).get("schema_version"))
+    if manifest_schema is not None and manifest_schema >= SCHEMA_VERSION:
+        raise UnsupportedDatabaseSchemaError(
+            "This knowledge base uses schema version "
+            f"{(selected or {}).get('schema_version')}, which requires "
+            "cisco-aibom 2.x. This 1.x CLI continues to support schema-1 "
+            "knowledge bases; upgrade the CLI before using this knowledge base."
+        )
 
 
 def ensure_local_database(console: Optional[Console] = None) -> Path:
@@ -37,6 +61,7 @@ def ensure_local_database(console: Optional[Console] = None) -> Path:
     del console
 
     manifest, manifest_path = _load_manifest()
+    require_supported_manifest_schema(manifest)
     env_db_path = os.environ.get("AIBOM_DB_PATH")
     has_env_db_path = bool(env_db_path)
     env_db_sha = os.environ.get("AIBOM_DB_SHA256")

--- a/aibom/src/aibom/kb/manager.py
+++ b/aibom/src/aibom/kb/manager.py
@@ -30,6 +30,7 @@ import platformdirs
 from pydantic import ValidationError
 
 from .manifest import KBManifest, KBManifestIndex
+from .vocabulary import CONCEPTS, SCHEMA_VERSION, VOCABULARY_VERSION, schema_major
 
 LOGGER = logging.getLogger(__name__)
 
@@ -255,7 +256,7 @@ class KBManager:
             raise KBError(f"Failed to query KB database: {e}") from e
 
         last_modified = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
-        return {
+        info: dict[str, Any] = {
             "version": m.kb_version,
             "path": str(db_path.resolve()),
             "sha256": sha256,
@@ -263,6 +264,18 @@ class KBManager:
             "entity_count": entity_count,
             "last_modified": last_modified,
         }
+        if schema_major(m.schema_version) == SCHEMA_VERSION:
+            info.update(
+                {
+                    "schema_version": m.schema_version,
+                    "vocabulary_version": (
+                        m.vocabulary_version or VOCABULARY_VERSION
+                    ),
+                    "concept_count": len(CONCEPTS),
+                    "concepts": ", ".join(CONCEPTS),
+                }
+            )
+        return info
 
     def verify(self) -> bool:
         mp = self._local_manifest_path()

--- a/aibom/src/aibom/kb/manager.py
+++ b/aibom/src/aibom/kb/manager.py
@@ -232,11 +232,27 @@ class KBManager:
         if not mp.exists():
             raise KBError("No local KB manifest found; run download first")
         try:
-            m = KBManifest.model_validate(json.loads(mp.read_text(encoding="utf-8")))
-        except (json.JSONDecodeError, ValidationError) as e:
+            manifest = json.loads(mp.read_text(encoding="utf-8"))
+            if not isinstance(manifest, dict):
+                raise KBError("Invalid local manifest: root must be an object")
+        except json.JSONDecodeError as e:
             raise KBError(f"Invalid local manifest: {e}") from e
 
-        db_path = self._kb_duckdb_path(m.kb_version)
+        manifest_schema = schema_major(manifest.get("schema_version"))
+        if manifest_schema == SCHEMA_VERSION:
+            version, db_path = self._schema_v2_info_source(manifest, mp)
+            schema_version = manifest.get("schema_version")
+            vocabulary_version = manifest.get("vocabulary_version")
+        else:
+            try:
+                legacy = KBManifest.model_validate(manifest)
+            except ValidationError as e:
+                raise KBError(f"Invalid local manifest: {e}") from e
+            version = legacy.kb_version
+            db_path = self._kb_duckdb_path(version)
+            schema_version = legacy.schema_version
+            vocabulary_version = legacy.vocabulary_version
+
         if not db_path.exists():
             raise KBError(f"Local KB file missing at {db_path}")
 
@@ -257,25 +273,56 @@ class KBManager:
 
         last_modified = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
         info: dict[str, Any] = {
-            "version": m.kb_version,
+            "version": version,
             "path": str(db_path.resolve()),
             "sha256": sha256,
             "size_bytes": stat.st_size,
             "entity_count": entity_count,
             "last_modified": last_modified,
         }
-        if schema_major(m.schema_version) == SCHEMA_VERSION:
+        if manifest_schema == SCHEMA_VERSION:
             info.update(
                 {
-                    "schema_version": m.schema_version,
+                    "schema_version": schema_version,
                     "vocabulary_version": (
-                        m.vocabulary_version or VOCABULARY_VERSION
+                        vocabulary_version
+                        if isinstance(vocabulary_version, str)
+                        and vocabulary_version
+                        else VOCABULARY_VERSION
                     ),
                     "concept_count": len(CONCEPTS),
                     "concepts": ", ".join(CONCEPTS),
                 }
             )
         return info
+
+    def _schema_v2_info_source(
+        self,
+        manifest: dict[str, Any],
+        manifest_path: Path,
+    ) -> tuple[str, Path]:
+        """Resolve offline display identity and DuckDB path for schema v2."""
+
+        raw_version = manifest.get("kb_version") or manifest.get("build_id")
+        if not isinstance(raw_version, str) or not raw_version.strip():
+            raise KBError(
+                "Invalid local schema-v2 manifest: "
+                "kb_version or build_id is required"
+            )
+        version = raw_version.strip()
+
+        duckdb_entry = manifest.get("duckdb")
+        if not isinstance(duckdb_entry, dict):
+            raise KBError(
+                "Invalid local schema-v2 manifest: duckdb object is required"
+            )
+        filename = duckdb_entry.get("filename")
+        if isinstance(filename, str) and filename.strip():
+            candidate = Path(filename.strip()).expanduser()
+            if candidate.is_absolute():
+                return version, candidate
+            return version, (manifest_path.parent / candidate).resolve()
+        return version, self._kb_duckdb_path(version)
 
     def verify(self) -> bool:
         mp = self._local_manifest_path()

--- a/aibom/src/aibom/kb/manifest.py
+++ b/aibom/src/aibom/kb/manifest.py
@@ -21,6 +21,8 @@ from pydantic import BaseModel, Field
 
 class KBManifest(BaseModel):
     kb_version: str
+    schema_version: int | str | None = None
+    vocabulary_version: str = ""
     min_cli_version: str = ""
     duckdb_sha256: str
     duckdb_url: str

--- a/aibom/src/aibom/kb/vocabulary.py
+++ b/aibom/src/aibom/kb/vocabulary.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Final
 
 SCHEMA_VERSION: Final[int] = 2
@@ -55,6 +56,8 @@ def schema_major(value: object) -> int | None:
     if isinstance(value, int):
         return value
     if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
         return int(value)
     text = str(value).strip().lower()
     if text.startswith("v"):

--- a/aibom/src/aibom/kb/vocabulary.py
+++ b/aibom/src/aibom/kb/vocabulary.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public schema-v2 vocabulary metadata used by offline KB inspection."""
+
+from __future__ import annotations
+
+from typing import Final
+
+SCHEMA_VERSION: Final[int] = 2
+VOCABULARY_VERSION: Final[str] = "v2.0"
+
+CONCEPTS: Final[tuple[str, ...]] = (
+    "model",
+    "embedding",
+    "reranker",
+    "agent",
+    "tool",
+    "skill",
+    "prompt",
+    "vector_store",
+    "retriever",
+    "memory",
+    "guardrail",
+    "evaluator",
+    "mcp_server",
+    "mcp_client",
+    "dataset",
+    "training_run",
+    "model_artifact",
+    "observability",
+    "framework_core",
+    "document_loader",
+)
+
+
+def schema_major(value: object) -> int | None:
+    """Return the leading numeric schema component, if one is present."""
+
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    text = str(value).strip().lower()
+    if text.startswith("v"):
+        text = text[1:]
+    first = text.split(".", 1)[0]
+    return int(first) if first.isdigit() else None

--- a/aibom/src/aibom/scanners/kb_enrichment_scanner.py
+++ b/aibom/src/aibom/scanners/kb_enrichment_scanner.py
@@ -34,7 +34,11 @@ from typing import Any, Optional
 
 from ..catalog_db import CatalogDB
 from ..cst_parser import parse_source_code
-from ..db_loader import DatabaseLoadError, ensure_local_database
+from ..db_loader import (
+    DatabaseLoadError,
+    UnsupportedDatabaseSchemaError,
+    ensure_local_database,
+)
 from ..models import (
     AIComponent,
     AIComponentType,
@@ -736,6 +740,9 @@ def _resolve_kb_path(context: ScanContext) -> Optional[Path]:
 
     try:
         return ensure_local_database()
+    except UnsupportedDatabaseSchemaError as exc:
+        _LOGGER.warning("%s", exc)
+        return None
     except (DatabaseLoadError, Exception):  # noqa: BLE001
         pass
 

--- a/aibom/src/aibom/scanners/kb_enrichment_scanner.py
+++ b/aibom/src/aibom/scanners/kb_enrichment_scanner.py
@@ -38,6 +38,7 @@ from ..db_loader import (
     DatabaseLoadError,
     UnsupportedDatabaseSchemaError,
     ensure_local_database,
+    require_supported_manifest_schema,
 )
 from ..models import (
     AIComponent,
@@ -733,6 +734,12 @@ def _is_known_call(
 
 def _resolve_kb_path(context: ScanContext) -> Optional[Path]:
     """Locate the KB DuckDB file.  Returns ``None`` when unavailable."""
+    try:
+        require_supported_manifest_schema()
+    except UnsupportedDatabaseSchemaError as exc:
+        _LOGGER.warning("%s", exc)
+        return None
+
     if context.kb_path:
         p = Path(context.kb_path)
         if p.is_file():

--- a/aibom/tests/test_cli_basic.py
+++ b/aibom/tests/test_cli_basic.py
@@ -30,6 +30,41 @@ def test_analyze_rejects_legacy_ui_output_format():
     assert "Invalid output format" in result.output
 
 
+def test_analyze_rejects_schema_v2_manifest_without_traceback(
+    monkeypatch,
+    tmp_path,
+):
+    source_dir = tmp_path / "repo"
+    source_dir.mkdir()
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "duckdb_file": "candidate.duckdb",
+                "duckdb_sha256": "unused",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AIBOM_MANIFEST_PATH", str(manifest))
+
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            str(source_dir),
+            "--llm-model",
+            "not-used",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Knowledge base upgrade required" in result.output
+    assert "requires cisco-aibom 2.x" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_analyze_defaults_cache_root_for_scan_and_agentic(tmp_path):
     source_dir = tmp_path / "repo"
     source_dir.mkdir()

--- a/aibom/tests/test_db_loader.py
+++ b/aibom/tests/test_db_loader.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib
+import json
 import tempfile
 from pathlib import Path
 
@@ -99,6 +100,47 @@ def test_ensure_local_database_uses_manifest_checksum_when_env_sha_missing(monke
 
         resolved = db_loader.ensure_local_database(console=None)
         assert resolved == db_path
+
+
+def test_schema_v2_manifest_requires_cli_upgrade(monkeypatch, tmp_path):
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        """{
+  "schema_version": 2,
+  "duckdb_sha256": "unused",
+  "duckdb_file": "candidate.duckdb"
+}""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AIBOM_MANIFEST_PATH", str(manifest_path))
+
+    with pytest.raises(
+        db_loader.UnsupportedDatabaseSchemaError,
+        match=r"requires cisco-aibom 2\.x",
+    ):
+        db_loader.ensure_local_database(console=None)
+
+
+@pytest.mark.parametrize("schema_version", ["1.0.9", 1])
+def test_schema_v1_manifest_remains_supported(
+    monkeypatch,
+    tmp_path,
+    schema_version,
+):
+    db_path = tmp_path / "frozen-v1.duckdb"
+    checksum = _write_dummy_db(db_path)
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        f"""{{
+  "schema_version": {json.dumps(schema_version)},
+  "duckdb_sha256": "{checksum}",
+  "duckdb_file": "{db_path.name}"
+}}""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AIBOM_MANIFEST_PATH", str(manifest_path))
+
+    assert db_loader.ensure_local_database(console=None) == db_path.resolve()
 
 
 def test_default_manifest_path_prefers_packaged_over_cwd(monkeypatch):

--- a/aibom/tests/test_db_loader.py
+++ b/aibom/tests/test_db_loader.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from aibom import db_loader
+from aibom.kb.vocabulary import schema_major
 
 
 def _write_dummy_db(path: Path, content: bytes = b"duckdb") -> str:
@@ -119,6 +120,11 @@ def test_schema_v2_manifest_requires_cli_upgrade(monkeypatch, tmp_path):
         match=r"requires cisco-aibom 2\.x",
     ):
         db_loader.ensure_local_database(console=None)
+
+
+@pytest.mark.parametrize("schema_version", [float("nan"), float("inf")])
+def test_non_finite_schema_versions_are_invalid(schema_version):
+    assert schema_major(schema_version) is None
 
 
 @pytest.mark.parametrize("schema_version", ["1.0.9", 1])

--- a/aibom/tests/test_kb_enrichment_scanner.py
+++ b/aibom/tests/test_kb_enrichment_scanner.py
@@ -264,6 +264,27 @@ def _kb_available() -> bool:
     return _resolve_kb_path(ctx) is not None
 
 
+def test_explicit_kb_path_does_not_bypass_schema_guard(
+    monkeypatch,
+    tmp_path: Path,
+):
+    db_path = tmp_path / "candidate.duckdb"
+    db_path.touch()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        """{
+  "schema_version": 2,
+  "duckdb_file": "candidate.duckdb",
+  "duckdb_sha256": "unused"
+}""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AIBOM_MANIFEST_PATH", str(manifest_path))
+    context = ScanContext(paths=[str(tmp_path)], kb_path=str(db_path))
+
+    assert _resolve_kb_path(context) is None
+
+
 class TestExtractLeafClass:
     """Unit tests for _extract_leaf_class KB id parsing."""
 

--- a/aibom/tests/test_kb_manager.py
+++ b/aibom/tests/test_kb_manager.py
@@ -158,11 +158,9 @@ def test_kb_manager_info_returns_expected_keys(tmp_path):
     assert info["size_bytes"] == db_path.stat().st_size
 
 
-def test_kb_manager_info_surfaces_schema_v2_vocabulary_offline(tmp_path):
+def test_kb_manager_info_surfaces_schema_v2_candidate_offline(tmp_path):
     root = tmp_path
-    catalogs = root / "catalogs"
-    catalogs.mkdir(parents=True)
-    db_path = catalogs / "kb-2.0.0.duckdb"
+    db_path = root / "aibom_catalog.duckdb"
     con = duckdb.connect(str(db_path))
     try:
         con.execute("CREATE TABLE component_catalog (id INTEGER)")
@@ -171,22 +169,30 @@ def test_kb_manager_info_surfaces_schema_v2_vocabulary_offline(tmp_path):
         con.close()
 
     manifest = {
-        "kb_version": "2.0.0",
+        "artifact_state": "candidate",
+        "authoritative": False,
         "schema_version": 2,
+        "build_id": "candidate-2026-07-24",
+        "min_cli_version": "2.0.0",
         "vocabulary_version": "v2.0",
-        "duckdb_sha256": "unused",
-        "duckdb_url": "https://example.com/k.duckdb",
+        "duckdb": {
+            "filename": db_path.name,
+            "size_bytes": db_path.stat().st_size,
+            "sha256": hashlib.sha256(db_path.read_bytes()).hexdigest(),
+        },
     }
     (root / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
 
     mgr = KBManager()
-    with (
-        patch.object(mgr, "_user_root", return_value=root),
-        patch.object(mgr, "_local_manifest_path", return_value=root / "manifest.json"),
-        patch.object(mgr, "_kb_duckdb_path", return_value=db_path),
+    with patch.object(
+        mgr,
+        "_local_manifest_path",
+        return_value=root / "manifest.json",
     ):
         info = mgr.info()
 
+    assert info["version"] == "candidate-2026-07-24"
+    assert info["path"] == str(db_path.resolve())
     assert info["schema_version"] == 2
     assert info["vocabulary_version"] == "v2.0"
     assert info["concept_count"] == 20

--- a/aibom/tests/test_kb_manager.py
+++ b/aibom/tests/test_kb_manager.py
@@ -158,6 +158,41 @@ def test_kb_manager_info_returns_expected_keys(tmp_path):
     assert info["size_bytes"] == db_path.stat().st_size
 
 
+def test_kb_manager_info_surfaces_schema_v2_vocabulary_offline(tmp_path):
+    root = tmp_path
+    catalogs = root / "catalogs"
+    catalogs.mkdir(parents=True)
+    db_path = catalogs / "kb-2.0.0.duckdb"
+    con = duckdb.connect(str(db_path))
+    try:
+        con.execute("CREATE TABLE component_catalog (id INTEGER)")
+        con.execute("INSERT INTO component_catalog VALUES (1)")
+    finally:
+        con.close()
+
+    manifest = {
+        "kb_version": "2.0.0",
+        "schema_version": 2,
+        "vocabulary_version": "v2.0",
+        "duckdb_sha256": "unused",
+        "duckdb_url": "https://example.com/k.duckdb",
+    }
+    (root / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    mgr = KBManager()
+    with (
+        patch.object(mgr, "_user_root", return_value=root),
+        patch.object(mgr, "_local_manifest_path", return_value=root / "manifest.json"),
+        patch.object(mgr, "_kb_duckdb_path", return_value=db_path),
+    ):
+        info = mgr.info()
+
+    assert info["schema_version"] == 2
+    assert info["vocabulary_version"] == "v2.0"
+    assert info["concept_count"] == 20
+    assert "document_loader" in info["concepts"]
+
+
 @respx.mock
 def test_kb_manager_check_update_available_when_remote_newer(tmp_path):
     root = tmp_path

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -303,6 +303,10 @@ Display information about the locally installed KB.
 cisco-aibom kb info
 ```
 
+For a schema-v2 manifest, this offline command also displays
+`schema_version`, `vocabulary_version`, and the 20-concept vocabulary. See
+[Schema-v2 concept vocabulary](concept-vocabulary.md).
+
 ### `kb verify`
 
 Verify the integrity of the locally installed KB (SHA-256 checksum).

--- a/docs/concept-vocabulary.md
+++ b/docs/concept-vocabulary.md
@@ -1,0 +1,69 @@
+# Schema-v2 concept vocabulary
+
+The schema-v2 knowledge base classifies every catalog entry with one of the
+20 concepts below. `cisco-aibom kb info` displays the schema and vocabulary
+versions, plus this concept list, when the locally installed manifest declares
+`schema_version: 2`. The command is fully offline.
+
+| Concept | Allowed subconcepts |
+|---|---|
+| `model` | `chat`, `completion`, `structured_output`, `multimodal_vision`, `multimodal_audio`, `multimodal_video`, `code_generation` |
+| `embedding` | `dense`, `sparse`, `colbert`, `multilingual` |
+| `reranker` | `cross_encoder`, `api_reranker`, `bm25` |
+| `agent` | `react`, `plan_and_execute`, `structured_chat`, `multi_agent_supervisor`, `openai_functions`, `tool_calling` |
+| `tool` | `function_call`, `retrieval`, `calculator`, `code_execution`, `web_search`, `file_ops`, `mcp_bridge` |
+| `skill` | None |
+| `prompt` | `template`, `few_shot`, `hub_pull`, `system`, `partial_template` |
+| `vector_store` | `managed_cloud`, `self_hosted`, `in_memory`, `hybrid_search` |
+| `retriever` | `bm25`, `tfidf`, `multi_query`, `parent_doc`, `contextual_compression`, `self_query`, `ensemble` |
+| `memory` | `buffer`, `summary`, `entity`, `vector_store_backed`, `window` |
+| `guardrail` | `input_filter`, `output_filter`, `policy_nemo`, `policy_guardrails_ai`, `content_safety` |
+| `evaluator` | `ragas`, `deepeval`, `llm_as_judge`, `custom_metric` |
+| `mcp_server` | `stdio`, `sse`, `http_streamable`, `fastmcp` |
+| `mcp_client` | `stdio`, `sse`, `http_streamable`, `multi_server` |
+| `dataset` | None |
+| `training_run` | `sft`, `dpo`, `grpo`, `reward_modeling`, `lora`, `qlora`, `full_finetune` |
+| `model_artifact` | `hf_hub_push`, `hf_hub_pull`, `checkpoint`, `lora_adapter`, `peft_adapter`, `quantized_gguf` |
+| `observability` | `tracer`, `callback_handler`, `span_exporter`, `cost_tracker` |
+| `framework_core` | None |
+| `document_loader` | `pdf`, `web`, `confluence`, `s3`, `github`, `notion`, `gdrive`, `sql`, `csv`, `office_docs` |
+
+## Exclusions
+
+`chain` and `text_splitter` are intentionally not schema-v2 concepts. A
+framework symbol with one of those roles must be represented by another
+allowed concept when appropriate; it must not extend the vocabulary implicitly.
+
+## Evolution policy
+
+- Adding a subconcept does not change the schema version. It increments the
+  vocabulary version.
+- Adding a concept increments the minor schema version and the vocabulary
+  version.
+- Renaming or removing a concept, or changing its meaning, increments the
+  major schema version and requires a coordinated cutover.
+
+## CLI compatibility
+
+The packaged CLI 1.x manifest and its schema-v1 DuckDB artifact remain
+supported. If a 1.x CLI is pointed at a schema-v2 manifest, it exits that KB
+load path with an upgrade-required message instead of attempting to read an
+incompatible catalog. That message applies only to the selected schema-v2
+knowledge base; it does not invalidate an existing schema-v1 artifact.
+
+## Release checks and rollback
+
+Before activating a schema-v2 manifest:
+
+1. Run a representative scan against a frozen schema-v1 fixture and confirm
+   its output is unchanged.
+2. Run `cisco-aibom kb info` against the schema-v2 candidate and confirm the
+   reported schema, vocabulary version, and concept count.
+3. Exercise the 1.x compatibility path and confirm the upgrade-required
+   message is concise and does not include a traceback.
+
+After activation, monitor KB download, checksum, and unsupported-schema
+failures separately. A rise in unsupported-schema failures can indicate that
+older clients are selecting the new manifest. Roll back by restoring the
+previous manifest selection; the frozen schema-v1 artifact itself remains
+valid.


### PR DESCRIPTION
## Summary

- Preserve the packaged CLI 1.x manifest and frozen schema-v1 DuckDB behavior.
- Reject a selected schema-v2 manifest with a concise upgrade-required message and no traceback.
- Treat malformed non-finite schema values as invalid instead of raising conversion errors.
- Inspect the actual nested schema-v2 candidate manifest through offline KB information without enabling schema-v2 analysis.
- Show schema-v2 vocabulary metadata through offline KB inspection while leaving legacy output unchanged when the fields are absent.
- Document the 20-concept vocabulary, exclusions, evolution policy, release checks, and rollback behavior.

## Stack and merge gate

This is the first independently reviewed layer of the CLI 2.0 stack. PR #75 is the next layer, and the distribution and integrity layer will be stacked above it.

This PR targets the protected `release-2.0.0` integration branch so `main` can remain on the supported 1.x line. Once this layer has the required approval and checks, it may merge into `release-2.0.0`. After it merges, PR #75 must be retargeted to the release branch and its diff rechecked before it merges.

The complete end-to-end candidate gates the final `release-2.0.0` to `main` merge and stable 2.0.0 publication; it does not gate this reviewed layer's integration into the release branch.

## Validation

- Full repository suite on the combined stack: 2,465 passed.
- Focused lower compatibility, scanner, and CLI suites: 146 passed.
- CI passes on Python 3.11, 3.12, and 3.13; CodeQL and version sync pass.
- Packaged 1.0.9 manifest unchanged.
- Public-repository hygiene scan passed; fixtures are synthetic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schema compatibility checks that clearly indicate when a knowledge base upgrade is required.
  * Enhanced offline knowledge base information with schema, vocabulary, and concept details.
  * Added schema-v2 concept vocabulary documentation.

* **Bug Fixes**
  * Prevented incompatible knowledge bases from starting analysis or enrichment without a clear error.

* **Documentation**
  * Updated CLI reference and README guidance for schema-v2 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
