### PR TITLE
fix(agentic): report degraded findings honestly

### DIFF
--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -2098,16 +2098,26 @@ class _DecisionMemo:
         if c_after is None:
             self._verdicts[k] = {"action": "remove"}
         elif c_after.component_type != c_before.component_type:
-            self._verdicts[k] = {
+            verdict: dict[str, Any] = {
                 "action": "reclassify",
                 "new_type": c_after.component_type.value,
                 "heuristic_confidence": c_after.heuristic_confidence,
             }
+            if c_after.agentic_confidence is not None:
+                verdict["agentic_confidence"] = c_after.agentic_confidence
+            if c_after.decision_annotation is not None:
+                verdict["decision_annotation"] = c_after.decision_annotation
+            self._verdicts[k] = verdict
         else:
-            self._verdicts[k] = {
+            verdict = {
                 "action": "keep",
                 "heuristic_confidence": c_after.heuristic_confidence,
             }
+            if c_after.agentic_confidence is not None:
+                verdict["agentic_confidence"] = c_after.agentic_confidence
+            if c_after.decision_annotation is not None:
+                verdict["decision_annotation"] = c_after.decision_annotation
+            self._verdicts[k] = verdict
 
     def lookup(self, c: AIComponent) -> dict[str, Any] | None:
         k = self._key(c)
@@ -2151,6 +2161,12 @@ class _DecisionMemo:
                             "heuristic_confidence": verdict.get(
                                 "heuristic_confidence", c.heuristic_confidence
                             ),
+                            "agentic_confidence": verdict.get(
+                                "agentic_confidence", c.agentic_confidence
+                            ),
+                            "decision_annotation": verdict.get(
+                                "decision_annotation"
+                            ),
                             "needs_agentic": False,
                         }
                     )
@@ -2161,6 +2177,12 @@ class _DecisionMemo:
                         update={
                             "heuristic_confidence": verdict.get(
                                 "heuristic_confidence", c.heuristic_confidence
+                            ),
+                            "agentic_confidence": verdict.get(
+                                "agentic_confidence", c.agentic_confidence
+                            ),
+                            "decision_annotation": verdict.get(
+                                "decision_annotation"
                             ),
                             "needs_agentic": False,
                         }
@@ -2178,7 +2200,7 @@ def _degraded_batch_components(
     hint: str,
 ) -> list[AIComponent]:
     return [
-        c.model_copy(update={"needs_agentic": False, "agentic_hint": hint})
+        c.model_copy(update={"needs_agentic": True, "agentic_hint": hint})
         for c in batch
     ]
 
