### PR TITLE
feat(kb): add package freshness enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,8 @@ cisco-aibom kb info
 
 For the schema-v2 concept contract and its compatibility policy, see
 [Schema-v2 concept vocabulary](docs/concept-vocabulary.md).
+Package snapshot and anonymous delta behavior is documented in
+[Package liveness freshness](docs/package-freshness.md).
 
 Manual download from GitHub Releases (replace `<VERSION>` with the desired KB version, e.g. the latest tag from [Releases](https://github.com/cisco-ai-defense/aibom/releases)):
 
@@ -538,6 +540,9 @@ All CLI options with an `envvar` binding can be set via environment variables or
 | `AIBOM_DB_PATH` | — | Override path to the DuckDB catalog file. |
 | `AIBOM_DB_SHA256` | — | Expected SHA-256 checksum for the catalog. |
 | `AIBOM_MANIFEST_PATH` | — | Override path to `manifest.json`. |
+| `AIBOM_NO_NETWORK` | `--no-network` | Disable package-liveness freshness requests while retaining snapshot fields. |
+| `AIBOM_LIVENESS_ONLY_SNAPSHOT` | `--liveness-only-snapshot` | Use only package-liveness fields frozen into the selected knowledge base. |
+| `CISCO_AIBOM_FRESHNESS_URL` | — | Optional package-freshness endpoint override. No default. |
 | `AIBOM_ENV_FILE` | — | Path to a custom `.env` file. |
 | `AIBOM_GALILEO_ENABLED` | `--galileo/--no-galileo` | Enable sanitized Galileo Agent-span telemetry (default `false`). |
 | `AIBOM_GALILEO_SAMPLE_RATE` | `--galileo-sample-rate` | Deterministic ordinary sanitized batch-agent-trace emission rate from `0.0` to `1.0` (default `1.0`; operational and quality exceptions are retained). |

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -1641,6 +1641,24 @@ def analyze(
             "extra). Surfaced as per-asset findings, not a coverage score."
         ),
     ),
+    no_network: bool = typer.Option(
+        False,
+        "--no-network",
+        envvar="AIBOM_NO_NETWORK",
+        help=(
+            "Disable package-liveness freshness requests. Frozen knowledge-base "
+            "snapshot fields are still included when available."
+        ),
+    ),
+    liveness_only_snapshot: bool = typer.Option(
+        False,
+        "--liveness-only-snapshot",
+        envvar="AIBOM_LIVENESS_ONLY_SNAPSHOT",
+        help=(
+            "Use only package-liveness fields frozen into the knowledge base; "
+            "do not request newer anonymous deltas."
+        ),
+    ),
     container_tier: str = typer.Option(
         "auto",
         "--container-extraction-tier",
@@ -2423,6 +2441,14 @@ def analyze(
                 source_summary["status"] = "completed"
 
             _dispose_extraction(temp_dir)
+
+        from .package_freshness import enrich_analysis_outputs
+
+        enrich_analysis_outputs(
+            all_analysis_outputs,
+            no_network=no_network,
+            liveness_only_snapshot=liveness_only_snapshot,
+        )
 
         run_metadata["completed_at"] = _utcnow_iso()
         run_metadata["error_count"] = len(run_errors)

--- a/aibom/src/aibom/kb/manifest.py
+++ b/aibom/src/aibom/kb/manifest.py
@@ -23,6 +23,7 @@ class KBManifest(BaseModel):
     kb_version: str
     schema_version: int | str | None = None
     vocabulary_version: str = ""
+    freshness_api: str = ""
     min_cli_version: str = ""
     duckdb_sha256: str
     duckdb_url: str

--- a/aibom/src/aibom/package_freshness.py
+++ b/aibom/src/aibom/package_freshness.py
@@ -1,0 +1,298 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Opportunistically refresh package liveness already present in an AI BOM."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable, MutableMapping, cast
+
+import httpx
+
+from .db_loader import _load_manifest
+from .package_registry import (
+    PackageCoordinate,
+    PackageSnapshot,
+    package_coordinate,
+    read_package_snapshots,
+    resolve_package_catalog_path,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+FRESHNESS_MAX_AGE = timedelta(days=7)
+FRESHNESS_BATCH_SIZE = 100
+FRESHNESS_TIMEOUT = httpx.Timeout(5.0)
+
+
+def resolve_freshness_url() -> str | None:
+    """Resolve an explicitly configured or manifest-advertised endpoint."""
+
+    configured = os.environ.get("CISCO_AIBOM_FRESHNESS_URL")
+    if configured:
+        return configured
+    manifest, _ = _load_manifest()
+    if not manifest:
+        return None
+    value = manifest.get("freshness_api")
+    return value if isinstance(value, str) and value else None
+
+
+def enrich_analysis_outputs(
+    outputs: MutableMapping[str, Any],
+    *,
+    db_path: Path | str | None = None,
+    freshness_url: str | None = None,
+    no_network: bool = False,
+    liveness_only_snapshot: bool = False,
+    now: datetime | None = None,
+    client: httpx.Client | None = None,
+) -> None:
+    """Enrich dependencies without changing deterministic scan caches."""
+
+    components: list[Any] = []
+    for output in outputs.values():
+        if not isinstance(output, dict) or not output.get("_v2"):
+            continue
+        value = output.get("components")
+        if isinstance(value, list):
+            components.extend(value)
+    enrich_components(
+        components,
+        db_path=db_path,
+        freshness_url=freshness_url,
+        no_network=no_network,
+        liveness_only_snapshot=liveness_only_snapshot,
+        now=now,
+        client=client,
+    )
+
+
+def enrich_components(
+    components: Iterable[Any],
+    *,
+    db_path: Path | str | None = None,
+    freshness_url: str | None = None,
+    no_network: bool = False,
+    liveness_only_snapshot: bool = False,
+    now: datetime | None = None,
+    client: httpx.Client | None = None,
+) -> None:
+    """Attach snapshot data and, when needed, anonymous live deltas."""
+
+    components_by_coordinate: dict[
+        PackageCoordinate,
+        list[Any],
+    ] = defaultdict(list)
+    for component in components:
+        coordinate = _component_coordinate(component)
+        if coordinate is not None:
+            components_by_coordinate[coordinate].append(component)
+    if not components_by_coordinate:
+        return
+
+    selected_path = (
+        db_path if db_path is not None else resolve_package_catalog_path()
+    )
+    snapshots = read_package_snapshots(
+        selected_path,
+        components_by_coordinate.keys(),
+    )
+    if not snapshots:
+        return
+
+    for coordinate, snapshot in snapshots.items():
+        for component in components_by_coordinate[coordinate]:
+            _apply_snapshot(component, snapshot)
+
+    if no_network or liveness_only_snapshot:
+        return
+    endpoint = (
+        freshness_url
+        if freshness_url is not None
+        else resolve_freshness_url()
+    )
+    if not endpoint:
+        return
+
+    current_time = now or datetime.now(timezone.utc)
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+    else:
+        current_time = current_time.astimezone(timezone.utc)
+    stale_by_snapshot: dict[str, list[PackageCoordinate]] = defaultdict(list)
+    for coordinate, snapshot in snapshots.items():
+        parsed_snapshot_at = _parse_timestamp(snapshot.liveness_snapshot_at)
+        if parsed_snapshot_at is None:
+            continue
+        if current_time - parsed_snapshot_at > FRESHNESS_MAX_AGE:
+            snapshot_key = snapshot.liveness_snapshot_at or ""
+            stale_by_snapshot[snapshot_key].append(coordinate)
+
+    owns_client = client is None
+    http_client = client or httpx.Client(timeout=FRESHNESS_TIMEOUT)
+    try:
+        for snapshot_key, coordinates in stale_by_snapshot.items():
+            for batch in _batches(coordinates, FRESHNESS_BATCH_SIZE):
+                _apply_live_batch(
+                    http_client,
+                    endpoint,
+                    snapshot_key,
+                    batch,
+                    components_by_coordinate,
+                )
+    finally:
+        if owns_client:
+            http_client.close()
+
+
+def _component_coordinate(component: Any) -> PackageCoordinate | None:
+    component_type = _component_value(component, "component_type")
+    if hasattr(component_type, "value"):
+        component_type = component_type.value
+    if component_type != "dependency":
+        return None
+    metadata = _component_value(component, "metadata")
+    if not isinstance(metadata, dict):
+        return None
+    ecosystem = metadata.get("ecosystem")
+    name = _component_value(component, "name")
+    if not isinstance(ecosystem, str) or not isinstance(name, str):
+        return None
+    if not ecosystem.strip() or not name.strip():
+        return None
+    return package_coordinate(ecosystem, name)
+
+
+def _component_value(component: Any, key: str) -> Any:
+    if isinstance(component, dict):
+        return component.get(key)
+    return getattr(component, key, None)
+
+
+def _metadata(component: Any) -> dict[str, Any]:
+    if isinstance(component, dict):
+        value = component.setdefault("metadata", {})
+        if not isinstance(value, dict):
+            value = {}
+            component["metadata"] = value
+    else:
+        value = component.metadata
+    return cast(dict[str, Any], value)
+
+
+def _apply_snapshot(component: Any, snapshot: PackageSnapshot) -> None:
+    metadata = _metadata(component)
+    if snapshot.liveness_status is not None:
+        metadata["liveness_status"] = snapshot.liveness_status
+    if snapshot.liveness_snapshot_at is not None:
+        metadata["liveness_snapshot_at"] = snapshot.liveness_snapshot_at
+    if snapshot.certification is not None:
+        metadata["liveness_certification"] = snapshot.certification
+
+
+def _apply_live_batch(
+    client: httpx.Client,
+    endpoint: str,
+    snapshot_at: str,
+    coordinates: list[PackageCoordinate],
+    components_by_coordinate: dict[PackageCoordinate, list[Any]],
+) -> None:
+    payload = {
+        "snapshot_at": snapshot_at,
+        "packages": [
+            {"ecosystem": item.ecosystem, "name": item.name}
+            for item in coordinates
+        ],
+    }
+    try:
+        response = client.post(endpoint, json=payload)
+        if response.status_code == 429:
+            LOGGER.warning(
+                "Package freshness request was rate limited; "
+                "using snapshot data."
+            )
+            return
+        response.raise_for_status()
+        body = response.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        LOGGER.warning(
+            "Package freshness request failed; using snapshot data: %s",
+            exc,
+        )
+        return
+    if not isinstance(body, dict):
+        return
+    as_of = _parse_timestamp(body.get("as_of"))
+    snapshot_time = _parse_timestamp(snapshot_at)
+    if as_of is None or snapshot_time is None or as_of <= snapshot_time:
+        return
+    signals = body.get("signals")
+    if not isinstance(signals, list):
+        return
+    for signal in signals:
+        if not isinstance(signal, dict):
+            continue
+        ecosystem = signal.get("ecosystem")
+        name = signal.get("package_name")
+        if not isinstance(ecosystem, str) or not isinstance(name, str):
+            continue
+        coordinate = package_coordinate(ecosystem, name)
+        for component in components_by_coordinate.get(coordinate, []):
+            metadata = _metadata(component)
+            status = signal.get("liveness_status")
+            if isinstance(status, str) and status:
+                metadata["liveness_status"] = status
+            metadata["as_of"] = _isoformat(as_of)
+            observed_at = _parse_timestamp(signal.get("observed_at"))
+            if observed_at is not None:
+                metadata["liveness_observed_at"] = _isoformat(observed_at)
+            certification = signal.get("certification")
+            if isinstance(certification, dict):
+                metadata["liveness_certification"] = certification
+
+
+def _batches(
+    items: list[PackageCoordinate],
+    size: int,
+) -> Iterable[list[PackageCoordinate]]:
+    for index in range(0, len(items), size):
+        yield items[index:index + size]
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str) and value.strip():
+        try:
+            normalized = value.strip().replace("Z", "+00:00")
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _isoformat(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/aibom/src/aibom/package_freshness.py
+++ b/aibom/src/aibom/package_freshness.py
@@ -216,6 +216,7 @@ def _apply_live_batch(
     coordinates: list[PackageCoordinate],
     components_by_coordinate: dict[PackageCoordinate, list[Any]],
 ) -> None:
+    requested_coordinates = set(coordinates)
     payload = {
         "snapshot_at": snapshot_at,
         "packages": [
@@ -256,6 +257,8 @@ def _apply_live_batch(
         if not isinstance(ecosystem, str) or not isinstance(name, str):
             continue
         coordinate = package_coordinate(ecosystem, name)
+        if coordinate not in requested_coordinates:
+            continue
         for component in components_by_coordinate.get(coordinate, []):
             metadata = _metadata(component)
             status = signal.get("liveness_status")

--- a/aibom/src/aibom/package_registry.py
+++ b/aibom/src/aibom/package_registry.py
@@ -1,0 +1,205 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read package liveness snapshots from the selected DuckDB catalog."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+import duckdb
+import platformdirs
+
+from .db_loader import _load_manifest, _resolve_db_path
+
+
+@dataclass(frozen=True, order=True)
+class PackageCoordinate:
+    """A normalized package identity."""
+
+    ecosystem: str
+    name: str
+
+
+@dataclass(frozen=True)
+class PackageSnapshot:
+    """Liveness fields frozen into one knowledge-base build."""
+
+    coordinate: PackageCoordinate
+    liveness_status: str | None
+    liveness_snapshot_at: str | None
+    certification: dict[str, Any] | None
+
+
+def normalize_package_name(name: str, ecosystem: str) -> str:
+    """Normalize a package name using ecosystem comparison rules."""
+
+    normalized = name.strip()
+    normalized_ecosystem = ecosystem.strip().lower()
+    if normalized_ecosystem in {"pypi", "npm", "cargo", "rubygems", "nuget"}:
+        normalized = normalized.lower()
+    if normalized_ecosystem == "pypi":
+        normalized = re.sub(r"[-_.]+", "-", normalized)
+    return normalized
+
+
+def package_coordinate(ecosystem: str, name: str) -> PackageCoordinate:
+    """Construct a normalized package coordinate."""
+
+    normalized_ecosystem = ecosystem.strip().lower()
+    return PackageCoordinate(
+        ecosystem=normalized_ecosystem,
+        name=normalize_package_name(name, normalized_ecosystem),
+    )
+
+
+def resolve_package_catalog_path() -> Path | None:
+    """Resolve the selected catalog without requiring schema-v2 loading."""
+
+    env_path = os.environ.get("AIBOM_DB_PATH")
+    if env_path:
+        return Path(env_path).expanduser().resolve()
+
+    manifest, manifest_path = _load_manifest()
+    if not manifest:
+        return None
+
+    db_file = manifest.get("duckdb_file")
+    if isinstance(db_file, str) and db_file:
+        return _resolve_db_path(db_file, False, manifest_path)
+
+    duckdb_entry = manifest.get("duckdb")
+    if isinstance(duckdb_entry, dict):
+        filename = duckdb_entry.get("filename")
+        if isinstance(filename, str) and filename and manifest_path:
+            return (manifest_path.parent / filename).resolve()
+
+    kb_version = manifest.get("kb_version")
+    if isinstance(kb_version, str) and kb_version:
+        user_root = Path(platformdirs.user_data_dir("aibom"))
+        return user_root / "catalogs" / f"kb-{kb_version}.duckdb"
+    return None
+
+
+def read_package_snapshots(
+    db_path: Path | str | None,
+    coordinates: Iterable[PackageCoordinate],
+) -> dict[PackageCoordinate, PackageSnapshot]:
+    """Read only the package coordinates already present in the user's BOM."""
+
+    requested = sorted(set(coordinates))
+    if not requested or db_path is None:
+        return {}
+    path = Path(db_path).expanduser()
+    if not path.is_file():
+        return {}
+
+    try:
+        connection = duckdb.connect(str(path), read_only=True)
+    except duckdb.Error:
+        return {}
+
+    snapshots: dict[PackageCoordinate, PackageSnapshot] = {}
+    try:
+        tables = {
+            str(row[0])
+            for row in connection.execute("SHOW TABLES").fetchall()
+        }
+        if "package_catalog" not in tables:
+            return {}
+        columns = {
+            str(row[1])
+            for row in connection.execute(
+                "PRAGMA table_info('package_catalog')"
+            ).fetchall()
+        }
+        required = {
+            "package_name",
+            "ecosystem",
+            "liveness_status",
+            "liveness_snapshot_at",
+        }
+        if not required.issubset(columns):
+            return {}
+        certification_sql = (
+            "liveness_certification"
+            if "liveness_certification" in columns
+            else "NULL"
+        )
+        query = f"""
+            SELECT package_name, ecosystem, liveness_status,
+                   liveness_snapshot_at, {certification_sql}
+              FROM package_catalog
+             WHERE lower(ecosystem) = ?
+               AND lower(package_name) = ?
+             LIMIT 1
+        """
+        for coordinate in requested:
+            row = connection.execute(
+                query,
+                [coordinate.ecosystem, coordinate.name.lower()],
+            ).fetchone()
+            if row is None:
+                continue
+            matched = package_coordinate(str(row[1]), str(row[0]))
+            snapshots[coordinate] = PackageSnapshot(
+                coordinate=matched,
+                liveness_status=str(row[2]) if row[2] is not None else None,
+                liveness_snapshot_at=_to_iso8601(row[3]),
+                certification=_json_object(row[4]),
+            )
+    except duckdb.Error:
+        return {}
+    finally:
+        connection.close()
+    return snapshots
+
+
+def _to_iso8601(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        timestamp = value
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        return (
+            timestamp.astimezone(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+    if isinstance(value, date):
+        timestamp = datetime.combine(value, datetime.min.time(), timezone.utc)
+        return timestamp.isoformat().replace("+00:00", "Z")
+    text = str(value).strip()
+    return text or None
+
+
+def _json_object(value: object) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None

--- a/aibom/src/aibom/package_registry.py
+++ b/aibom/src/aibom/package_registry.py
@@ -145,27 +145,43 @@ def read_package_snapshots(
             if "liveness_certification" in columns
             else "NULL"
         )
-        query = f"""
-            SELECT package_name, ecosystem, liveness_status,
-                   liveness_snapshot_at, {certification_sql}
-              FROM package_catalog
-             WHERE lower(ecosystem) = ?
-               AND lower(package_name) = ?
-             LIMIT 1
-        """
-        for coordinate in requested:
-            row = connection.execute(
-                query,
-                [coordinate.ecosystem, coordinate.name.lower()],
-            ).fetchone()
-            if row is None:
+        connection.execute(
+            """
+            CREATE TEMP TABLE requested_packages (
+                ecosystem VARCHAR,
+                package_name VARCHAR
+            )
+            """
+        )
+        connection.executemany(
+            "INSERT INTO requested_packages VALUES (?, ?)",
+            [
+                (coordinate.ecosystem, coordinate.name.lower())
+                for coordinate in requested
+            ],
+        )
+        rows = connection.execute(
+            f"""
+            SELECT requested.ecosystem, requested.package_name,
+                   catalog.package_name, catalog.ecosystem,
+                   catalog.liveness_status, catalog.liveness_snapshot_at,
+                   {certification_sql}
+              FROM requested_packages AS requested
+              JOIN package_catalog AS catalog
+                ON lower(catalog.ecosystem) = requested.ecosystem
+               AND lower(catalog.package_name) = requested.package_name
+            """
+        ).fetchall()
+        for row in rows:
+            coordinate = package_coordinate(str(row[0]), str(row[1]))
+            if coordinate in snapshots:
                 continue
-            matched = package_coordinate(str(row[1]), str(row[0]))
+            matched = package_coordinate(str(row[3]), str(row[2]))
             snapshots[coordinate] = PackageSnapshot(
                 coordinate=matched,
-                liveness_status=str(row[2]) if row[2] is not None else None,
-                liveness_snapshot_at=_to_iso8601(row[3]),
-                certification=_json_object(row[4]),
+                liveness_status=str(row[4]) if row[4] is not None else None,
+                liveness_snapshot_at=_to_iso8601(row[5]),
+                certification=_json_object(row[6]),
             )
     except duckdb.Error:
         return {}

--- a/aibom/tests/test_package_freshness.py
+++ b/aibom/tests/test_package_freshness.py
@@ -199,6 +199,60 @@ def test_fresh_snapshot_does_not_call_network(tmp_path):
 
 
 @respx.mock
+def test_live_delta_only_updates_packages_in_request_batch(tmp_path):
+    path = _catalog(tmp_path)
+    connection = duckdb.connect(str(path))
+    try:
+        connection.execute(
+            """
+            INSERT INTO package_catalog
+            VALUES (?, ?, ?, CAST(? AS TIMESTAMP), CAST(? AS JSON))
+            """,
+            [
+                "fresh-package",
+                "pypi",
+                "maintained",
+                "2026-07-23T00:00:00Z",
+                '{"source_count": 2}',
+            ],
+        )
+    finally:
+        connection.close()
+    stale_component = _dependency()
+    fresh_component = _dependency("fresh-package")
+    respx.post(FRESHNESS_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "snapshot_version": "build-2",
+                "as_of": "2026-07-24T00:00:00Z",
+                "signals": [
+                    {
+                        "snapshot_version": "build-2",
+                        "ecosystem": "pypi",
+                        "package_name": "fresh-package",
+                        "liveness_status": "stale",
+                        "observed_at": "2026-07-23T12:00:00Z",
+                        "source": "registry",
+                        "certification": {"source_count": 3},
+                    }
+                ],
+            },
+        )
+    )
+
+    enrich_components(
+        [stale_component, fresh_component],
+        db_path=path,
+        freshness_url=FRESHNESS_URL,
+        now=datetime(2026, 7, 24, tzinfo=timezone.utc),
+    )
+
+    assert fresh_component.metadata["liveness_status"] == "maintained"
+    assert "as_of" not in fresh_component.metadata
+
+
+@respx.mock
 def test_rate_limit_falls_back_to_snapshot(tmp_path, caplog):
     path = _catalog(tmp_path)
     component = _dependency()

--- a/aibom/tests/test_package_freshness.py
+++ b/aibom/tests/test_package_freshness.py
@@ -1,0 +1,365 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import duckdb
+import httpx
+import pytest
+import respx
+from typer.main import get_command
+
+from aibom.cli import app
+from aibom.models import AIComponent
+from aibom.models.enums import AIComponentType
+from aibom.package_freshness import (
+    enrich_analysis_outputs,
+    enrich_components,
+    resolve_freshness_url,
+)
+from aibom.package_registry import (
+    package_coordinate,
+    read_package_snapshots,
+    resolve_package_catalog_path,
+)
+
+FRESHNESS_URL = "https://freshness.example.test/packages"
+
+
+def _catalog(tmp_path, *, snapshot_at: str = "2026-07-01T00:00:00Z"):
+    path = tmp_path / "catalog.duckdb"
+    connection = duckdb.connect(str(path))
+    try:
+        connection.execute(
+            """
+            CREATE TABLE package_catalog (
+                package_name VARCHAR NOT NULL,
+                ecosystem VARCHAR NOT NULL,
+                liveness_status VARCHAR,
+                liveness_snapshot_at TIMESTAMP,
+                liveness_certification JSON
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO package_catalog
+            VALUES (?, ?, ?, CAST(? AS TIMESTAMP), CAST(? AS JSON))
+            """,
+            [
+                "langchain",
+                "pypi",
+                "maintained",
+                snapshot_at,
+                '{"source_count": 2}',
+            ],
+        )
+    finally:
+        connection.close()
+    return path
+
+
+def _dependency(name: str = "langchain") -> AIComponent:
+    return AIComponent(
+        name=name,
+        component_type=AIComponentType.DEPENDENCY,
+        metadata={"ecosystem": "pypi"},
+    )
+
+
+def test_registry_reads_only_requested_package_snapshots(tmp_path):
+    path = _catalog(tmp_path)
+    requested = package_coordinate("pypi", "langchain")
+    missing = package_coordinate("pypi", "unrelated-package")
+
+    snapshots = read_package_snapshots(path, [requested, missing])
+
+    assert set(snapshots) == {requested}
+    assert snapshots[requested].liveness_status == "maintained"
+    assert snapshots[requested].liveness_snapshot_at == "2026-07-01T00:00:00Z"
+    assert snapshots[requested].certification == {"source_count": 2}
+
+
+def test_snapshot_only_enrichment_never_calls_network(tmp_path):
+    path = _catalog(tmp_path)
+    component = _dependency()
+
+    with respx.mock:
+        enrich_components(
+            [component],
+            db_path=path,
+            freshness_url=FRESHNESS_URL,
+            no_network=True,
+            now=datetime(2026, 7, 24, tzinfo=timezone.utc),
+        )
+
+    assert component.metadata["liveness_status"] == "maintained"
+    assert component.metadata["liveness_snapshot_at"] == (
+        "2026-07-01T00:00:00Z"
+    )
+    assert component.metadata["liveness_certification"] == {"source_count": 2}
+    assert "as_of" not in component.metadata
+
+
+def test_liveness_only_snapshot_never_calls_network(tmp_path):
+    path = _catalog(tmp_path)
+    component = _dependency()
+
+    with respx.mock:
+        enrich_components(
+            [component],
+            db_path=path,
+            freshness_url=FRESHNESS_URL,
+            liveness_only_snapshot=True,
+            now=datetime(2026, 7, 24, tzinfo=timezone.utc),
+        )
+
+    assert component.metadata["liveness_status"] == "maintained"
+    assert "as_of" not in component.metadata
+
+
+@respx.mock
+def test_stale_snapshot_uses_anonymous_live_delta_for_bom_packages(tmp_path):
+    path = _catalog(tmp_path)
+    component = _dependency()
+    unrelated = _dependency("unrelated-package")
+    route = respx.post(FRESHNESS_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "snapshot_version": "build-2",
+                "as_of": "2026-07-24T00:00:00Z",
+                "signals": [
+                    {
+                        "snapshot_version": "build-2",
+                        "ecosystem": "pypi",
+                        "package_name": "langchain",
+                        "liveness_status": "stale",
+                        "observed_at": "2026-07-23T12:00:00Z",
+                        "source": "registry",
+                        "certification": {"source_count": 3},
+                    }
+                ],
+            },
+        )
+    )
+
+    enrich_components(
+        [component, unrelated],
+        db_path=path,
+        freshness_url=FRESHNESS_URL,
+        now=datetime(2026, 7, 24, tzinfo=timezone.utc),
+    )
+
+    assert route.called
+    request = route.calls.last.request
+    assert json.loads(request.content) == {
+        "snapshot_at": "2026-07-01T00:00:00Z",
+        "packages": [{"ecosystem": "pypi", "name": "langchain"}],
+    }
+    assert "authorization" not in request.headers
+    assert component.metadata["liveness_status"] == "stale"
+    assert component.metadata["as_of"] == "2026-07-24T00:00:00Z"
+    assert component.metadata["liveness_observed_at"] == (
+        "2026-07-23T12:00:00Z"
+    )
+    assert "liveness_status" not in unrelated.metadata
+
+
+def test_fresh_snapshot_does_not_call_network(tmp_path):
+    path = _catalog(tmp_path, snapshot_at="2026-07-23T00:00:00Z")
+    component = _dependency()
+
+    with respx.mock:
+        enrich_components(
+            [component],
+            db_path=path,
+            freshness_url=FRESHNESS_URL,
+            now=datetime(2026, 7, 24, tzinfo=timezone.utc),
+        )
+
+    assert component.metadata["liveness_status"] == "maintained"
+    assert "as_of" not in component.metadata
+
+
+@respx.mock
+def test_rate_limit_falls_back_to_snapshot(tmp_path, caplog):
+    path = _catalog(tmp_path)
+    component = _dependency()
+    respx.post(FRESHNESS_URL).mock(
+        return_value=httpx.Response(429, headers={"Retry-After": "60"})
+    )
+
+    enrich_components(
+        [component],
+        db_path=path,
+        freshness_url=FRESHNESS_URL,
+        now=datetime(2026, 7, 24, tzinfo=timezone.utc),
+    )
+
+    assert component.metadata["liveness_status"] == "maintained"
+    assert "as_of" not in component.metadata
+    assert "rate limited" in caplog.text
+
+
+@respx.mock
+def test_timeout_falls_back_to_snapshot(tmp_path, caplog):
+    path = _catalog(tmp_path)
+    component = _dependency()
+    respx.post(FRESHNESS_URL).mock(
+        side_effect=httpx.ReadTimeout("synthetic timeout")
+    )
+
+    enrich_components(
+        [component],
+        db_path=path,
+        freshness_url=FRESHNESS_URL,
+        now=datetime(2026, 7, 24, tzinfo=timezone.utc),
+    )
+
+    assert component.metadata["liveness_status"] == "maintained"
+    assert "as_of" not in component.metadata
+    assert "using snapshot data" in caplog.text
+
+
+def test_legacy_catalog_without_package_table_is_a_no_op(tmp_path):
+    path = tmp_path / "legacy.duckdb"
+    connection = duckdb.connect(str(path))
+    connection.execute("CREATE TABLE component_catalog (id VARCHAR)")
+    connection.close()
+    component = _dependency()
+
+    with respx.mock:
+        enrich_components(
+            [component],
+            db_path=path,
+            freshness_url=FRESHNESS_URL,
+            now=datetime(2026, 7, 24, tzinfo=timezone.utc),
+        )
+
+    assert component.metadata == {"ecosystem": "pypi"}
+
+
+def test_cached_dictionary_outputs_receive_snapshot_enrichment(tmp_path):
+    path = _catalog(tmp_path)
+    outputs = {
+        "source": {
+            "_v2": True,
+            "components": [
+                {
+                    "name": "langchain",
+                    "component_type": "dependency",
+                    "metadata": {"ecosystem": "pypi"},
+                }
+            ],
+            "relationships": [],
+        }
+    }
+
+    enrich_analysis_outputs(
+        outputs,
+        db_path=path,
+        no_network=True,
+    )
+
+    metadata = outputs["source"]["components"][0]["metadata"]
+    assert metadata["liveness_status"] == "maintained"
+    assert metadata["liveness_snapshot_at"] == "2026-07-01T00:00:00Z"
+
+
+@pytest.mark.parametrize(
+    "component",
+    [
+        AIComponent(
+            name="langchain",
+            component_type=AIComponentType.MODEL,
+            metadata={"ecosystem": "pypi"},
+        ),
+        AIComponent(
+            name="langchain",
+            component_type=AIComponentType.DEPENDENCY,
+            metadata={},
+        ),
+    ],
+)
+def test_non_package_components_are_not_queried(tmp_path, component):
+    path = _catalog(tmp_path)
+
+    with respx.mock:
+        enrich_components(
+            [component],
+            db_path=path,
+            freshness_url=FRESHNESS_URL,
+            now=datetime(2026, 7, 24, tzinfo=timezone.utc),
+        )
+
+    assert "liveness_status" not in component.metadata
+
+
+def test_manifest_advertises_catalog_and_freshness_endpoint(
+    monkeypatch,
+    tmp_path,
+):
+    catalog = tmp_path / "candidate.duckdb"
+    catalog.touch()
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "freshness_api": FRESHNESS_URL,
+                "duckdb": {"filename": catalog.name},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AIBOM_MANIFEST_PATH", str(manifest))
+    monkeypatch.delenv("AIBOM_DB_PATH", raising=False)
+    monkeypatch.delenv("CISCO_AIBOM_FRESHNESS_URL", raising=False)
+
+    assert resolve_package_catalog_path() == catalog
+    assert resolve_freshness_url() == FRESHNESS_URL
+
+
+def test_freshness_url_environment_override_wins(monkeypatch, tmp_path):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps({"freshness_api": "https://manifest.example.test"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AIBOM_MANIFEST_PATH", str(manifest))
+    monkeypatch.setenv(
+        "CISCO_AIBOM_FRESHNESS_URL",
+        "https://override.example.test",
+    )
+
+    assert resolve_freshness_url() == "https://override.example.test"
+
+
+def test_analyze_registers_snapshot_controls():
+    root_command = get_command(app)
+    analyze_command = root_command.commands["analyze"]
+    option_names = {
+        option
+        for parameter in analyze_command.params
+        for option in parameter.opts
+    }
+
+    assert "--no-network" in option_names
+    assert "--liveness-only-snapshot" in option_names

--- a/aibom/tests/test_package_freshness.py
+++ b/aibom/tests/test_package_freshness.py
@@ -96,6 +96,38 @@ def test_registry_reads_only_requested_package_snapshots(tmp_path):
     assert snapshots[requested].certification == {"source_count": 2}
 
 
+def test_registry_reads_multiple_package_snapshots_in_one_batch(tmp_path):
+    path = _catalog(tmp_path)
+    connection = duckdb.connect(str(path))
+    try:
+        connection.execute(
+            """
+            INSERT INTO package_catalog
+            VALUES (?, ?, ?, CAST(? AS TIMESTAMP), CAST(? AS JSON))
+            """,
+            [
+                "fastapi",
+                "pypi",
+                "maintained",
+                "2026-07-02T00:00:00Z",
+                '{"source_count": 3}',
+            ],
+        )
+    finally:
+        connection.close()
+    requested = {
+        package_coordinate("pypi", "langchain"),
+        package_coordinate("pypi", "fastapi"),
+    }
+
+    snapshots = read_package_snapshots(path, requested)
+
+    assert set(snapshots) == requested
+    assert snapshots[package_coordinate("pypi", "fastapi")].certification == {
+        "source_count": 3
+    }
+
+
 def test_snapshot_only_enrichment_never_calls_network(tmp_path):
     path = _catalog(tmp_path)
     component = _dependency()

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -98,6 +98,11 @@ the distinction between sanitized telemetry and raw full-trajectory diagnostics.
 | `--cache-dir` | Shared cache root. Defaults to `~/.aibom/cache` and stores `scan`, `agentic`, `org`, `model`, and `packages` caches beneath it. |
 | `--include-code-snippets` / `--no-code-snippets` | Include raw code snippets in per-finding decision annotations. Off by default. |
 | `--component-summary` / `--no-component-summary` | When `--output-format=json`, include a flat `component_summary` key in the report listing each non-test component as `{component_type, name, file_path, line_number}`, grouped by source and sorted by `(component_type, name)`. Intended for quick human review and demos; the full structured output is unchanged. Off by default. |
+| `--no-network` | Disable anonymous package-liveness freshness requests while retaining local snapshot fields. Also available as `AIBOM_NO_NETWORK`. |
+| `--liveness-only-snapshot` | Use only package-liveness fields frozen into the selected knowledge base. Also available as `AIBOM_LIVENESS_ONLY_SNAPSHOT`. |
+
+See [Package liveness freshness](package-freshness.md) for the snapshot,
+privacy, retry, and output-field contract.
 
 ### Examples
 
@@ -450,6 +455,9 @@ cisco-aibom plugin list
 | `AIBOM_DB_PATH` | Override path to the DuckDB catalog file. |
 | `AIBOM_DB_SHA256` | Expected SHA-256 checksum for the DuckDB catalog. |
 | `AIBOM_MANIFEST_PATH` | Override path to `manifest.json`. |
+| `AIBOM_NO_NETWORK` | Disable package-liveness freshness requests. |
+| `AIBOM_LIVENESS_ONLY_SNAPSHOT` | Use only package-liveness snapshot fields. |
+| `CISCO_AIBOM_FRESHNESS_URL` | Optional package-freshness endpoint override. No default. |
 | `CISCO_AI_DEFENSE_API_KEY` | API key for KB request commands. |
 | `CISCO_AI_DEFENSE_API_BASE` | Regional API base URL for KB request commands. Same regional hosts as `AIBOM_POST_URL` (e.g. `https://api.security.cisco.com`, `https://api.eu.security.cisco.com`). No default. |
 | `CISCO_AIBOM_MANIFEST_URL` | KB manifest URL for `kb download` / `kb check`. No default. |

--- a/docs/package-freshness.md
+++ b/docs/package-freshness.md
@@ -1,0 +1,37 @@
+# Package liveness freshness
+
+When a selected knowledge base contains a `package_catalog`, AI BOM adds its
+frozen liveness fields to dependency components that were already discovered
+in the user's scan. It does not enumerate or probe packages that are absent
+from the AI BOM.
+
+The component `metadata` object may contain:
+
+- `liveness_status`
+- `liveness_snapshot_at`
+- `liveness_certification`
+- `as_of` and `liveness_observed_at` when a newer live delta is returned
+
+The frozen snapshot is always the fallback. If its timestamp is more than
+seven days old and the manifest advertises `freshness_api`, the CLI may send
+an anonymous request containing only the ecosystem and normalized name of the
+packages already present in the scan. Requests contain at most 100 packages.
+No tenant credential or authorization header is sent. Timeouts, rate limits,
+invalid responses, and other endpoint failures leave the frozen snapshot in
+place and do not fail the scan.
+
+Use either of these options to prevent live freshness requests:
+
+```bash
+cisco-aibom analyze ./my-app --no-network ...
+cisco-aibom analyze ./my-app --liveness-only-snapshot ...
+```
+
+For this feature, the options are equivalent: both retain local snapshot
+fields and suppress the freshness request. They are also available through
+`AIBOM_NO_NETWORK` and `AIBOM_LIVENESS_ONLY_SNAPSHOT`.
+
+`CISCO_AIBOM_FRESHNESS_URL` can explicitly select a freshness endpoint for
+testing or a custom knowledge-base distribution. Otherwise the CLI uses the
+`freshness_api` value from the selected manifest. No default endpoint is
+shipped.


### PR DESCRIPTION
## Summary

- Read frozen package liveness fields from the selected DuckDB in one batched lookup, only for dependency coordinates already present in the AI BOM.
- Request anonymous live deltas only when the snapshot is older than seven days, in batches of at most 100 packages.
- Scope every returned delta to the exact requested batch and snapshot boundary.
- Surface liveness status, snapshot timestamp, certification, and live as-of metadata when a newer delta exists.
- Add no-network and snapshot-only controls.
- Fall back to the frozen snapshot on timeouts, rate limits, invalid responses, missing package tables, or unavailable endpoints.
- Apply freshness after scan-cache persistence so live state does not contaminate deterministic cache entries.

## Stack and merge gate

This is the second independently reviewed layer of the CLI 2.0 stack and is currently based on PR #74. The distribution and integrity layer will be stacked above this branch.

Keep this PR based on `kb-v2-compat` until PR #74 merges into the protected `release-2.0.0` branch. Then retarget this PR to `release-2.0.0`, verify that its diff contains only the package-freshness layer, and require its checks and approval before merging it into the release branch. The upper-layer pull request must then be retargeted and rechecked in the same way.

The complete end-to-end candidate gates the final `release-2.0.0` to `main` merge and stable 2.0.0 publication; it does not gate this reviewed layer's integration into the release branch.

## Privacy and network behavior

The caller never enumerates packages outside the user scan. Freshness requests contain only ecosystem and normalized package name for packages already in the AI BOM, and no authorization header is sent. No endpoint is shipped by default.

## Validation

- Full repository suite: 2,465 passed.
- Focused compatibility and freshness suites: 162 passed.
- New files pass flake8 and mypy.
- CI passes on Python 3.11, 3.12, and 3.13; CodeQL and version sync pass.
- Public-repository hygiene scan passed; all freshness fixtures and endpoints are synthetic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added package-liveness information to dependency components using local knowledge-base snapshots.
  - Refreshes stale package data anonymously when an endpoint is available, while preserving snapshot data if requests fail.
  - Added `--no-network` and `--liveness-only-snapshot` options for controlling freshness requests.
  - Added environment-variable configuration for network behavior and freshness endpoint overrides.

- **Documentation**
  - Documented package freshness behavior, fallback handling, configuration options, and new CLI controls.
  - Updated the CLI reference and README with the new settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
