### PR TITLE
feat(scanners): discover Claude skills under .claude/skills

### DIFF
--- a/aibom/src/aibom/scanners/skill_detector.py
+++ b/aibom/src/aibom/scanners/skill_detector.py
@@ -285,6 +285,16 @@ def _collect_from_root(
             components.append(c)
             scan_roots.append(str(skill_md.parent.resolve()))
 
+    for skill_md in root.glob("**/.claude/skills/*/SKILL.md"):
+        if _is_excluded(skill_md, scan_root, spec):
+            continue
+        c = _component_for_skill_md(
+            skill_md, "claude", scan_root, spec, seen
+        )
+        if c:
+            components.append(c)
+            scan_roots.append(str(skill_md.parent.resolve()))
+
     for plugins in root.glob("**/.claude/plugins"):
         if not plugins.is_dir() or _is_excluded(plugins, scan_root, spec):
             continue

--- a/aibom/tests/test_skill_detector.py
+++ b/aibom/tests/test_skill_detector.py
@@ -30,13 +30,14 @@ class TestSkillDetector:
         assert len(comps) == 1
         assert comps[0].skill_format == "codex"
 
-    def test_claude_skill_skill_md(self, tmp_path: Path) -> None:
+        def test_claude_skill_skill_md(self, tmp_path: Path) -> None:
         md = "# Claude Skill\n\nDesc.\n"
         comps, _ = run_scanner(
             SkillDetector, tmp_path, {"proj/.claude/skills/my-skill/SKILL.md": md}
         )
         assert len(comps) == 1
         assert comps[0].skill_format == "claude"
+        assert comps[0].component_type == AIComponentType.SKILL
         assert comps[0].name == "Claude Skill"
 
     def test_claude_skill_nested_skill_md_not_double_counted(

--- a/aibom/tests/test_skill_detector.py
+++ b/aibom/tests/test_skill_detector.py
@@ -30,6 +30,32 @@ class TestSkillDetector:
         assert len(comps) == 1
         assert comps[0].skill_format == "codex"
 
+        def test_claude_skill_skill_md(self, tmp_path: Path) -> None:
+        md = "# Claude Skill\n\nDesc.\n"
+        comps, _ = run_scanner(
+            SkillDetector, tmp_path, {"proj/.claude/skills/my-skill/SKILL.md": md}
+        )
+        assert len(comps) == 1
+        assert comps[0].skill_format == "claude"
+        assert comps[0].name == "Claude Skill"
+
+    def test_claude_skill_nested_skill_md_not_double_counted(
+        self, tmp_path: Path
+    ) -> None:
+        # Claude skills are single-level (.claude/skills/<name>/SKILL.md). A
+        # nested SKILL.md inside a skill's reference subdir must not register a
+        # second component.
+        comps, _ = run_scanner(
+            SkillDetector,
+            tmp_path,
+            {
+                "proj/.claude/skills/my-skill/SKILL.md": "# Real Skill\n\nDesc.\n",
+                "proj/.claude/skills/my-skill/references/SKILL.md": "# Nested\n",
+            },
+        )
+        assert len(comps) == 1
+        assert comps[0].name == "Real Skill"
+
     def test_agents_md_format(self, tmp_path: Path) -> None:
         comps, _ = run_scanner(
             SkillDetector, tmp_path, {"AGENTS.md": "# Repo Agents\n\nRules here.\n"}

--- a/aibom/tests/test_skill_detector.py
+++ b/aibom/tests/test_skill_detector.py
@@ -30,7 +30,7 @@ class TestSkillDetector:
         assert len(comps) == 1
         assert comps[0].skill_format == "codex"
 
-        def test_claude_skill_skill_md(self, tmp_path: Path) -> None:
+    def test_claude_skill_skill_md(self, tmp_path: Path) -> None:
         md = "# Claude Skill\n\nDesc.\n"
         comps, _ = run_scanner(
             SkillDetector, tmp_path, {"proj/.claude/skills/my-skill/SKILL.md": md}


### PR DESCRIPTION
## Summary

`SkillDetector` already enumerated the `skills/*/SKILL.md` layout for
Cursor (`.cursor/skills/`) and Codex (`.codex/skills/`), but for Claude it
only scanned `.claude/plugins`. Repositories using the standard Claude
Agent Skills layout — `.claude/skills/<name>/SKILL.md` — had **zero**
skills detected.

This adds a single-level glob for that layout, emitting the skills as
`claude` skill components, bringing Claude to parity with the existing
Cursor and Codex skill discovery.

## Changes

- Detect `**/.claude/skills/*/SKILL.md` and emit `claude` skill components.
- Add a positive test and a negative test asserting a nested `SKILL.md`
  (e.g. inside a skill's `references/` subdir) is not double-counted.

## Testing

- `uv run pytest tests/test_skill_detector.py -v` — all tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery and conversion of Claude skills from `.claude/skills/<name>/` directories into compatible skill components.
  * Skill names are derived from their definitions, and only the primary skill files are recognized during discovery.

* **Tests**
  * Added coverage for Claude skill detection, naming, classification, and exclusion of nested reference files from component discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->