@@ -3676,12 +3698,12 @@ def _run_tier(
         time.sleep(_RETRY_COOLDOWN_S)
 
         retry_batch_size = batch_size
-        has_recursion_failures = any(
-            c_orig.agentic_hint == "batch_recursion_limit"
+        has_batch_size_sensitive_failures = any(
+            c_orig.agentic_hint in {"batch_recursion_limit", "batch_timeout"}
             for c_orig in enriched
             if c_orig.agentic_hint in _RETRYABLE_HINTS
         )
-        if has_recursion_failures:
+        if has_batch_size_sensitive_failures:
             retry_batch_size = max(1, batch_size // 2)
 
         retry_batches = _locality_aware_batches(retry_candidates, retry_batch_size)

--- a/aibom/src/aibom/agentic/agent.py
+++ b/aibom/src/aibom/agentic/agent.py
@@ -2106,7 +2106,15 @@ class _DecisionMemo:
             if c_after.agentic_confidence is not None:
                 verdict["agentic_confidence"] = c_after.agentic_confidence
             if c_after.decision_annotation is not None:
-                verdict["decision_annotation"] = c_after.decision_annotation
+                verdict["decision_annotation"] = (
+                    c_after.decision_annotation.model_copy(
+                        deep=True,
+                        update={
+                            "evidence_locations": [],
+                            "code_snippet": None,
+                        },
+                    )
+                )
             self._verdicts[k] = verdict
         else:
             verdict = {
@@ -2116,7 +2124,15 @@ class _DecisionMemo:
             if c_after.agentic_confidence is not None:
                 verdict["agentic_confidence"] = c_after.agentic_confidence
             if c_after.decision_annotation is not None:
-                verdict["decision_annotation"] = c_after.decision_annotation
+                verdict["decision_annotation"] = (
+                    c_after.decision_annotation.model_copy(
+                        deep=True,
+                        update={
+                            "evidence_locations": [],
+                            "code_snippet": None,
+                        },
+                    )
+                )
             self._verdicts[k] = verdict
 
     def lookup(self, c: AIComponent) -> dict[str, Any] | None:

--- a/aibom/src/aibom/agentic/middleware.py
+++ b/aibom/src/aibom/agentic/middleware.py
@@ -777,6 +777,59 @@ def _normalize_ws(text: str) -> str:
     return " ".join(text.split())
 
 
+def _unique_snippet_line_range(
+    file_text: str,
+    snippet: str,
+) -> tuple[int, int] | None:
+    """Return the unique whitespace-normalized snippet location in a file."""
+
+    normalized_parts: list[str] = []
+    token_spans: list[tuple[int, int, int]] = []
+    normalized_length = 0
+    for line_number, line in enumerate(file_text.splitlines(), 1):
+        for match in re.finditer(r"\S+", line):
+            token = match.group(0)
+            if normalized_parts:
+                normalized_length += 1
+            start = normalized_length
+            normalized_parts.append(token)
+            normalized_length += len(token)
+            token_spans.append((start, normalized_length, line_number))
+
+    normalized_file = " ".join(normalized_parts)
+    normalized_snippet = _normalize_ws(snippet)
+    matches: list[tuple[int, int]] = []
+    offset = 0
+    while normalized_snippet:
+        match_start = normalized_file.find(normalized_snippet, offset)
+        if match_start < 0:
+            break
+        match_end = match_start + len(normalized_snippet) - 1
+        start_line = next(
+            (
+                line_number
+                for start, end, line_number in token_spans
+                if start <= match_start < end
+            ),
+            None,
+        )
+        end_line = next(
+            (
+                line_number
+                for start, end, line_number in token_spans
+                if start <= match_end < end
+            ),
+            None,
+        )
+        if start_line is not None and end_line is not None:
+            matches.append((start_line, end_line))
+        offset = match_start + 1
+
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
 def _verify_agent_evidence(
     raw: Any,
     *,
@@ -844,24 +897,44 @@ def _verify_agent_evidence(
     except OSError:
         return False, "file not readable"
 
-    lines = file_text.splitlines()
-    total = len(lines)
     start = raw.get("definition_start_line") or 0
     end = raw.get("definition_end_line") or 0
     if not isinstance(start, int) or not isinstance(end, int):
-        return False, "invalid line range"
-    if start < 1 or end < start or end > total:
         return False, "invalid line range"
 
     snippet = raw.get("evidence_snippet") or ""
     if not isinstance(snippet, str) or not snippet.strip():
         return False, "missing evidence_snippet"
 
-    window = "\n".join(lines[start - 1:end])
-    if _normalize_ws(snippet) not in _normalize_ws(window):
-        return False, "snippet not found in cited range"
+    lines = file_text.splitlines()
+    total = len(lines)
+    range_is_valid = start >= 1 and end >= start and end <= total
+    if range_is_valid:
+        window = "\n".join(lines[start - 1:end])
+        if _normalize_ws(snippet) in _normalize_ws(window):
+            return True, ""
 
-    return True, ""
+    repaired = _unique_snippet_line_range(file_text, snippet)
+    if repaired is not None:
+        raw["definition_start_line"], raw["definition_end_line"] = repaired
+        _LOGGER.info(
+            "Repaired agent evidence line range for %s: %s-%s -> %s-%s",
+            definition_file,
+            start,
+            end,
+            repaired[0],
+            repaired[1],
+        )
+        return True, ""
+
+    normalized_file = _normalize_ws(file_text)
+    normalized_snippet = _normalize_ws(snippet)
+    if normalized_file.count(normalized_snippet) > 1:
+        return False, "snippet match is ambiguous in cited file"
+    if not range_is_valid:
+        return False, "invalid line range"
+    return False, "snippet not found in cited file"
+
 
 
 def _normalize_endpoint_model_name(comp: AIComponent) -> AIComponent:
@@ -898,6 +971,9 @@ def _reject_class_name_models(
     """Remove ``model`` components whose name is a class name, not a model ID."""
     result: list[AIComponent] = []
     for comp in components:
+        if comp.agentic_hint:
+            result.append(comp)
+            continue
         if (
             comp.component_type == AIComponentType.MODEL
             and _is_class_name_not_model_id(comp.name)
@@ -954,6 +1030,9 @@ def _drop_env_placeholder_identifiers(
     """
     result: list[AIComponent] = []
     for comp in components:
+        if comp.agentic_hint:
+            result.append(comp)
+            continue
         if comp.component_type not in _ENV_PLACEHOLDER_IDENTIFIER_TYPES:
             result.append(comp)
             continue
@@ -987,6 +1066,9 @@ def _remove_unresolved_embedders(
 
     result: list[AIComponent] = []
     for comp in components:
+        if comp.agentic_hint:
+            result.append(comp)
+            continue
         if comp.component_type == AIComponentType.EMBEDDING:
             has_model = bool(comp.model_name or comp.embedding_model)
             has_rel = comp.name in has_embedding_rel
@@ -1434,6 +1516,10 @@ class AIBOMScannerMiddleware:
                 component_name=name,
                 component_type=comp_type.value,
             )
+            if comp_type in _AGENT_CLASSIFICATION_TYPES:
+                agent_evidence = item.get("agent_evidence")
+                if isinstance(agent_evidence, dict):
+                    sanitized_meta["agent_evidence"] = agent_evidence
             probe = AIComponent(
                 name=name,
                 component_type=comp_type,

--- a/aibom/src/aibom/agentic/middleware.py
+++ b/aibom/src/aibom/agentic/middleware.py
@@ -363,6 +363,21 @@ def _sanitize_metadata(
     return cleaned
 
 
+def _agent_evidence_metadata(raw: dict[str, Any]) -> dict[str, Any]:
+    """Persist verified evidence coordinates without copying raw source text."""
+
+    return {
+        key: raw[key]
+        for key in (
+            "pattern",
+            "definition_file",
+            "definition_start_line",
+            "definition_end_line",
+        )
+        if key in raw
+    }
+
+
 _DOCSTRING_RE = re.compile(r'("""|\'\'\')(.*?)\1', re.DOTALL)
 _BLOCK_COMMENT_RE = re.compile(r'/\*.*?\*/', re.DOTALL)
 # Line comments must start at the line (possibly after whitespace). This
@@ -1381,7 +1396,9 @@ class AIBOMScannerMiddleware:
                     merged_meta = dict(comp.metadata)
                     reclass_evidence = reclassify_evidence.get(comp.instance_id)
                     if reclass_evidence is not None:
-                        merged_meta["agent_evidence"] = reclass_evidence
+                        merged_meta["agent_evidence"] = (
+                            _agent_evidence_metadata(reclass_evidence)
+                        )
                     comp = comp.model_copy(update={
                         "component_type": new_type,
                         "needs_agentic": False,
@@ -1413,7 +1430,9 @@ class AIBOMScannerMiddleware:
                         _LOGGER.warning("Invalid component_type '%s' in enrichment for %s", raw_type, comp.instance_id)
                 enrich_evidence = enrichment_evidence.get(comp.instance_id)
                 if enrich_evidence is not None:
-                    merged_meta["agent_evidence"] = enrich_evidence
+                    merged_meta["agent_evidence"] = (
+                        _agent_evidence_metadata(enrich_evidence)
+                    )
                 comp = comp.model_copy(update={
                     **upd,
                     "metadata": merged_meta,
@@ -1519,7 +1538,9 @@ class AIBOMScannerMiddleware:
             if comp_type in _AGENT_CLASSIFICATION_TYPES:
                 agent_evidence = item.get("agent_evidence")
                 if isinstance(agent_evidence, dict):
-                    sanitized_meta["agent_evidence"] = agent_evidence
+                    sanitized_meta["agent_evidence"] = (
+                        _agent_evidence_metadata(agent_evidence)
+                    )
             probe = AIComponent(
                 name=name,
                 component_type=comp_type,

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -1202,6 +1202,13 @@ def _source_outcomes_from_report(report: Dict[str, Any]) -> Dict[str, Dict[str, 
             "last_generated_at": summary.get("last_generated_at"),
             "assets_discovered": summary.get("assets_discovered"),
         }
+        for key in (
+            "agentic_status",
+            "agentic_degraded_count",
+            "agentic_degradation_reasons",
+        ):
+            if key in summary:
+                outcomes[source_path][key] = summary[key]
     return outcomes
 
 

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -370,21 +370,54 @@ def _require_supported_cache_type(cache_type: str) -> None:
     raise typer.Exit(code=1)
 
 
+def _org_cache_has_agentic_outcome(cached_sr: Any) -> bool:
+    """Return whether an org-cache entry carries the current status contract."""
+
+    metadata = getattr(cached_sr, "metadata", None)
+    if not isinstance(metadata, dict):
+        return False
+    return (
+        metadata.get("agentic_status") in {"success", "degraded", "skipped"}
+        and isinstance(metadata.get("agentic_degraded_count"), int)
+        and isinstance(metadata.get("agentic_degradation_reasons"), dict)
+    )
+
+
 def _v2_output_from_org_cache(cached_sr: Any) -> Dict[str, Any]:
     merged_components: list = []
     merged_rels: list = []
     for s in cached_sr.sources:
         merged_components.extend(s.components)
         merged_rels.extend(s.relationships)
+    cached_metadata = (
+        cached_sr.metadata if isinstance(cached_sr.metadata, dict) else {}
+    )
+    cached_status = cached_metadata.get("agentic_status", "skipped")
+    if cached_status not in {"success", "degraded", "skipped"}:
+        cached_status = "skipped"
+    cached_degraded_count = cached_metadata.get(
+        "agentic_degraded_count",
+        0,
+    )
+    cached_reasons = cached_metadata.get(
+        "agentic_degradation_reasons",
+        {},
+    )
     return {
         "_v2": True,
         "components": merged_components,
         "relationships": merged_rels,
         "_agentic_risk_flags": [],
         "_agentic_candidate_count": 0,
-        "_agentic_status": "skipped",
-        "_agentic_degraded_count": 0,
-        "_agentic_degradation_reasons": {},
+        "_agentic_status": cached_status,
+        "_agentic_degraded_count": (
+            cached_degraded_count
+            if isinstance(cached_degraded_count, int)
+            else 0
+        ),
+        "_agentic_degradation_reasons": (
+            dict(cached_reasons) if isinstance(cached_reasons, dict) else {}
+        ),
     }
 
 
@@ -2292,6 +2325,14 @@ def analyze(
 
                 org_cache = OrgCache()
                 cached_sr = org_cache.get_cached(str(path_to_analyze.resolve()))
+                if cached_sr is not None and not _org_cache_has_agentic_outcome(
+                    cached_sr
+                ):
+                    console.print(
+                        f"[yellow]Ignoring legacy org cache entry[/] for "
+                        f"{source}: agentic outcome is unavailable"
+                    )
+                    cached_sr = None
                 if cached_sr is not None:
                     console.print(
                         f"[green]Org cache hit[/] for {source} " f"(~/.aibom/cache/org)"
@@ -2453,7 +2494,16 @@ def analyze(
                 org_cache.store(
                     str(path_to_analyze.resolve()),
                     ScanResult(
-                        metadata=run_metadata,
+                        metadata={
+                            **run_metadata,
+                            "agentic_status": result.agentic_status,
+                            "agentic_degraded_count": (
+                                result.agentic_degraded_count
+                            ),
+                            "agentic_degradation_reasons": dict(
+                                result.agentic_degradation_reasons
+                            ),
+                        },
                         sources=[
                             SourceResult(
                                 path=scan_path,

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -383,6 +383,18 @@ def _org_cache_has_agentic_outcome(cached_sr: Any) -> bool:
     )
 
 
+def _scan_cache_has_agentic_outcome(cached: Any) -> bool:
+    """Return whether a scan-cache entry carries the current status contract."""
+
+    if not isinstance(cached, dict):
+        return False
+    return (
+        cached.get("_agentic_status") in {"success", "degraded", "skipped"}
+        and isinstance(cached.get("_agentic_degraded_count"), int)
+        and isinstance(cached.get("_agentic_degradation_reasons"), dict)
+    )
+
+
 def _v2_output_from_org_cache(cached_sr: Any) -> Dict[str, Any]:
     merged_components: list = []
     merged_rels: list = []
@@ -2380,7 +2392,15 @@ def analyze(
                     _ck,
                     search_dirs=scan_cache_read_dirs,
                 )
-                if cached:
+                if cached is not None and not _scan_cache_has_agentic_outcome(
+                    cached
+                ):
+                    console.print(
+                        f"[yellow]Ignoring legacy scan cache entry[/] for "
+                        f"{source}: agentic outcome is unavailable"
+                    )
+                    cached = None
+                if cached is not None:
                     _scan_cache_hit = True
                     console.print(f"[green]Cache hit[/] for {source} ({_ck[:12]}…)")
                     all_analysis_outputs[source] = cached

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -382,6 +382,9 @@ def _v2_output_from_org_cache(cached_sr: Any) -> Dict[str, Any]:
         "relationships": merged_rels,
         "_agentic_risk_flags": [],
         "_agentic_candidate_count": 0,
+        "_agentic_status": "skipped",
+        "_agentic_degraded_count": 0,
+        "_agentic_degradation_reasons": {},
     }
 
 
@@ -392,6 +395,11 @@ def _v2_output_from_pipeline_result(result: Any) -> Dict[str, Any]:
         "relationships": result.relationships,
         "_agentic_risk_flags": result.agentic_risk_flags,
         "_agentic_candidate_count": result.agentic_candidate_count,
+        "_agentic_status": result.agentic_status,
+        "_agentic_degraded_count": result.agentic_degraded_count,
+        "_agentic_degradation_reasons": dict(
+            result.agentic_degradation_reasons
+        ),
     }
 
 
@@ -405,7 +413,61 @@ def _serializable_scan_cache_payload(result: Any) -> Dict[str, Any]:
             for f in result.agentic_risk_flags
         ],
         "_agentic_candidate_count": result.agentic_candidate_count,
+        "_agentic_status": result.agentic_status,
+        "_agentic_degraded_count": result.agentic_degraded_count,
+        "_agentic_degradation_reasons": dict(
+            result.agentic_degradation_reasons
+        ),
     }
+
+
+def _apply_cached_agentic_outcome(
+    source_summary: Dict[str, Any],
+    cached: Dict[str, Any],
+) -> None:
+    """Restore machine-readable agentic state from a whole-scan cache."""
+
+    source_summary["agentic_status"] = cached.get(
+        "_agentic_status", "skipped"
+    )
+    source_summary["agentic_degraded_count"] = cached.get(
+        "_agentic_degraded_count", 0
+    )
+    reasons = cached.get("_agentic_degradation_reasons", {})
+    source_summary["agentic_degradation_reasons"] = (
+        dict(reasons) if isinstance(reasons, dict) else {}
+    )
+
+
+def _aggregate_agentic_outcomes(
+    source_outcomes: Dict[str, Dict[str, Any]],
+) -> tuple[str, int, Dict[str, int]]:
+    """Aggregate per-source agentic outcomes into the run metadata."""
+
+    statuses = {
+        str(outcome.get("agentic_status", "skipped"))
+        for outcome in source_outcomes.values()
+    }
+    if "degraded" in statuses:
+        status = "degraded"
+    elif "success" in statuses:
+        status = "success"
+    else:
+        status = "skipped"
+
+    degraded_count = sum(
+        int(outcome.get("agentic_degraded_count", 0) or 0)
+        for outcome in source_outcomes.values()
+    )
+    reasons: Counter[str] = Counter()
+    for outcome in source_outcomes.values():
+        raw_reasons = outcome.get("agentic_degradation_reasons", {})
+        if not isinstance(raw_reasons, dict):
+            continue
+        for reason, count in raw_reasons.items():
+            if isinstance(reason, str) and isinstance(count, int) and count > 0:
+                reasons[reason] += count
+    return status, degraded_count, dict(sorted(reasons.items()))
 
 
 def _gather_analysis_sources(
@@ -2069,6 +2131,9 @@ def analyze(
                 "errors": [],
                 "source_name": str(source),
                 "source_path": str(source),
+                "agentic_status": "skipped",
+                "agentic_degraded_count": 0,
+                "agentic_degradation_reasons": {},
             }
             source_outcomes[source] = source_summary
 
@@ -2237,6 +2302,10 @@ def analyze(
                         cached_v2_output["components"]
                     )
                     source_summary["last_generated_at"] = _utcnow_iso()
+                    _apply_cached_agentic_outcome(
+                        source_summary,
+                        cached_v2_output,
+                    )
                     if source_summary["status"] == "in_progress":
                         source_summary["status"] = "completed"
                     _record_agentic_source_summary(
@@ -2271,6 +2340,7 @@ def analyze(
                         cached.get("components", [])
                     )
                     source_summary["last_generated_at"] = _utcnow_iso()
+                    _apply_cached_agentic_outcome(source_summary, cached)
                     if source_summary["status"] == "in_progress":
                         source_summary["status"] = "completed"
                     _record_agentic_source_summary(
@@ -2402,6 +2472,13 @@ def analyze(
             source_summary["completion_tokens"] = result.completion_tokens
             source_summary["total_tokens"] = result.total_tokens
             source_summary["cached_tokens"] = result.cached_tokens
+            source_summary["agentic_status"] = result.agentic_status
+            source_summary["agentic_degraded_count"] = (
+                result.agentic_degraded_count
+            )
+            source_summary["agentic_degradation_reasons"] = dict(
+                result.agentic_degradation_reasons
+            )
             run_metadata["total_tokens"] += result.total_tokens
             run_metadata["prompt_tokens"] += result.prompt_tokens
             run_metadata["completion_tokens"] += result.completion_tokens
@@ -2426,6 +2503,11 @@ def analyze(
             run_metadata["status"] = "completed_with_errors"
         else:
             run_metadata["status"] = "completed"
+        (
+            run_metadata["agentic_status"],
+            run_metadata["agentic_degraded_count"],
+            run_metadata["agentic_degradation_reasons"],
+        ) = _aggregate_agentic_outcomes(source_outcomes)
 
         v2_outputs = {
             k: v

--- a/aibom/src/aibom/diff.py
+++ b/aibom/src/aibom/diff.py
@@ -145,6 +145,13 @@ def load_scan_result_json(path: Path | str) -> ScanResult:
             "last_generated_at": summary.get("last_generated_at"),
             "assets_discovered": summary.get("assets_discovered"),
         }
+        for key in (
+            "agentic_status",
+            "agentic_degraded_count",
+            "agentic_degradation_reasons",
+        ):
+            if key in summary:
+                source_details[source_path][key] = summary[key]
         raw_comps = src.get("components", [])
         flat: list[AIComponent] = []
         if isinstance(raw_comps, dict):

--- a/aibom/src/aibom/finding_annotations.py
+++ b/aibom/src/aibom/finding_annotations.py
@@ -106,8 +106,22 @@ def _component_annotation(
         role="primary",
     )
     if component.decision_annotation is not None:
+        annotation = component.decision_annotation
+        decision = annotation.decision.strip().lower()
+        if decision not in {"confirmed", "added"}:
+            annotation = annotation.model_copy(
+                update={
+                    "decision": "unreviewed",
+                    "justification": (
+                        annotation.justification
+                        or "No usable component verdict was attached."
+                    ),
+                }
+            )
+        elif annotation.decision != decision:
+            annotation = annotation.model_copy(update={"decision": decision})
         return _hydrate_annotation(
-            component.decision_annotation,
+            annotation,
             include_code_snippets=include_code_snippets,
             snippet_location=primary_location,
             allowed_roots=allowed_roots,
@@ -124,13 +138,35 @@ def _component_annotation(
             f"Prompt '{component.name}' detected but prompt text was not "
             f"extracted; it may be loaded from a file at runtime."
         )
-        evidence_kinds = ["code_context", "file_loaded_limitation"] if evidence_locations else ["file_loaded_limitation"]
+        evidence_kinds = (
+            ["code_context", "file_loaded_limitation"]
+            if evidence_locations
+            else ["file_loaded_limitation"]
+        )
+        decision = "unreviewed"
     elif component.detection_source == DetectionSource.AGENTIC:
         justification = (
             f"{component.component_type.value.replace('_', ' ').capitalize()} "
             f"'{component.name}' was created by agentic enrichment."
         )
-        evidence_kinds = ["code_context", "agentic_enrichment"] if evidence_locations else ["agentic_enrichment"]
+        evidence_kinds = (
+            ["code_context", "agentic_enrichment"]
+            if evidence_locations
+            else ["agentic_enrichment"]
+        )
+        decision = "added"
+    elif component.agentic_hint:
+        justification = (
+            f"{component.component_type.value.replace('_', ' ').capitalize()} "
+            f"'{component.name}' was retained without an agentic verdict "
+            f"because agentic processing degraded ({component.agentic_hint})."
+        )
+        evidence_kinds = (
+            ["code_context", "agentic_degradation"]
+            if evidence_locations
+            else ["agentic_degradation"]
+        )
+        decision = "unreviewed"
     else:
         detector = (
             component.detection_source.value
@@ -143,9 +179,10 @@ def _component_annotation(
             f"agentic verdict was attached to this finding."
         )
         evidence_kinds = ["code_context"] if evidence_locations else ["scan_result"]
+        decision = "unreviewed"
 
     annotation = DecisionAnnotation(
-        decision="confirmed",
+        decision=decision,
         justification=justification,
         evidence_kinds=evidence_kinds,
         evidence_locations=evidence_locations,
@@ -255,18 +292,20 @@ def annotate_findings(
     allowed_roots: list[str] | None = None,
 ) -> tuple[list[AIComponent], list[ComponentRelationship], list[RiskFlag]]:
     """Ensure every final finding carries a decision annotation."""
-    annotated_components = [
-        component.model_copy(
-            update={
-                "decision_annotation": _component_annotation(
-                    component,
-                    include_code_snippets=include_code_snippets,
-                    allowed_roots=allowed_roots,
-                )
-            }
+    annotated_components: list[AIComponent] = []
+    for component in components:
+        annotation = _component_annotation(
+            component,
+            include_code_snippets=include_code_snippets,
+            allowed_roots=allowed_roots,
         )
-        for component in components
-    ]
+        updates: dict[str, object] = {"decision_annotation": annotation}
+        if annotation.decision == "unreviewed":
+            updates["needs_agentic"] = True
+        elif annotation.decision in {"confirmed", "added"}:
+            updates["needs_agentic"] = False
+            updates["agentic_hint"] = ""
+        annotated_components.append(component.model_copy(update=updates))
     component_by_id = {component.instance_id: component for component in annotated_components}
     annotated_relationships = [
         relationship.model_copy(

--- a/aibom/src/aibom/finding_annotations.py
+++ b/aibom/src/aibom/finding_annotations.py
@@ -120,6 +120,10 @@ def _component_annotation(
             )
         elif annotation.decision != decision:
             annotation = annotation.model_copy(update={"decision": decision})
+        if not annotation.evidence_locations and primary_location is not None:
+            annotation = annotation.model_copy(
+                update={"evidence_locations": [primary_location]}
+            )
         return _hydrate_annotation(
             annotation,
             include_code_snippets=include_code_snippets,

--- a/aibom/src/aibom/reporters/json_reporter.py
+++ b/aibom/src/aibom/reporters/json_reporter.py
@@ -210,20 +210,29 @@ def _aibom_payload(
             val = detail.get(mk)
             if val is not None:
                 per_source_meta[mk] = val
+        source_summary: dict[str, Any] = {
+            "status": detail.get("status") or "completed",
+            "source_kind": summary_source_kind,
+            "assets_discovered": detail.get("assets_discovered")
+            or total_components,
+            "last_generated_at": (
+                detail.get("last_generated_at") or raw_metadata.get("completed_at")
+            ),
+        }
+        for key in (
+            "agentic_status",
+            "agentic_degraded_count",
+            "agentic_degradation_reasons",
+        ):
+            if key in detail:
+                source_summary[key] = detail[key]
+
         sources_out[source_key] = {
             "source_name": source_name,
             "source_path": source_path,
             "components": comps,
             "relationships": [r.model_dump(mode="json") for r in src.relationships],
-            "summary": {
-                "status": detail.get("status") or "completed",
-                "source_kind": summary_source_kind,
-                "assets_discovered": detail.get("assets_discovered")
-                or total_components,
-                "last_generated_at": (
-                    detail.get("last_generated_at") or raw_metadata.get("completed_at")
-                ),
-            },
+            "summary": source_summary,
             "metadata": per_source_meta,
         }
         components_by_source[source_key] = list(src.components)

--- a/aibom/src/aibom/scan_pipeline.py
+++ b/aibom/src/aibom/scan_pipeline.py
@@ -228,7 +228,13 @@ def _fanout_agentic_results(
             clone.needs_agentic = c.needs_agentic
             clone.agentic_hint = c.agentic_hint
             clone.decision_annotation = (
-                c.decision_annotation.model_copy(deep=True)
+                c.decision_annotation.model_copy(
+                    deep=True,
+                    update={
+                        "evidence_locations": [],
+                        "code_snippet": None,
+                    },
+                )
                 if c.decision_annotation is not None
                 else None
             )
@@ -573,6 +579,7 @@ def _evidence_gate(
 
 
 _REVIEWED_COMPONENT_DECISIONS = frozenset({"confirmed", "added"})
+_MISSING_AGENTIC_VERDICT = "missing_agentic_verdict"
 
 
 def _mark_missing_agentic_verdicts(
@@ -601,7 +608,7 @@ def _mark_missing_agentic_verdicts(
                 update={
                     "needs_agentic": True,
                     "agentic_hint": (
-                        component.agentic_hint or "missing_agentic_verdict"
+                        component.agentic_hint or _MISSING_AGENTIC_VERDICT
                     ),
                 }
             )
@@ -1502,10 +1509,10 @@ class ScanPipeline:
 
         tu = getattr(self, "_agentic_token_usage", None)
         agentic_degraded_count = getattr(self, "_agentic_degraded_count", 0)
-        if not self.llm_config or self._agentic_input_count == 0:
-            agentic_status = "skipped"
-        elif agentic_degraded_count:
+        if agentic_degraded_count:
             agentic_status = "degraded"
+        elif not self.llm_config or self._agentic_input_count == 0:
+            agentic_status = "skipped"
         else:
             agentic_status = "success"
         if telemetry_enabled and self.agentic_telemetry is not None:
@@ -1922,7 +1929,7 @@ class ScanPipeline:
                         for component in retained
                         if component.agentic_hint
                     ),
-                    "missing_agentic_verdict",
+                    _MISSING_AGENTIC_VERDICT,
                 )
                 degradation_reasons[reason] += 1
 
@@ -1950,6 +1957,7 @@ class ScanPipeline:
             raise
         except Exception as exc:  # noqa: BLE001
             exact_candidates = self._agentic_input_count or len(components)
+            self._agentic_input_count = exact_candidates
             failure_hint = "agentic_stage_error"
             components = [
                 component.model_copy(

--- a/aibom/src/aibom/scan_pipeline.py
+++ b/aibom/src/aibom/scan_pipeline.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import logging
 import re
 import time
+from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -99,7 +100,12 @@ class PipelineResult:
     relationships: list[ComponentRelationship] = field(default_factory=list)
     agentic_risk_flags: list[Any] = field(default_factory=list)
     agentic_candidate_count: int = 0
+    agentic_input_count: int = 0
+    agentic_reviewed_count: int = 0
+    agentic_removed_count: int = 0
+    agentic_status: str = "skipped"
     agentic_degraded_count: int = 0
+    agentic_degradation_reasons: dict[str, int] = field(default_factory=dict)
     env_index: CrossRefIndex | None = None
     pkg_index: CrossRefIndex | None = None
     external_deps: list[ExternalRepoDep] = field(default_factory=list)
@@ -220,6 +226,12 @@ def _fanout_agentic_results(
             clone.heuristic_confidence = c.heuristic_confidence
             clone.agentic_confidence = c.agentic_confidence
             clone.needs_agentic = c.needs_agentic
+            clone.agentic_hint = c.agentic_hint
+            clone.decision_annotation = (
+                c.decision_annotation.model_copy(deep=True)
+                if c.decision_annotation is not None
+                else None
+            )
             if c.model_name:
                 clone.model_name = c.model_name
             if c.component_type != sib.component_type:
@@ -403,8 +415,13 @@ def _propagate_removals(
             continue
         drop_ids.add(c.instance_id)
 
-    result = [c for c in lookup_pool if c.instance_id not in drop_ids]
-    dropped = len(lookup_pool) - len(result)
+    # ``lookup_pool`` is deliberately wider than ``received`` so removals can
+    # be resolved against siblings that pre-agentic deduplication collapsed.
+    # The result must still be filtered from ``received``: rebuilding it from
+    # the original candidates would discard successful verdicts, repaired
+    # evidence, and degradation reasons attached by the agentic stage.
+    result = [c for c in received if c.instance_id not in drop_ids]
+    dropped = len(received) - len(result)
     if dropped:
         weak_n = sum(1 for v in restrict_import.values() if v)
         test_n = sum(1 for v in restrict_test.values() if v)
@@ -478,6 +495,12 @@ def _evidence_gate(
         if orig is None:
             result.append(c)
             continue
+        if c.agentic_hint:
+            # A failed-open candidate did not receive an agentic verdict.
+            # Preserve it as unreviewed instead of applying evidence rules
+            # intended for affirmative agent decisions.
+            result.append(c)
+            continue
 
         if (
             c.component_type == AIComponentType.MODEL
@@ -545,6 +568,43 @@ def _evidence_gate(
             total_removed,
             gate_removed,
             agent_evidence_removed,
+        )
+    return result
+
+
+_REVIEWED_COMPONENT_DECISIONS = frozenset({"confirmed", "added"})
+
+
+def _mark_missing_agentic_verdicts(
+    components: list["AIComponent"],
+    *,
+    input_ids: set[str],
+) -> list["AIComponent"]:
+    """Mark retained inputs without a usable component verdict as degraded."""
+
+    result: list["AIComponent"] = []
+    for component in components:
+        if component.instance_id not in input_ids:
+            result.append(component)
+            continue
+        annotation = component.decision_annotation
+        decision = annotation.decision.strip().lower() if annotation else ""
+        if decision in _REVIEWED_COMPONENT_DECISIONS:
+            result.append(
+                component.model_copy(
+                    update={"needs_agentic": False, "agentic_hint": ""}
+                )
+            )
+            continue
+        result.append(
+            component.model_copy(
+                update={
+                    "needs_agentic": True,
+                    "agentic_hint": (
+                        component.agentic_hint or "missing_agentic_verdict"
+                    ),
+                }
+            )
         )
     return result
 
@@ -1255,6 +1315,9 @@ class ScanPipeline:
         self.telemetry_source_id = telemetry_source_id
         self.telemetry_source_kind = telemetry_source_kind
         self._agentic_degraded_count = 0
+        self._agentic_degradation_reasons: dict[str, int] = {}
+        self._agentic_reviewed_count = 0
+        self._agentic_removed_count = 0
         self._agentic_telemetry_degraded_count: int | None = None
         self._agentic_token_usage: Any | None = None
         self._agentic_input_count = 0
@@ -1291,6 +1354,9 @@ class ScanPipeline:
     def run(self) -> PipelineResult:
         clear_cache()
         self._agentic_degraded_count = 0
+        self._agentic_degradation_reasons = {}
+        self._agentic_reviewed_count = 0
+        self._agentic_removed_count = 0
         self._agentic_telemetry_degraded_count = None
         self._agentic_token_usage = None
         self._agentic_input_count = 0
@@ -1435,6 +1501,13 @@ class ScanPipeline:
         total_elapsed = time.monotonic() - pipeline_start
 
         tu = getattr(self, "_agentic_token_usage", None)
+        agentic_degraded_count = getattr(self, "_agentic_degraded_count", 0)
+        if not self.llm_config or self._agentic_input_count == 0:
+            agentic_status = "skipped"
+        elif agentic_degraded_count:
+            agentic_status = "degraded"
+        else:
+            agentic_status = "success"
         if telemetry_enabled and self.agentic_telemetry is not None:
             degraded_count = (
                 self._agentic_telemetry_degraded_count
@@ -1542,7 +1615,14 @@ class ScanPipeline:
             relationships=relationships,
             agentic_risk_flags=agentic_flags,
             agentic_candidate_count=agentic_count,
-            agentic_degraded_count=getattr(self, "_agentic_degraded_count", 0),
+            agentic_input_count=self._agentic_input_count,
+            agentic_reviewed_count=self._agentic_reviewed_count,
+            agentic_removed_count=self._agentic_removed_count,
+            agentic_status=agentic_status,
+            agentic_degraded_count=agentic_degraded_count,
+            agentic_degradation_reasons=dict(
+                self._agentic_degradation_reasons
+            ),
             env_index=env_idx,
             pkg_index=pkg_idx,
             external_deps=ext_deps,
@@ -1672,7 +1752,7 @@ class ScanPipeline:
         )
 
         try:
-            from .agentic.agent import _count_degraded, run_agentic_enrichment
+            from .agentic.agent import run_agentic_enrichment
         except ImportError as exc:
             raise ImportError(
                 "Agentic classification requires the agentic runtime. "
@@ -1756,21 +1836,17 @@ class ScanPipeline:
             )
             self._agentic_added_relationship_count = len(agentic_rels)
             self._agentic_raw_risk_count = len(agentic_flags)
-            # Count degraded components from the raw agentic output, before
-            # post-filters below may strip components (and their hints) from the
-            # BOM.
-            self._agentic_degraded_count = _count_degraded(enriched)
-            self._agentic_degraded_ids = {
-                component.instance_id
-                for component in enriched
-                if component.agentic_hint
-            }
             deduped_ids = {c.instance_id for c in deduped}
+            enriched = _mark_missing_agentic_verdicts(
+                enriched,
+                input_ids=deduped_ids,
+            )
             enriched_deduped_ids = {
                 c.instance_id for c in enriched if c.instance_id in deduped_ids
             }
+            removed_ids = deduped_ids - enriched_deduped_ids
             new_components = [c for c in enriched if c.instance_id not in deduped_ids]
-            pre_fanout_removed = deduped_ids - enriched_deduped_ids
+            pre_fanout_removed = removed_ids
             enriched_for_fanout = [c for c in enriched if c.instance_id in deduped_ids]
             enriched = _fanout_agentic_results(enriched_for_fanout, fanout)
             enriched = _propagate_removals(
@@ -1799,6 +1875,66 @@ class ScanPipeline:
             enriched = _remove_unresolved_embedders(enriched, all_rels)
             enriched = _drop_env_placeholder_identifiers(enriched)
             all_rels = _backfill_relationship_instance_ids(all_rels, enriched)
+
+            # Reconcile terminal outcomes at the guarded Stage-3 boundary.
+            # Removal propagation and evidence filters can legitimately drop
+            # a raw degraded result, so reporting from the unguarded LLM
+            # response would overstate how many unresolved findings remain in
+            # the BOM. Fanout siblings are mapped back to their one deduped
+            # input representative to preserve the accounting invariant.
+            candidate_instance_ids = {
+                component.instance_id for component in components
+            }
+            enriched = _mark_missing_agentic_verdicts(
+                enriched,
+                input_ids=candidate_instance_ids,
+            )
+            enriched_by_id = {
+                component.instance_id: component for component in enriched
+            }
+            reviewed_ids: set[str] = set()
+            degraded_ids: set[str] = set()
+            degradation_reasons: Counter[str] = Counter()
+            for representative in deduped:
+                siblings = fanout.get(
+                    representative.instance_id,
+                    [representative],
+                )
+                retained = [
+                    enriched_by_id[sibling.instance_id]
+                    for sibling in siblings
+                    if sibling.instance_id in enriched_by_id
+                ]
+                if not retained:
+                    continue
+                if any(
+                    component.decision_annotation is not None
+                    and component.decision_annotation.decision.strip().lower()
+                    in _REVIEWED_COMPONENT_DECISIONS
+                    for component in retained
+                ):
+                    reviewed_ids.add(representative.instance_id)
+                    continue
+                degraded_ids.add(representative.instance_id)
+                reason = next(
+                    (
+                        component.agentic_hint
+                        for component in retained
+                        if component.agentic_hint
+                    ),
+                    "missing_agentic_verdict",
+                )
+                degradation_reasons[reason] += 1
+
+            self._agentic_degraded_ids = degraded_ids
+            self._agentic_degraded_count = len(degraded_ids)
+            self._agentic_degradation_reasons = dict(degradation_reasons)
+            self._agentic_reviewed_count = len(reviewed_ids)
+            self._agentic_removed_count = (
+                self._agentic_input_count
+                - self._agentic_reviewed_count
+                - self._agentic_degraded_count
+            )
             self._agentic_token_usage = agentic_token_usage
             if self._telemetry_enabled():
                 # Snapshot the true Stage-3 return boundary. Everything above
@@ -1814,13 +1950,27 @@ class ScanPipeline:
             raise
         except Exception as exc:  # noqa: BLE001
             exact_candidates = self._agentic_input_count or len(components)
+            failure_hint = "agentic_stage_error"
+            components = [
+                component.model_copy(
+                    update={
+                        "needs_agentic": True,
+                        "agentic_hint": failure_hint,
+                    }
+                )
+                for component in components
+            ]
+            self._agentic_degraded_count = exact_candidates
+            self._agentic_degradation_reasons = {
+                failure_hint: exact_candidates
+            }
+            self._agentic_reviewed_count = 0
+            self._agentic_removed_count = 0
+            self._agentic_degraded_ids = {
+                component.instance_id for component in components
+            }
             if self._telemetry_enabled():
                 self._agentic_telemetry_degraded_count = exact_candidates
-                # Keep the PipelineResult consumed by Galileo evaluation in
-                # sync with the source summary. This assignment intentionally
-                # remains inside the Galileo-enabled path so observability does
-                # not change non-Galileo scan results.
-                self._agentic_degraded_count = exact_candidates
                 if not self._agentic_input_snapshot:
                     self._agentic_input_snapshot = [
                         component.model_copy(deep=True) for component in components
@@ -1833,9 +1983,6 @@ class ScanPipeline:
                 self._agentic_output_snapshot = [
                     component.model_copy(deep=True) for component in components
                 ]
-                self._agentic_degraded_ids = {
-                    component.instance_id for component in self._agentic_input_snapshot
-                }
             _LOGGER.warning("Agentic classification failed: %s", exc, exc_info=True)
 
         return components, relationships, []

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -1925,6 +1925,67 @@ class TestRunTier:
         assert retry_call.kwargs["attempt_number"] == 2
         assert retry_call.kwargs["telemetry_context"] is telemetry_context
 
+    @patch("aibom.agentic.agent._RETRY_COOLDOWN_S", 0)
+    def test_timeout_retry_repartitions_into_smaller_batches(self):
+        from aibom.agentic.agent import _run_tier
+        from aibom.agentic.middleware import AIBOMScannerMiddleware
+
+        components = [
+            AIComponent(
+                name=f"model-{index}",
+                component_type=AIComponentType.MODEL,
+                file_path="app.py",
+                line_number=index,
+                model_name=f"model-{index}",
+            )
+            for index in range(1, 5)
+        ]
+        degraded = [
+            component.model_copy(
+                update={
+                    "needs_agentic": True,
+                    "agentic_hint": "batch_timeout",
+                }
+            )
+            for component in components
+        ]
+
+        def run_batch(*args, **kwargs):
+            batch = args[2]
+            if kwargs.get("attempt_kind") == "retry":
+                recovered = [
+                    component.model_copy(
+                        update={"needs_agentic": False, "agentic_hint": ""}
+                    )
+                    for component in batch
+                ]
+                return recovered, [], [], [], False
+            return degraded, [], [], [], True
+
+        with patch(
+            "aibom.agentic.agent._run_batch",
+            side_effect=run_batch,
+        ) as run_batch_mock:
+            enriched, _, _, _ = _run_tier(
+                agent=MagicMock(),
+                middleware=AIBOMScannerMiddleware(),
+                components=components,
+                relationships=[],
+                scan_paths=["/tmp"],
+                batch_size=4,
+                max_concurrent=1,
+                all_components=components,
+                cache=None,
+            )
+
+        assert len(enriched) == 4
+        retry_calls = [
+            call
+            for call in run_batch_mock.call_args_list
+            if call.kwargs.get("attempt_kind") == "retry"
+        ]
+        assert [len(call.args[2]) for call in retry_calls] == [2, 2]
+
     def test_memo_hit_emits_cache_trace_without_running_the_agent(self):
         from aibom.agentic.agent import _DecisionMemo, _run_tier
         from aibom.agentic.middleware import AIBOMScannerMiddleware
@@ -2162,7 +2223,14 @@ class TestDecisionMemo:
             line_number=1,
         )
         after = before.model_copy(
-            update={"heuristic_confidence": 0.95, "needs_agentic": False}
+            update={
+                "heuristic_confidence": 0.95,
+                "needs_agentic": False,
+                "decision_annotation": DecisionAnnotation(
+                    decision="confirmed",
+                    justification="The dependency is declared.",
+                ),
+            }
         )
 
         memo.record(before, after)
@@ -2170,6 +2238,9 @@ class TestDecisionMemo:
         assert verdict is not None
         assert verdict["action"] == "keep"
         assert verdict["heuristic_confidence"] == 0.95
+        replayed = memo.apply([before])[0]
+        assert replayed.decision_annotation is not None
+        assert replayed.decision_annotation.decision == "confirmed"
 
     def test_record_and_lookup_remove(self):
         from aibom.agentic.agent import _DecisionMemo

--- a/aibom/tests/test_agentic_agent.py
+++ b/aibom/tests/test_agentic_agent.py
@@ -2229,6 +2229,14 @@ class TestDecisionMemo:
                 "decision_annotation": DecisionAnnotation(
                     decision="confirmed",
                     justification="The dependency is declared.",
+                    evidence_locations=[
+                        EvidenceLocation(
+                            file_path="req.txt",
+                            start_line=1,
+                            end_line=1,
+                            role="primary",
+                        )
+                    ],
                 ),
             }
         )
@@ -2241,6 +2249,8 @@ class TestDecisionMemo:
         replayed = memo.apply([before])[0]
         assert replayed.decision_annotation is not None
         assert replayed.decision_annotation.decision == "confirmed"
+        assert replayed.decision_annotation.evidence_locations == []
+        assert replayed.decision_annotation.code_snippet is None
 
     def test_record_and_lookup_remove(self):
         from aibom.agentic.agent import _DecisionMemo

--- a/aibom/tests/test_agentic_timeout.py
+++ b/aibom/tests/test_agentic_timeout.py
@@ -54,7 +54,7 @@ class TestAgenticTimeout:
             timeout_s=1,
         )
         assert len(comps) == 1
-        assert comps[0].needs_agentic is False
+        assert comps[0].needs_agentic is True
         assert comps[0].agentic_hint == "batch_timeout"
 
     @patch("aibom.agentic.agent._RETRY_COOLDOWN_S", 0)
@@ -108,7 +108,7 @@ class TestAgenticTimeout:
             elapsed < 20
         ), f"batch hung for {elapsed:.1f}s on a never-returning invoke"
         assert len(comps) == 1
-        assert comps[0].needs_agentic is False
+        assert comps[0].needs_agentic is True
         assert comps[0].agentic_hint == "batch_timeout"
 
 
@@ -186,7 +186,7 @@ class TestAgenticAsyncTimeout:
             elapsed < 25
         ), f"parallel path hung for {elapsed:.1f}s on a never-returning ainvoke"
         assert len(out) == 2
-        assert all(c.needs_agentic is False for c in out)
+        assert all(c.needs_agentic is True for c in out)
         assert all(c.agentic_hint == "batch_timeout" for c in out)
 
 
@@ -464,7 +464,7 @@ class TestAgenticCircuitBreaker:
         # 3 main-pass invocations (breaker trips, 4th skipped) +
         # 3 retry-pass invocations (retry breaker also trips on 4th)
         assert mock_agent.invoke.call_count == 6
-        assert all(c.needs_agentic is False for c in comps)
+        assert all(c.needs_agentic is True for c in comps)
 
     @patch("aibom.agentic.agent._RETRY_COOLDOWN_S", 0)
     @patch("aibom.agentic.agent._close_model_clients")

--- a/aibom/tests/test_cli_basic.py
+++ b/aibom/tests/test_cli_basic.py
@@ -257,6 +257,9 @@ def test_analyze_scan_cache_hit_finalizes_per_source_status(tmp_path):
         "relationships": [],
         "_agentic_risk_flags": [],
         "_agentic_candidate_count": 0,
+        "_agentic_status": "success",
+        "_agentic_degraded_count": 0,
+        "_agentic_degradation_reasons": {},
     }
     telemetry = MagicMock(enabled=True)
 
@@ -309,6 +312,68 @@ def test_analyze_scan_cache_hit_finalizes_per_source_status(tmp_path):
     assert summary["candidate_count"] == 0
     assert summary["candidate_count_available"] is False
     assert summary["final_component_count"] == 0
+
+
+def test_analyze_ignores_legacy_scan_cache_without_agentic_outcome(tmp_path):
+    source_dir = tmp_path / "repo"
+    source_dir.mkdir()
+    (source_dir / "app.py").write_text("print('hello')\n", encoding="utf-8")
+    report = tmp_path / "report.json"
+    legacy_cached_payload = {
+        "_v2": True,
+        "components": [],
+        "relationships": [],
+        "_agentic_risk_flags": [],
+        "_agentic_candidate_count": 0,
+    }
+    fresh_result = PipelineResult(
+        components=[],
+        relationships=[],
+        agentic_risk_flags=[],
+        agentic_candidate_count=2,
+        external_deps=[],
+        timings=[],
+        total_elapsed_s=0.0,
+        agentic_status="degraded",
+        agentic_degraded_count=2,
+        agentic_degradation_reasons={"batch_timeout": 2},
+    )
+
+    with patch("aibom.cli.ensure_llm_runtime_available"):
+        with patch(
+            "aibom.scan_cache.load_cached",
+            return_value=legacy_cached_payload,
+        ):
+            with patch("aibom.scan_cache.save_cached") as mock_save:
+                with patch(
+                    "aibom.scan_pipeline.ScanPipeline.run",
+                    return_value=fresh_result,
+                ) as mock_run:
+                    result = runner.invoke(
+                        app,
+                        [
+                            "analyze",
+                            str(source_dir),
+                            "--output-format",
+                            "json",
+                            "--output-file",
+                            str(report),
+                            "--llm-model",
+                            "test-model",
+                        ],
+                    )
+
+    assert result.exit_code == 0, result.output
+    assert "Ignoring legacy scan cache entry" in result.output
+    mock_run.assert_called_once()
+    mock_save.assert_called_once()
+    data = json.loads(report.read_text(encoding="utf-8"))
+    source = next(iter(data["aibom_analysis"]["sources"].values()))
+    assert source["summary"]["agentic_status"] == "degraded"
+    assert source["summary"]["agentic_degraded_count"] == 2
+    assert source["summary"]["agentic_degradation_reasons"] == {
+        "batch_timeout": 2
+    }
 
 
 def test_analyze_pipeline_exception_emits_failed_source_summary(tmp_path):

--- a/aibom/tests/test_cli_report.py
+++ b/aibom/tests/test_cli_report.py
@@ -4,15 +4,125 @@ import json
 import uuid
 from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from typer.testing import CliRunner
 
-from aibom.cli import app
+from aibom.cli import (
+    _aggregate_agentic_outcomes,
+    _apply_cached_agentic_outcome,
+    _build_submission_payload,
+    _serializable_scan_cache_payload,
+    app,
+)
 from aibom.models import AIComponent, AIComponentType, RiskScore, ScanResult, SourceResult
 from aibom.reporters.json_reporter import JsonReporter
 
 runner = CliRunner()
+
+
+def test_scan_cache_preserves_agentic_outcome() -> None:
+    result = SimpleNamespace(
+        components=[],
+        relationships=[],
+        agentic_risk_flags=[],
+        agentic_candidate_count=3,
+        agentic_status="degraded",
+        agentic_degraded_count=2,
+        agentic_degradation_reasons={
+            "batch_timeout": 1,
+            "retry_budget_exhausted": 1,
+        },
+    )
+
+    cached = _serializable_scan_cache_payload(result)
+    source_summary: dict = {}
+    _apply_cached_agentic_outcome(source_summary, cached)
+
+    assert source_summary == {
+        "agentic_status": "degraded",
+        "agentic_degraded_count": 2,
+        "agentic_degradation_reasons": {
+            "batch_timeout": 1,
+            "retry_budget_exhausted": 1,
+        },
+    }
+
+
+def test_run_agentic_outcome_aggregates_sources() -> None:
+    outcomes = {
+        "first": {
+            "agentic_status": "success",
+            "agentic_degraded_count": 0,
+            "agentic_degradation_reasons": {},
+        },
+        "second": {
+            "agentic_status": "degraded",
+            "agentic_degraded_count": 3,
+            "agentic_degradation_reasons": {
+                "batch_timeout": 2,
+                "retry_failed": 1,
+            },
+        },
+        "third": {
+            "agentic_status": "degraded",
+            "agentic_degraded_count": 1,
+            "agentic_degradation_reasons": {"batch_timeout": 1},
+        },
+    }
+
+    assert _aggregate_agentic_outcomes(outcomes) == (
+        "degraded",
+        4,
+        {"batch_timeout": 3, "retry_failed": 1},
+    )
+
+
+def test_submission_preserves_unreviewed_and_agentic_outcome() -> None:
+    report = {
+        "aibom_analysis": {
+            "metadata": {
+                "run_id": "run-123",
+                "analyzer_version": "1.0.9",
+                "agentic_status": "degraded",
+                "agentic_degraded_count": 1,
+                "agentic_degradation_reasons": {"batch_timeout": 1},
+            },
+            "sources": {
+                "example/repo": {
+                    "components": {
+                        "agent": [
+                            {
+                                "name": "RouterAgent",
+                                "decision_annotation": {
+                                    "decision": "unreviewed"
+                                },
+                                "needs_agentic": True,
+                                "agentic_hint": "batch_timeout",
+                            }
+                        ]
+                    },
+                    "summary": {
+                        "agentic_status": "degraded",
+                        "agentic_degraded_count": 1,
+                        "agentic_degradation_reasons": {
+                            "batch_timeout": 1
+                        },
+                    },
+                }
+            },
+        }
+    }
+
+    payload = _build_submission_payload(report)
+
+    assert payload["report"] == report
+    component = payload["report"]["aibom_analysis"]["sources"][
+        "example/repo"
+    ]["components"]["agent"][0]
+    assert component["decision_annotation"]["decision"] == "unreviewed"
+    assert component["needs_agentic"] is True
 
 
 def _write_report(path: Path, *, include_version: bool = True) -> dict:

--- a/aibom/tests/test_cli_report.py
+++ b/aibom/tests/test_cli_report.py
@@ -14,6 +14,7 @@ from aibom.cli import (
     _apply_cached_agentic_outcome,
     _build_submission_payload,
     _org_cache_has_agentic_outcome,
+    _scan_cache_has_agentic_outcome,
     _serializable_scan_cache_payload,
     _v2_output_from_org_cache,
     app,
@@ -48,6 +49,11 @@ def test_scan_cache_preserves_agentic_outcome() -> None:
     source_summary: dict = {}
     _apply_cached_agentic_outcome(source_summary, cached)
 
+    assert _scan_cache_has_agentic_outcome(cached) is True
+    legacy = {
+        key: value for key, value in cached.items() if not key.startswith("_agentic_")
+    }
+    assert _scan_cache_has_agentic_outcome(legacy) is False
     assert source_summary == {
         "agentic_status": "degraded",
         "agentic_degraded_count": 2,

--- a/aibom/tests/test_cli_report.py
+++ b/aibom/tests/test_cli_report.py
@@ -318,6 +318,13 @@ def _write_multi_source_report(
             "source_ref_version": spec["version"],
             "status": "completed",
         }
+        for key in (
+            "agentic_status",
+            "agentic_degraded_count",
+            "agentic_degradation_reasons",
+        ):
+            if key in spec:
+                source_outcomes[spec["path"]][key] = spec[key]
     result = ScanResult(
         metadata={
             "run_id": run_id,
@@ -429,6 +436,67 @@ def test_two_sources_fan_out_to_two_uploads(mock_post, tmp_path: Path):
     # Each upload's report is scoped to exactly one source.
     for p in payloads:
         assert len(p["report"]["aibom_analysis"]["sources"]) == 1
+
+
+@patch("aibom.cli.post_report_with_retries")
+def test_report_upload_preserves_per_source_agentic_outcomes(
+    mock_post, tmp_path: Path
+):
+    report_file = tmp_path / "report.json"
+    _write_multi_source_report(
+        report_file,
+        [
+            {
+                "path": "/repo/degraded",
+                "name": "org/degraded",
+                "kind": "git",
+                "canonical": "github.com/org/degraded",
+                "version": "aaa",
+                "agentic_status": "degraded",
+                "agentic_degraded_count": 2,
+                "agentic_degradation_reasons": {
+                    "retry_failed": 1,
+                    "circuit_breaker_tripped": 1,
+                },
+            },
+            {
+                "path": "/repo/success",
+                "name": "org/success",
+                "kind": "git",
+                "canonical": "github.com/org/success",
+                "version": "bbb",
+                "agentic_status": "success",
+                "agentic_degraded_count": 0,
+                "agentic_degradation_reasons": {},
+            },
+        ],
+    )
+
+    generated = json.loads(report_file.read_text(encoding="utf-8"))
+    generated_summaries = {
+        key: value["summary"]
+        for key, value in generated["aibom_analysis"]["sources"].items()
+    }
+    assert generated_summaries["org/degraded"]["agentic_status"] == "degraded"
+    assert generated_summaries["org/success"]["agentic_status"] == "success"
+
+    result = _invoke_upload(report_file)
+
+    assert result.exit_code == 0, result.output
+    assert mock_post.call_count == 2
+    uploaded_summaries = {}
+    for call in mock_post.call_args_list:
+        uploaded_sources = call.args[1]["report"]["aibom_analysis"]["sources"]
+        assert len(uploaded_sources) == 1
+        source_key, source_entry = next(iter(uploaded_sources.items()))
+        uploaded_summaries[source_key] = source_entry["summary"]
+
+    assert uploaded_summaries["org/degraded"] == generated_summaries[
+        "org/degraded"
+    ]
+    assert uploaded_summaries["org/success"] == generated_summaries[
+        "org/success"
+    ]
 
 
 @patch("aibom.cli.post_report_with_retries")

--- a/aibom/tests/test_cli_report.py
+++ b/aibom/tests/test_cli_report.py
@@ -13,10 +13,18 @@ from aibom.cli import (
     _aggregate_agentic_outcomes,
     _apply_cached_agentic_outcome,
     _build_submission_payload,
+    _org_cache_has_agentic_outcome,
     _serializable_scan_cache_payload,
+    _v2_output_from_org_cache,
     app,
 )
-from aibom.models import AIComponent, AIComponentType, RiskScore, ScanResult, SourceResult
+from aibom.models import (
+    AIComponent,
+    AIComponentType,
+    RiskScore,
+    ScanResult,
+    SourceResult,
+)
 from aibom.reporters.json_reporter import JsonReporter
 
 runner = CliRunner()
@@ -48,6 +56,33 @@ def test_scan_cache_preserves_agentic_outcome() -> None:
             "retry_budget_exhausted": 1,
         },
     }
+
+
+def test_org_cache_preserves_agentic_outcome() -> None:
+    cached_result = ScanResult(
+        metadata={
+            "agentic_status": "degraded",
+            "agentic_degraded_count": 2,
+            "agentic_degradation_reasons": {"batch_timeout": 2},
+        },
+        sources=[
+            SourceResult(
+                path="/repo",
+                components=[],
+                relationships=[],
+            )
+        ],
+    )
+
+    cached = _v2_output_from_org_cache(cached_result)
+
+    assert cached["_agentic_status"] == "degraded"
+    assert cached["_agentic_degraded_count"] == 2
+    assert cached["_agentic_degradation_reasons"] == {"batch_timeout": 2}
+    assert _org_cache_has_agentic_outcome(cached_result) is True
+
+    legacy = cached_result.model_copy(update={"metadata": {}})
+    assert _org_cache_has_agentic_outcome(legacy) is False
 
 
 def test_run_agentic_outcome_aggregates_sources() -> None:

--- a/aibom/tests/test_finding_annotations.py
+++ b/aibom/tests/test_finding_annotations.py
@@ -99,6 +99,9 @@ def test_annotate_findings_hydrates_snippets_when_enabled(tmp_path) -> None:
     assert components[0].decision_annotation is not None
     assert components[0].decision_annotation.code_snippet is not None
     assert "client = OpenAI()" in components[0].decision_annotation.code_snippet.text
+    assert components[0].decision_annotation.evidence_locations[0].file_path == str(
+        source_file
+    )
     assert components[0].needs_agentic is False
     assert components[0].agentic_hint == ""
 

--- a/aibom/tests/test_finding_annotations.py
+++ b/aibom/tests/test_finding_annotations.py
@@ -56,6 +56,11 @@ def test_annotate_findings_adds_default_annotations(tmp_path) -> None:
     )
 
     assert all(component.decision_annotation is not None for component in components)
+    assert all(
+        component.decision_annotation.decision == "unreviewed"
+        for component in components
+    )
+    assert all(component.needs_agentic for component in components)
     assert relationships[0].decision_annotation is not None
     assert relationships[0].decision_annotation.decision == "derived"
     assert risk_flags[0].decision_annotation is not None
@@ -81,6 +86,7 @@ def test_annotate_findings_hydrates_snippets_when_enabled(tmp_path) -> None:
             evidence_kinds=["code_context"],
             evidence_locations=[],
         ),
+        agentic_hint="stale_review_hint",
     )
 
     components, _, _ = annotate_findings(
@@ -93,6 +99,8 @@ def test_annotate_findings_hydrates_snippets_when_enabled(tmp_path) -> None:
     assert components[0].decision_annotation is not None
     assert components[0].decision_annotation.code_snippet is not None
     assert "client = OpenAI()" in components[0].decision_annotation.code_snippet.text
+    assert components[0].needs_agentic is False
+    assert components[0].agentic_hint == ""
 
 
 def test_snippet_blocked_for_out_of_repo_path(tmp_path) -> None:
@@ -135,12 +143,7 @@ def test_snippet_blocked_for_out_of_repo_path(tmp_path) -> None:
 def test_fall_through_justification_does_not_falsely_claim_agentic_confirmation(
     tmp_path,
 ) -> None:
-    """Fix 9: when no decision_annotation was set by the agent, the
-    fall-through must NOT pretend the row was confirmed by agentic
-    review. ``decision`` stays ``"confirmed"`` (no JSON contract change),
-    but the justification text must name the deterministic detector and
-    explicitly note that no agentic verdict was attached.
-    """
+    """A deterministic finding without a verdict is explicitly unreviewed."""
     src = tmp_path / "deployment.py"
     src.write_text("agent = SomeAgent()\n", encoding="utf-8")
 
@@ -159,9 +162,8 @@ def test_fall_through_justification_does_not_falsely_claim_agentic_confirmation(
 
     annotation = components[0].decision_annotation
     assert annotation is not None
-    assert annotation.decision == "confirmed", (
-        "Fix 9 keeps the JSON contract: decision stays 'confirmed'."
-    )
+    assert annotation.decision == "unreviewed"
+    assert components[0].needs_agentic is True
     j = annotation.justification.lower()
     assert "detected by code_analysis" in j, (
         f"justification must name the deterministic detector; got "
@@ -178,11 +180,7 @@ def test_fall_through_justification_does_not_falsely_claim_agentic_confirmation(
 
 
 def test_fall_through_justification_for_agentic_origin(tmp_path) -> None:
-    """Fix 9: when the component was created by the agentic pass itself
-    (``detection_source=AGENTIC``) but no decision_annotation was set, the
-    fall-through must record the agentic provenance honestly and tag the
-    evidence with ``agentic_enrichment``.
-    """
+    """An agentic-created finding receives the explicit ``added`` decision."""
     src = tmp_path / "agent_birth.py"
     src.write_text("# inferred by the LLM enrichment phase\n", encoding="utf-8")
 
@@ -201,9 +199,52 @@ def test_fall_through_justification_for_agentic_origin(tmp_path) -> None:
 
     annotation = components[0].decision_annotation
     assert annotation is not None
-    assert annotation.decision == "confirmed"
+    assert annotation.decision == "added"
+    assert components[0].needs_agentic is False
     assert "agentic enrichment" in annotation.justification.lower()
     assert "agentic_enrichment" in (annotation.evidence_kinds or []), (
         f"evidence_kinds must include 'agentic_enrichment' so consumers "
         f"can distinguish agent-born rows; got {annotation.evidence_kinds!r}"
     )
+
+
+def test_degraded_component_is_unreviewed_with_reason(tmp_path) -> None:
+    src = tmp_path / "agent.py"
+    src.write_text("agent = SomeAgent()\n", encoding="utf-8")
+    component = AIComponent(
+        name="some_agent",
+        component_type=AIComponentType.AGENT,
+        file_path=str(src),
+        line_number=1,
+        instance_id="a-degraded",
+        needs_agentic=False,
+        agentic_hint="batch_timeout",
+    )
+
+    components, _, _ = annotate_findings([component], [], [])
+
+    annotation = components[0].decision_annotation
+    assert annotation is not None
+    assert annotation.decision == "unreviewed"
+    assert components[0].needs_agentic is True
+    assert "batch_timeout" in annotation.justification
+    assert "agentic_degradation" in annotation.evidence_kinds
+
+
+def test_invalid_component_decision_is_normalized_to_unreviewed() -> None:
+    component = AIComponent(
+        name="router",
+        component_type=AIComponentType.AGENT,
+        decision_annotation=DecisionAnnotation(
+            decision="derived",
+            justification="Relationship semantics were used by mistake.",
+        ),
+        needs_agentic=False,
+    )
+
+    components, _, _ = annotate_findings([component], [], [])
+
+    annotation = components[0].decision_annotation
+    assert annotation is not None
+    assert annotation.decision == "unreviewed"
+    assert components[0].needs_agentic is True

--- a/aibom/tests/test_middleware_agent_evidence_gate.py
+++ b/aibom/tests/test_middleware_agent_evidence_gate.py
@@ -158,11 +158,24 @@ class TestVerifyAgentEvidence:
             (-1, 2),
             (2, 1),
             (1, 9999),
-            ("1", 2),
-            (1, "2"),
         ],
     )
-    def test_invalid_line_range_fails(
+    def test_stale_numeric_line_range_is_repaired(
+        self, agent_py: Path, start, end
+    ) -> None:
+        ev = _valid_evidence(agent_py)
+        ev["definition_start_line"] = start
+        ev["definition_end_line"] = end
+        ok, reason = _verify_agent_evidence(
+            ev, allowed_roots=[str(agent_py.parent)]
+        )
+        assert ok
+        assert reason == ""
+        assert ev["definition_start_line"] == 4
+        assert ev["definition_end_line"] == 4
+
+    @pytest.mark.parametrize("start,end", [("1", 2), (1, "2")])
+    def test_non_integer_line_range_fails(
         self, agent_py: Path, start, end
     ) -> None:
         ev = _valid_evidence(agent_py)
@@ -190,9 +203,9 @@ class TestVerifyAgentEvidence:
             ev, allowed_roots=[str(agent_py.parent)]
         )
         assert not ok
-        assert reason == "snippet not found in cited range"
+        assert reason == "snippet not found in cited file"
 
-    def test_snippet_present_but_outside_cited_range_fails(
+    def test_unique_snippet_outside_cited_range_is_repaired(
         self, agent_py: Path
     ) -> None:
         ev = _valid_evidence(agent_py)
@@ -202,8 +215,33 @@ class TestVerifyAgentEvidence:
         ok, reason = _verify_agent_evidence(
             ev, allowed_roots=[str(agent_py.parent)]
         )
+        assert ok
+        assert reason == ""
+        assert ev["definition_start_line"] == 4
+        assert ev["definition_end_line"] == 4
+
+    def test_ambiguous_snippet_outside_range_is_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        source = tmp_path / "agents.py"
+        source.write_text(
+            "first = Agent()\nsecond = Agent()\n",
+            encoding="utf-8",
+        )
+        ev = {
+            "pattern": "framework_agent",
+            "definition_file": str(source),
+            "definition_start_line": 99,
+            "definition_end_line": 99,
+            "evidence_snippet": "Agent()",
+        }
+
+        ok, reason = _verify_agent_evidence(
+            ev, allowed_roots=[str(tmp_path)]
+        )
+
         assert not ok
-        assert reason == "snippet not found in cited range"
+        assert reason == "snippet match is ambiguous in cited file"
 
     def test_whitespace_tolerant_match(self, agent_py: Path) -> None:
         ev = _valid_evidence(agent_py)
@@ -238,6 +276,9 @@ class TestVerifyAgentEvidence:
 class TestGateOnNewComponents:
     def test_new_agent_with_valid_evidence_is_kept(self, agent_py: Path) -> None:
         mw = AIBOMScannerMiddleware(allowed_roots=[str(agent_py.parent)])
+        evidence = _valid_evidence(agent_py)
+        evidence["definition_start_line"] = 1
+        evidence["definition_end_line"] = 2
         data = {
             "new_components": [
                 {
@@ -245,13 +286,16 @@ class TestGateOnNewComponents:
                     "component_type": "agent",
                     "file_path": str(agent_py),
                     "line_number": 4,
-                    "agent_evidence": _valid_evidence(agent_py),
+                    "agent_evidence": evidence,
                 }
             ],
         }
         components, _rels, _flags = mw.extract_findings_from_dict(data)
         assert [c.name for c in components] == ["MyAgent"]
         assert components[0].component_type == AIComponentType.AGENT
+        stored = components[0].metadata["agent_evidence"]
+        assert stored["definition_start_line"] == 4
+        assert stored["definition_end_line"] == 4
 
     @pytest.mark.parametrize("comp_type", ["agent", "agent_proxy"])
     def test_new_agent_without_evidence_is_rejected(

--- a/aibom/tests/test_middleware_agent_evidence_gate.py
+++ b/aibom/tests/test_middleware_agent_evidence_gate.py
@@ -296,6 +296,8 @@ class TestGateOnNewComponents:
         stored = components[0].metadata["agent_evidence"]
         assert stored["definition_start_line"] == 4
         assert stored["definition_end_line"] == 4
+        assert stored["definition_file"] == str(agent_py)
+        assert "evidence_snippet" not in stored
 
     @pytest.mark.parametrize("comp_type", ["agent", "agent_proxy"])
     def test_new_agent_without_evidence_is_rejected(
@@ -396,6 +398,9 @@ class TestGateOnReclassify:
         result = mw.apply_enrichments_from_dict([existing], data)
         assert len(result) == 1
         assert result[0].component_type == AIComponentType.AGENT
+        stored = result[0].metadata["agent_evidence"]
+        assert stored["definition_file"] == str(agent_py)
+        assert "evidence_snippet" not in stored
 
     def test_reclassify_to_agent_without_evidence_is_rejected(
         self, agent_py: Path
@@ -494,6 +499,9 @@ class TestGateOnEnrichmentUpdates:
         comp = result[0]
         assert comp.component_type == AIComponentType.AGENT
         assert comp.framework == "langchain"
+        stored = comp.metadata["agent_evidence"]
+        assert stored["definition_file"] == str(agent_py)
+        assert "evidence_snippet" not in stored
 
     def test_enrichment_without_type_change_bypasses_the_gate(
         self, agent_py: Path

--- a/aibom/tests/test_reporters.py
+++ b/aibom/tests/test_reporters.py
@@ -202,6 +202,58 @@ def test_json_reporter_render(sample_scan_result: ScanResult):
         assert "summary" in src_data
 
 
+def test_json_reporter_emits_run_and_source_agentic_outcomes():
+    component = AIComponent(
+        name="router_agent",
+        component_type=AIComponentType.AGENT,
+        file_path="/repo/app.py",
+        line_number=4,
+    )
+    result = ScanResult(
+        metadata={
+            "run_id": "run-agentic-status",
+            "agentic_status": "degraded",
+            "agentic_degraded_count": 1,
+            "agentic_degradation_reasons": {"batch_timeout": 1},
+            "source_outcomes": {
+                "/repo": {
+                    "source_name": "example/repo",
+                    "source_path": "/repo",
+                    "source_kind": "local-path",
+                    "status": "completed",
+                    "agentic_status": "degraded",
+                    "agentic_degraded_count": 1,
+                    "agentic_degradation_reasons": {"batch_timeout": 1},
+                }
+            },
+        },
+        sources=[
+            SourceResult(
+                path="/repo",
+                components=[component],
+                relationships=[],
+            )
+        ],
+    )
+    buf = StringIO()
+
+    JsonReporter().render(result, buf)
+
+    analysis = json.loads(buf.getvalue())["aibom_analysis"]
+    assert analysis["metadata"]["agentic_status"] == "degraded"
+    assert analysis["metadata"]["agentic_degraded_count"] == 1
+    assert analysis["metadata"]["agentic_degradation_reasons"] == {
+        "batch_timeout": 1
+    }
+    source_summary = analysis["sources"]["example/repo"]["summary"]
+    assert source_summary["status"] == "completed"
+    assert source_summary["agentic_status"] == "degraded"
+    assert source_summary["agentic_degraded_count"] == 1
+    assert source_summary["agentic_degradation_reasons"] == {
+        "batch_timeout": 1
+    }
+
+
 def test_json_reporter_preserves_decision_annotations():
     component = AIComponent(
         name="router_agent",

--- a/aibom/tests/test_scan_pipeline.py
+++ b/aibom/tests/test_scan_pipeline.py
@@ -9,7 +9,12 @@ from unittest.mock import MagicMock, patch
 
 from aibom.agentic.agent import TokenUsage
 from aibom.cross_ref import CrossRefIndex
-from aibom.models import AIComponent, AIComponentType, DecisionAnnotation
+from aibom.models import (
+    AIComponent,
+    AIComponentType,
+    DecisionAnnotation,
+    EvidenceLocation,
+)
 from aibom.scan_pipeline import ScanPipeline, StageTiming
 
 
@@ -787,6 +792,51 @@ class TestAgenticScope:
         assert result.components[0].needs_agentic is True
         assert result.components[0].agentic_hint == "agentic_stage_error"
 
+    def test_stage_failure_before_dedup_preserves_accounting(
+        self, tmp_path: Path
+    ) -> None:
+        component = AIComponent(
+            name="router",
+            component_type=AIComponentType.AGENT,
+            file_path="app.py",
+            line_number=1,
+        )
+        pipeline = ScanPipeline(
+            scan_paths=[str(tmp_path)],
+            llm_config={"model": "test/model", "api_key": "fake"},
+        )
+        with (
+            patch.object(pipeline, "_stage_scan", return_value=([component], [])),
+            patch.object(
+                pipeline,
+                "_stage_cross_ref",
+                return_value=(
+                    [component],
+                    CrossRefIndex(),
+                    CrossRefIndex(),
+                    [],
+                ),
+            ),
+            patch("aibom.scan_pipeline.ensure_llm_runtime_available"),
+            patch(
+                "aibom.scan_pipeline._partition_agentic_secrets",
+                side_effect=RuntimeError("partition failed"),
+            ),
+        ):
+            result = pipeline.run()
+
+        assert result.agentic_status == "degraded"
+        assert result.agentic_input_count == 1
+        assert result.agentic_reviewed_count == 0
+        assert result.agentic_removed_count == 0
+        assert result.agentic_degraded_count == 1
+        assert (
+            result.agentic_reviewed_count
+            + result.agentic_removed_count
+            + result.agentic_degraded_count
+            == result.agentic_input_count
+        )
+
     def test_agentic_candidate_accounting_has_one_terminal_outcome(
         self, tmp_path: Path
     ) -> None:
@@ -1123,6 +1173,14 @@ class TestFanoutAgenticResults:
                 "decision_annotation": DecisionAnnotation(
                     decision="confirmed",
                     justification="The dependency declaration is explicit.",
+                    evidence_locations=[
+                        EvidenceLocation(
+                            file_path=deduped[0].file_path,
+                            start_line=1,
+                            end_line=1,
+                            role="primary",
+                        )
+                    ],
                 ),
             }
         )
@@ -1136,6 +1194,8 @@ class TestFanoutAgenticResults:
             assert c.agentic_hint == ""
             assert c.decision_annotation is not None
             assert c.decision_annotation.decision == "confirmed"
+            assert c.decision_annotation.evidence_locations == []
+            assert c.decision_annotation.code_snippet is None
 
         assert result[0].decision_annotation is not result[1].decision_annotation
 

--- a/aibom/tests/test_scan_pipeline.py
+++ b/aibom/tests/test_scan_pipeline.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 from aibom.agentic.agent import TokenUsage
 from aibom.cross_ref import CrossRefIndex
-from aibom.models import AIComponent, AIComponentType
+from aibom.models import AIComponent, AIComponentType, DecisionAnnotation
 from aibom.scan_pipeline import ScanPipeline, StageTiming
 
 
@@ -28,6 +28,7 @@ class TestScanPipeline:
         assert result.components is not None
         assert result.env_index is not None
         assert result.pkg_index is not None
+        assert result.agentic_status == "skipped"
 
     def test_strict_filters_agentic(self, tmp_path: Path) -> None:
         """Strict mode should remove agentic candidates from results."""
@@ -253,7 +254,20 @@ class TestAgenticScope:
             patch("aibom.scan_pipeline.ensure_llm_runtime_available"),
             patch("aibom.agentic.agent.run_agentic_enrichment") as enrich,
         ):
-            enrich.return_value = ([model], [], [], _stub_token_usage())
+            reviewed_model = model.model_copy(
+                update={
+                    "decision_annotation": DecisionAnnotation(
+                        decision="confirmed",
+                        justification="The model call is present.",
+                    )
+                }
+            )
+            enrich.return_value = (
+                [reviewed_model],
+                [],
+                [],
+                _stub_token_usage(),
+            )
             result = pipeline.run()
 
         assert len(enrich.call_args.kwargs["deterministic_components"]) == 1
@@ -403,9 +417,10 @@ class TestAgenticScope:
         summary = telemetry.record_summary.call_args.kwargs
         assert summary["candidate_count"] == 1
         assert summary["agentic_component_count"] == 1
-        assert summary["decisions"]["kept"] == 1
+        assert summary["decisions"]["kept"] == 0
         assert summary["decisions"]["removed"] == 0
         assert summary["decisions"]["discovered"] == 0
+        assert summary["decisions"]["degraded"] == 1
 
     def test_source_summary_excludes_discovery_removed_by_post_agent_gate(
         self, tmp_path: Path
@@ -446,7 +461,19 @@ class TestAgenticScope:
             patch(
                 "aibom.agentic.agent.run_agentic_enrichment",
                 return_value=(
-                    [dependency, unresolved_endpoint],
+                    [
+                        dependency.model_copy(
+                            update={
+                                "decision_annotation": DecisionAnnotation(
+                                    decision="confirmed",
+                                    justification=(
+                                        "The dependency is declared."
+                                    ),
+                                )
+                            }
+                        ),
+                        unresolved_endpoint,
+                    ],
                     [],
                     [],
                     _stub_token_usage(),
@@ -463,7 +490,7 @@ class TestAgenticScope:
         assert summary["decisions"]["removed"] == 0
         assert summary["decisions"]["discovered"] == 0
 
-    def test_source_summary_does_not_count_post_guard_degraded_as_removed(
+    def test_source_summary_retains_degraded_candidate_as_unreviewed(
         self, tmp_path: Path
     ) -> None:
         unresolved_endpoint = AIComponent(
@@ -506,10 +533,12 @@ class TestAgenticScope:
         ):
             result = pipeline.run()
 
-        assert result.components == []
+        assert len(result.components) == 1
+        assert result.components[0].agentic_hint == "batch_timeout"
+        assert result.components[0].needs_agentic is True
         summary = telemetry.record_summary.call_args.kwargs
         assert summary["candidate_count"] == 1
-        assert summary["agentic_component_count"] == 0
+        assert summary["agentic_component_count"] == 1
         assert summary["decisions"]["kept"] == 0
         assert summary["decisions"]["removed"] == 0
         assert summary["decisions"]["degraded"] == 1
@@ -657,16 +686,37 @@ class TestAgenticScope:
             model_name="gpt-4o",
             agentic_hint="batch_timeout",
         )
-        with patch("aibom.scan_pipeline.ensure_llm_runtime_available"):
-            with patch("aibom.agentic.agent.run_agentic_enrichment") as mock_enrich:
-                mock_enrich.return_value = (
+        with (
+            patch.object(pipeline, "_stage_scan", return_value=([degraded], [])),
+            patch.object(
+                pipeline,
+                "_stage_cross_ref",
+                return_value=(
                     [degraded],
+                    CrossRefIndex(),
+                    CrossRefIndex(),
                     [],
-                    [],
-                    _stub_token_usage(),
-                )
-                result = pipeline.run()
+                ),
+            ),
+            patch("aibom.scan_pipeline.ensure_llm_runtime_available"),
+            patch(
+                "aibom.agentic.agent.run_agentic_enrichment",
+                return_value=([degraded], [], [], _stub_token_usage()),
+            ),
+        ):
+            result = pipeline.run()
         assert result.agentic_degraded_count == 1
+        assert result.agentic_status == "degraded"
+        assert result.agentic_degradation_reasons == {"batch_timeout": 1}
+        assert result.agentic_input_count == 1
+        assert result.agentic_reviewed_count == 0
+        assert result.agentic_removed_count == 0
+        assert (
+            result.agentic_reviewed_count
+            + result.agentic_removed_count
+            + result.agentic_degraded_count
+            == result.agentic_input_count
+        )
 
     def test_degraded_count_zero_when_clean(self, tmp_path: Path) -> None:
         (tmp_path / "app.py").write_text(
@@ -681,12 +731,196 @@ class TestAgenticScope:
             line_number=2,
             model_name="gpt-4o",
             agentic_hint="",
+            decision_annotation=DecisionAnnotation(
+                decision="confirmed",
+                justification="The model call is present.",
+            ),
         )
         with patch("aibom.scan_pipeline.ensure_llm_runtime_available"):
             with patch("aibom.agentic.agent.run_agentic_enrichment") as mock_enrich:
                 mock_enrich.return_value = ([clean], [], [], _stub_token_usage())
                 result = pipeline.run()
         assert result.agentic_degraded_count == 0
+        assert result.agentic_status == "success"
+        assert result.agentic_degradation_reasons == {}
+        assert result.agentic_reviewed_count == 1
+
+    def test_stage_failure_is_machine_readable_without_telemetry(
+        self, tmp_path: Path
+    ) -> None:
+        component = AIComponent(
+            name="gpt-4o",
+            component_type=AIComponentType.MODEL,
+            file_path="app.py",
+            line_number=1,
+            model_name="gpt-4o",
+        )
+        pipeline = ScanPipeline(
+            scan_paths=[str(tmp_path)],
+            llm_config={"model": "test/model", "api_key": "fake"},
+        )
+        with (
+            patch.object(pipeline, "_stage_scan", return_value=([component], [])),
+            patch.object(
+                pipeline,
+                "_stage_cross_ref",
+                return_value=(
+                    [component],
+                    CrossRefIndex(),
+                    CrossRefIndex(),
+                    [],
+                ),
+            ),
+            patch("aibom.scan_pipeline.ensure_llm_runtime_available"),
+            patch(
+                "aibom.agentic.agent.run_agentic_enrichment",
+                side_effect=RuntimeError("provider unavailable"),
+            ),
+        ):
+            result = pipeline.run()
+
+        assert result.agentic_status == "degraded"
+        assert result.agentic_degraded_count == 1
+        assert result.agentic_degradation_reasons == {
+            "agentic_stage_error": 1
+        }
+        assert result.components[0].needs_agentic is True
+        assert result.components[0].agentic_hint == "agentic_stage_error"
+
+    def test_agentic_candidate_accounting_has_one_terminal_outcome(
+        self, tmp_path: Path
+    ) -> None:
+        candidates = [
+            AIComponent(
+                name=f"tool-{index}",
+                component_type=AIComponentType.TOOL,
+                file_path="app.py",
+                line_number=index,
+                instance_id=f"tool-{index}",
+            )
+            for index in range(1, 4)
+        ]
+        confirmed = candidates[0].model_copy(
+            update={
+                "needs_agentic": False,
+                "decision_annotation": DecisionAnnotation(
+                    decision="confirmed",
+                    justification="The tool is invoked by the application.",
+                ),
+            }
+        )
+        unreviewed = candidates[2].model_copy(
+            update={
+                "needs_agentic": True,
+                "agentic_hint": "batch_timeout",
+            }
+        )
+        pipeline = ScanPipeline(
+            scan_paths=[str(tmp_path)],
+            llm_config={"model": "test/model", "api_key": "fake"},
+        )
+        with (
+            patch.object(
+                pipeline,
+                "_stage_scan",
+                return_value=(candidates, []),
+            ),
+            patch.object(
+                pipeline,
+                "_stage_cross_ref",
+                return_value=(
+                    candidates,
+                    CrossRefIndex(),
+                    CrossRefIndex(),
+                    [],
+                ),
+            ),
+            patch("aibom.scan_pipeline.ensure_llm_runtime_available"),
+            patch(
+                "aibom.agentic.agent.run_agentic_enrichment",
+                return_value=(
+                    [confirmed, unreviewed],
+                    [],
+                    [],
+                    _stub_token_usage(),
+                ),
+            ),
+        ):
+            result = pipeline.run()
+
+        assert result.agentic_input_count == 3
+        assert result.agentic_reviewed_count == 1
+        assert result.agentic_removed_count == 1
+        assert result.agentic_degraded_count == 1
+        assert (
+            result.agentic_reviewed_count
+            + result.agentic_removed_count
+            + result.agentic_degraded_count
+            == result.agentic_input_count
+        )
+
+    def test_degraded_candidate_dropped_by_guard_is_counted_as_removed(
+        self, tmp_path: Path
+    ) -> None:
+        removed_agent = AIComponent(
+            name="shared",
+            component_type=AIComponentType.AGENT,
+            file_path="removed.py",
+            line_number=1,
+            instance_id="removed-agent",
+        )
+        degraded_candidate = AIComponent(
+            name="shared",
+            component_type=AIComponentType.AGENT,
+            file_path="degraded.py",
+            line_number=2,
+            instance_id="degraded-agent",
+        )
+        degraded_agent = degraded_candidate.model_copy(
+            update={
+                "needs_agentic": True,
+                "agentic_hint": "batch_timeout",
+            }
+        )
+        pipeline = ScanPipeline(
+            scan_paths=[str(tmp_path)],
+            llm_config={"model": "test/model", "api_key": "fake"},
+        )
+        with (
+            patch.object(
+                pipeline,
+                "_stage_scan",
+                return_value=([removed_agent, degraded_candidate], []),
+            ),
+            patch.object(
+                pipeline,
+                "_stage_cross_ref",
+                return_value=(
+                    [removed_agent, degraded_candidate],
+                    CrossRefIndex(),
+                    CrossRefIndex(),
+                    [],
+                ),
+            ),
+            patch("aibom.scan_pipeline.ensure_llm_runtime_available"),
+            patch(
+                "aibom.agentic.agent.run_agentic_enrichment",
+                return_value=(
+                    [degraded_agent],
+                    [],
+                    [],
+                    _stub_token_usage(),
+                ),
+            ),
+        ):
+            result = pipeline.run()
+
+        assert result.components == []
+        assert result.agentic_input_count == 2
+        assert result.agentic_reviewed_count == 0
+        assert result.agentic_removed_count == 2
+        assert result.agentic_degraded_count == 0
+        assert result.agentic_degradation_reasons == {}
 
 
 class TestFileCache:
@@ -881,14 +1115,64 @@ class TestFanoutAgenticResults:
         ]
         deduped, fanout = _dedup_for_agentic(comps)
         rep = deduped[0].model_copy(
-            update={"heuristic_confidence": 0.95, "needs_agentic": False}
+            update={
+                "heuristic_confidence": 0.95,
+                "agentic_confidence": 0.9,
+                "needs_agentic": False,
+                "agentic_hint": "",
+                "decision_annotation": DecisionAnnotation(
+                    decision="confirmed",
+                    justification="The dependency declaration is explicit.",
+                ),
+            }
         )
 
         result = _fanout_agentic_results([rep], fanout)
         assert len(result) == 2
         for c in result:
             assert c.heuristic_confidence == 0.95
+            assert c.agentic_confidence == 0.9
             assert c.needs_agentic is False
+            assert c.agentic_hint == ""
+            assert c.decision_annotation is not None
+            assert c.decision_annotation.decision == "confirmed"
+
+        assert result[0].decision_annotation is not result[1].decision_annotation
+
+    def test_fanout_propagates_degradation_reason(self):
+        from aibom.scan_pipeline import _dedup_for_agentic, _fanout_agentic_results
+
+        comps = [
+            AIComponent(
+                name="torch",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="a/req.txt",
+                line_number=1,
+            ),
+            AIComponent(
+                name="torch",
+                component_type=AIComponentType.DEPENDENCY,
+                file_path="b/req.txt",
+                line_number=1,
+            ),
+        ]
+        deduped, fanout = _dedup_for_agentic(comps)
+        degraded = deduped[0].model_copy(
+            update={
+                "needs_agentic": True,
+                "agentic_hint": "batch_timeout",
+                "decision_annotation": None,
+            }
+        )
+
+        result = _fanout_agentic_results([degraded], fanout)
+
+        assert len(result) == 2
+        assert all(component.needs_agentic for component in result)
+        assert all(
+            component.agentic_hint == "batch_timeout" for component in result
+        )
+        assert all(component.decision_annotation is None for component in result)
 
     def test_fanout_propagates_removal(self):
         from aibom.scan_pipeline import _dedup_for_agentic, _fanout_agentic_results
@@ -958,6 +1242,44 @@ class TestFanoutAgenticResults:
 
 
 class TestPropagateRemovals:
+    def test_kept_components_preserve_agentic_verdicts(self):
+        from aibom.scan_pipeline import _propagate_removals
+
+        removed = AIComponent(
+            name="ordinary-wrapper",
+            component_type=AIComponentType.AGENT,
+            file_path="src/wrapper.py",
+            line_number=1,
+        )
+        original_kept = AIComponent(
+            name="openai",
+            component_type=AIComponentType.DEPENDENCY,
+            file_path="requirements.txt",
+            line_number=1,
+        )
+        enriched_kept = original_kept.model_copy(
+            update={
+                "needs_agentic": False,
+                "agentic_hint": "",
+                "decision_annotation": DecisionAnnotation(
+                    decision="confirmed",
+                    justification="The manifest declares an AI dependency.",
+                ),
+            }
+        )
+
+        result = _propagate_removals(
+            sent=[removed, original_kept],
+            received=[enriched_kept],
+            all_candidates=[removed, original_kept],
+            pre_fanout_removed_ids={removed.instance_id},
+        )
+
+        assert result == [enriched_kept]
+        assert result[0] is enriched_kept
+        assert result[0].decision_annotation is not None
+        assert result[0].decision_annotation.decision == "confirmed"
+
     def test_prefanout_removed_ids_drop_all_matching_siblings(self):
         from aibom.scan_pipeline import _propagate_removals
 

--- a/docs/AGENTIC_MODE.md
+++ b/docs/AGENTIC_MODE.md
@@ -193,8 +193,13 @@ cisco-aibom analyze ./my-repo \
 1. **Candidate triage** — After deterministic scanning, all candidates are split into "simple" (registry-confirmable, e.g. known model IDs, manifest dependencies) and "complex" (needs deeper reasoning) tiers.
 2. **Locality-aware batching** — Candidates are grouped by directory to provide better code context per batch.
 3. **Agent tools** — The agent has access to tools: `read_file_snippet` (inspect source), `search_codebase` (regex-style search across the scanned tree), `trace_data_flow` (follow a symbol's assignments and call sites), `search_package_info` (queries PyPI/npm/Go registries), `analyze_imports`, `lookup_model`, and `resolve_env_var`. It uses these to confirm or reject each candidate.
-4. **Structured output** — Each batch returns a structured JSON response with confirmed components, removed false positives, reclassifications, relationships, and risk findings. Kept findings carry `decision_annotation` metadata with justification and evidence references. Raw code snippets are only included when `--include-code-snippets` is enabled.
+4. **Structured output** — Each batch returns a structured JSON response with confirmed components, removed false positives, reclassifications, relationships, and risk findings. Reviewed existing components use `decision_annotation.decision: confirmed`; agentic discoveries use `added`. A deterministic candidate retained without a usable verdict uses `unreviewed`, keeps `needs_agentic: true`, and is not presented as confirmed. Raw code snippets are only included when `--include-code-snippets` is enabled.
 5. **Caching** — Results are cached by content hash at `~/.aibom/cache/agentic/`. Unchanged components reuse cached results on subsequent runs.
+
+Agent and agent-proxy evidence is verified against the allowed source file. If
+the cited line range is stale, the verifier repairs it only when the exact
+whitespace-normalized snippet has one unique match in that same file. Missing,
+ambiguous, non-numeric, unreadable, or out-of-scope evidence is rejected.
 
 ## Circuit Breaker
 
@@ -202,7 +207,23 @@ To protect against runaway API costs, a circuit breaker trips after 3 consecutiv
 
 - Remaining batches are skipped.
 - Skipped components are marked with `agentic_hint: circuit_breaker_tripped`.
-- The deterministic detection results are preserved.
+- The deterministic detection results are preserved as `unreviewed` with
+  `needs_agentic: true`.
+
+Timed-out work is retried in smaller batches, within the existing retry budget,
+before it is left unreviewed. The JSON report records agentic completeness
+separately from normal scan completion:
+
+- `aibom_analysis.metadata.agentic_status` is `success`, `degraded`, or
+  `skipped`.
+- `agentic_degraded_count` is the number of input candidates retained by the
+  agentic stage without a usable verdict.
+- `agentic_degradation_reasons` maps stable failure hints to affected-candidate
+  counts.
+
+The same fields appear in each source's `summary`. A degraded agentic pass does
+not turn an otherwise successful scan into a run error: the report can retain
+`status: completed` while separately reporting `agentic_status: degraded`.
 
 ## Cache Management
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -174,6 +174,8 @@ Components with an explicit reviewed verdict use `confirmed`, and agentic
 discoveries use `added`. A retained component that did not receive a usable
 verdict uses `decision_annotation.decision = "unreviewed"`, keeps
 `needs_agentic = true`, and preserves its failure reason in `agentic_hint`.
+Whole-scan and organization-cache hits preserve these agentic outcome fields;
+legacy organization-cache entries that lack them are ignored and regenerated.
 
 ### `report show`
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -175,7 +175,7 @@ discoveries use `added`. A retained component that did not receive a usable
 verdict uses `decision_annotation.decision = "unreviewed"`, keeps
 `needs_agentic = true`, and preserves its failure reason in `agentic_hint`.
 Whole-scan and organization-cache hits preserve these agentic outcome fields;
-legacy organization-cache entries that lack them are ignored and regenerated.
+legacy cache entries that lack them are ignored and regenerated.
 
 ### `report show`
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -156,7 +156,24 @@ cisco-aibom report show REPORT_FILE [--raw-json]
 cisco-aibom report upload REPORT_FILE --format json --post-url URL [OPTIONS]
 ```
 
-The JSON reporter writes `aibom_analysis.metadata.report_schema_version = "1"`. Unversioned legacy JSON reports are still accepted for `report upload`; the CLI warns and synthesizes the current schema version before submitting.
+The JSON reporter writes
+`aibom_analysis.metadata.report_schema_version = "2"`. Unversioned legacy JSON
+reports are still accepted for `report upload`; the CLI warns and synthesizes
+the current schema version before submitting.
+
+Agentic completeness is reported independently from the normal scan status.
+Run metadata and each per-source `summary` include:
+
+| Field | Description |
+|---|---|
+| `agentic_status` | `success`, `degraded`, or `skipped`. |
+| `agentic_degraded_count` | Input candidates retained by the agentic stage without a usable verdict. |
+| `agentic_degradation_reasons` | Failure-hint counts for those candidates. |
+
+Components with an explicit reviewed verdict use `confirmed`, and agentic
+discoveries use `added`. A retained component that did not receive a usable
+verdict uses `decision_annotation.decision = "unreviewed"`, keeps
+`needs_agentic = true`, and preserves its failure reason in `agentic_hint`.
 
 ### `report show`
 

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -25,8 +25,8 @@
 5. **Scan Pipeline Stage 1: Scan** — Run all registered scanners against the source files. Each scanner produces components and relationships. File I/O uses async caching for performance.
 6. **Scan Pipeline Stage 2: Cross-Ref** — Build env-var and package indexes. Resolve env-var references (`os.getenv("MODEL_NAME")`) to concrete values by correlating across files, `.env`, docker-compose, Helm, and Terraform.
 7. **Scan Pipeline Stage 3: Agentic** — Classify all candidates into simple/complex tiers. Run locality-aware batched LLM classification. The agent confirms, rejects, reclassifies, or enriches each candidate using tools (`read_file_snippet`, `search_codebase`, `trace_data_flow`, `search_package_info`, `analyze_imports`, `lookup_model`, `resolve_env_var`). Apply structured output (enrichments, new components, removals, risk findings). Cache results by content hash.
-8. **Scan Pipeline Stage 4: Assemble** — Apply `--strict` filtering (drop `needs_agentic` items), collect counts and timing, build the final `PipelineResult`, and ensure final findings carry decision annotations.
-9. **Reporting** — Route `PipelineResult` to the selected reporter. Convert container temp paths to container-style paths. Build per-source summaries, schema version metadata, and run metadata.
+8. **Scan Pipeline Stage 4: Assemble** — Apply `--strict` filtering (drop `needs_agentic` items), collect counts and timing, build the final `PipelineResult`, and ensure final findings carry honest `confirmed`, `added`, or `unreviewed` component decisions.
+9. **Reporting** — Route `PipelineResult` to the selected reporter. Convert container temp paths to container-style paths. Build per-source summaries, schema version metadata, run metadata, and separate machine-readable agentic completion status/count/reasons.
 10. **Post-Processing** — Optionally POST the JSON report with retries or upload an already-generated JSON report, run policy checks, display compliance advisories, render Rich console summary.
 
 ## 3. Scanner Architecture


### PR DESCRIPTION
## Summary

- Separate normal scan completion from agentic completeness with run-level and per-source `agentic_status`, `agentic_degraded_count`, and `agentic_degradation_reasons` fields.
- Emit honest component decisions: reviewed existing findings are `confirmed`, agentic discoveries are `added`, and retained findings without a usable verdict are `unreviewed` with `needs_agentic: true` and a stable degradation hint. Relationship and risk decisions remain `derived` and `flagged`.
- Preserve verdicts, confidence, evidence, and degradation reasons through decision memo replay, pre-agentic dedup fanout, guarded removal propagation, final annotation, JSON reporting, report-file load/regeneration, upload fanout, and both cache paths.
- Reject and regenerate legacy organization and whole-scan cache entries that lack the agentic outcome contract, preventing an earlier degraded result from being replayed as `skipped`.
- Reconcile terminal candidate accounting after guarded filtering so reviewed + removed + degraded equals the deduplicated agentic input population without counting discoveries.
- Retry timed-out batches at half size within the existing bounded retry budget and circuit breaker. Repair stale agent evidence line ranges only when an exact whitespace-normalized snippet has one unique match in the same allowed source file; missing, ambiguous, non-numeric, unreadable, and out-of-scope evidence remains rejected.
- Document the report contract, decision meanings, retry behavior, evidence repair rule, cache compatibility behavior, and the distinction between scan and agentic status.

## Behavior

A partial but otherwise successful BOM continues to exit successfully and report `status: completed` with `error_count: 0`. If agentic review is incomplete, the separate agentic fields report degradation and its causes, while downstream clients can distinguish or filter `unreviewed` components without treating the scan itself as failed.

## Verification

- CI-equivalent environment: `2445 passed, 13 skipped`.
- Hosted checks pass on Python 3.11, 3.12, and 3.13, plus CodeQL and version synchronization.
- Public sample E2E: `openai/openai-cs-agents-demo@bd7bfca`. The live pass exercised batch timeouts, smaller retry batches, explicit removals, and unique same-file evidence range repairs. The resulting report contained 3 `confirmed`, 4 `added`, and 3 `unreviewed` components with `agentic_status: degraded`, `agentic_degraded_count: 3`, and `batch_timeout: 3`.
- Real cache matrix on the same repository: a current whole-scan cache hit preserved the run/source outcome; removing only the three agentic outcome fields produced the legacy warning, reran all four pipeline stages, rewrote the cache, and preserved the same degraded result on the next cache hit.
- Actual `report upload` to a local capture endpoint preserved run-level and per-source agentic outcome fields as well as all three `unreviewed` components, their `needs_agentic: true` markers, and failure hints.