### PR TITLE
feat(kb): add schema v2 distribution workflow

### DIFF
--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "httpx>=0.28.1",
     "rich>=13.9.0",
     "platformdirs>=4.0.0",
+    "cryptography>=45.0.0",
     "pyyaml>=6.0",
     "pathspec>=0.12.0",
     "cyclonedx-python-lib>=9.0.0",

--- a/aibom/src/aibom/cli.py
+++ b/aibom/src/aibom/cli.py
@@ -21,6 +21,7 @@ import logging
 import os
 import shutil
 import sys
+import time
 import uuid
 from collections import Counter
 from datetime import datetime
@@ -2645,6 +2646,17 @@ def analyze(
         )
         scan_result.risk.flags = annotated_risk_flags
 
+        from .kb.coverage import build_coverage_gaps
+
+        coverage_gaps = build_coverage_gaps(scan_result)
+        if coverage_gaps:
+            console.print(
+                "[yellow]KB coverage gap:[/] "
+                f"{coverage_gaps['uncatalogued_ai_symbol_count']} "
+                "AI-relevant symbol(s) are not catalogued."
+            )
+            console.print(f"[dim]{coverage_gaps['request_hint']}[/]")
+
         if compliance:
             from .compliance import (
                 ComplianceFramework,
@@ -3324,26 +3336,80 @@ def plugin_list() -> None:
 def kb_download(
     version: Optional[str] = typer.Option(
         None,
+        "--aibom-kb-version",
         "--version",
-        "-v",
         help="Specific KB version to download (latest if omitted).",
     ),
     url: Optional[str] = typer.Option(
         None,
+        "--aibom-manifest-url",
         "--url",
-        help=(
-            "KB manifest URL. Required: pass --url or set CISCO_AIBOM_MANIFEST_URL. "
-            "No default is shipped."
-        ),
+        help=("Direct regional S3 HTTPS manifest URL. Overrides a configured pin."),
+    ),
+    allow_unsigned: bool = typer.Option(
+        False,
+        "--allow-unsigned-rehearsal",
+        help="Allow an explicitly unsigned rehearsal artifact. Never use for releases.",
+        hidden=True,
+    ),
+    prefetched_manifest: Optional[Path] = typer.Option(
+        None,
+        "--prefetched-manifest",
+        exists=True,
+        readable=True,
+        dir_okay=False,
+        help="Install prefetched manifest and sibling objects through normal validation.",
     ),
 ) -> None:
-    """Download the knowledge base from the configured remote."""
+    """Download and cryptographically verify a schema-v2 knowledge base."""
     mgr = KBManager()
     try:
-        path = mgr.download(version=version, url=url)
+        if prefetched_manifest:
+            if version or url:
+                raise KBError(
+                    "--prefetched-manifest cannot be combined with a version or URL"
+                )
+            path = mgr.install_prefetched(
+                prefetched_manifest,
+                allow_unsigned=allow_unsigned,
+            )
+        else:
+            path = mgr.download(
+                version=version,
+                url=url,
+                allow_unsigned=allow_unsigned,
+            )
         console.print(f"[green]KB downloaded to {path}[/]")
     except KBError as exc:
         console.print(f"[bold red]Download failed:[/] {exc}")
+        raise typer.Exit(code=1)
+
+
+@kb_app.command("pin")
+def kb_pin(
+    value: Optional[str] = typer.Argument(
+        None,
+        help="Exact KB version or immutable direct S3 manifest URL.",
+    ),
+    clear: bool = typer.Option(False, "--clear", help="Remove the configured pin."),
+) -> None:
+    """Pin downloads to one immutable KB version or manifest URL."""
+
+    mgr = KBManager()
+    try:
+        if clear and value:
+            raise KBError("Pass either a pin value or --clear, not both")
+        if not clear and not value:
+            current = mgr.configured_pin()
+            console.print(current or "No KB pin configured.")
+            return
+        path = mgr.set_pin(None if clear else value)
+        if clear:
+            console.print(f"[green]KB pin cleared in {path}[/]")
+        else:
+            console.print(f"[green]KB pin set to {value} in {path}[/]")
+    except KBError as exc:
+        console.print(f"[bold red]Pin failed:[/] {exc}")
         raise typer.Exit(code=1)
 
 
@@ -3392,14 +3458,211 @@ def kb_verify() -> None:
         raise typer.Exit(code=1)
 
 
+def _normalize_kb_requests(raw: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        raise KBError("KB request input must be a JSON array")
+    grouped: dict[tuple[str, str], set[str]] = {}
+    allowed = {"cargo", "npm", "nuget", "pypi", "rubygems"}
+    for item in raw:
+        if not isinstance(item, dict):
+            raise KBError("Each KB request must be a JSON object")
+        ecosystem = str(item.get("ecosystem") or "").strip().lower()
+        package_name = str(item.get("package_name") or "").strip()
+        item_symbols = item.get("symbols")
+        if ecosystem not in allowed:
+            raise KBError(f"Unsupported ecosystem: {ecosystem or '(empty)'}")
+        if not package_name or not isinstance(item_symbols, list):
+            raise KBError("Each request requires package_name and a symbols array")
+        cleaned = {str(value).strip() for value in item_symbols if str(value).strip()}
+        if not cleaned:
+            raise KBError(f"Package {package_name} has no symbols")
+        grouped.setdefault((ecosystem, package_name), set()).update(cleaned)
+    requests = [
+        {
+            "ecosystem": ecosystem,
+            "package_name": package_name,
+            "symbols": sorted(values),
+        }
+        for (ecosystem, package_name), values in sorted(grouped.items())
+    ]
+    if not requests:
+        raise KBError("At least one KB request is required")
+    if len(requests) > 20 or sum(len(item["symbols"]) for item in requests) > 200:
+        raise KBError("A request supports at most 20 packages and 200 symbols")
+    return requests
+
+
+def _load_kb_requests(
+    *,
+    ecosystem: Optional[str],
+    package_name: Optional[str],
+    symbols: list[str],
+    from_scan: Optional[Path],
+    symbols_from: Optional[Path],
+) -> list[dict[str, Any]]:
+    selected = sum(
+        bool(value)
+        for value in (
+            from_scan,
+            symbols_from,
+            ecosystem or package_name or symbols,
+        )
+    )
+    if selected != 1:
+        raise KBError(
+            "Provide one source: --from-scan, --symbols-from, or "
+            "--ecosystem/--package/--symbol"
+        )
+    if from_scan:
+        try:
+            payload = json.loads(from_scan.read_text(encoding="utf-8"))
+            gaps = payload["aibom_analysis"]["coverage_gaps"]["packages"]
+        except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+            raise KBError("Scan report has no valid coverage_gaps block") from exc
+        return _normalize_kb_requests(gaps)
+    if symbols_from:
+        try:
+            text_value = symbols_from.read_text(encoding="utf-8")
+            try:
+                parsed = json.loads(text_value)
+            except json.JSONDecodeError:
+                parsed = []
+                for line_number, line in enumerate(text_value.splitlines(), start=1):
+                    if not line.strip() or line.lstrip().startswith("#"):
+                        continue
+                    parts = [part.strip() for part in line.split(",", 2)]
+                    if len(parts) != 3:
+                        raise KBError(
+                            f"Invalid symbols file line {line_number}; expected "
+                            "ecosystem,package,symbol"
+                        )
+                    parsed.append(
+                        {
+                            "ecosystem": parts[0],
+                            "package_name": parts[1],
+                            "symbols": [parts[2]],
+                        }
+                    )
+        except OSError as exc:
+            raise KBError(f"Could not read symbols file: {exc}") from exc
+        return _normalize_kb_requests(parsed)
+    return _normalize_kb_requests(
+        [
+            {
+                "ecosystem": ecosystem,
+                "package_name": package_name,
+                "symbols": symbols,
+            }
+        ]
+    )
+
+
+def _print_kb_request_result(result: dict[str, Any]) -> None:
+    request = result.get("request")
+    if isinstance(request, dict):
+        console.print(
+            f"[green]Request accepted:[/] {request.get('request_id', 'unknown')}"
+        )
+        console.print(f"State: {request.get('state', 'unknown')}")
+        console.print(f"Disposition: {request.get('disposition', 'unknown')}")
+        if request.get("estimated_build_eta"):
+            console.print(f"Estimated build ETA: {request['estimated_build_eta']}")
+        console.print(f"Coalesced: {bool(result.get('coalesced'))}")
+    else:
+        console.print(
+            "[green]Request IDs:[/] "
+            + (", ".join(result.get("request_ids", [])) or "coalesced")
+        )
+        console.print(f"Duplicates: {len(result.get('duplicates', []))}")
+        console.print(f"Rejected: {len(result.get('rejected', []))}")
+    console.print(f"Quota remaining: {result.get('quota_remaining', 'unknown')}")
+    rate_limit = result.get("rate_limit") or {}
+    if any(rate_limit.values()):
+        console.print(
+            "Rate limit: "
+            f"{rate_limit.get('remaining', '?')}/{rate_limit.get('limit', '?')} "
+            f"(reset {rate_limit.get('reset', '?')})"
+        )
+
+
+def _watch_kb_request(
+    manager: KBManager,
+    request_id: str,
+    *,
+    api_key: Optional[str],
+    api_base: Optional[str],
+    json_output: bool,
+) -> dict[str, Any]:
+    delay = 30
+    deadline = time.monotonic() + 24 * 60 * 60
+    terminal = {"available", "rejected"}
+    while True:
+        result = manager.request_status(
+            request_id,
+            api_key=api_key,
+            api_base=api_base,
+        )
+        if json_output:
+            console.print_json(data=result)
+        else:
+            console.print(
+                f"{request_id}: {result.get('state', 'unknown')}"
+                + (
+                    f" (KB {result['available_kb_version']})"
+                    if result.get("available_kb_version")
+                    else ""
+                )
+            )
+        if result.get("state") in terminal:
+            return result
+        if time.monotonic() + delay > deadline:
+            raise KBError(f"Watch timed out after 24 hours for request {request_id}")
+        time.sleep(delay)
+        delay = min(delay * 2, 5 * 60)
+
+
 @kb_app.command("request")
 def kb_request(
-    sdk: str = typer.Option(..., "--sdk", help="SDK name (e.g., langchain, openai)."),
-    version: str = typer.Option(
-        ..., "--version", "-v", help="SDK version to request KB build for."
+    ecosystem: Optional[str] = typer.Option(
+        None,
+        "--ecosystem",
+        help="Package ecosystem: cargo, npm, nuget, pypi, or rubygems.",
     ),
-    language: str = typer.Option(
-        "python", "--language", "-l", help="Programming language."
+    package_name: Optional[str] = typer.Option(
+        None,
+        "--package",
+        help="Package name containing the uncatalogued symbols.",
+    ),
+    symbols: Optional[List[str]] = typer.Option(
+        None,
+        "--symbol",
+        help="Uncatalogued symbol. Repeat for multiple symbols.",
+    ),
+    from_scan: Optional[Path] = typer.Option(
+        None,
+        "--from-scan",
+        exists=True,
+        readable=True,
+        dir_okay=False,
+        help="Read package groups from a JSON report's coverage_gaps block.",
+    ),
+    symbols_from: Optional[Path] = typer.Option(
+        None,
+        "--symbols-from",
+        exists=True,
+        readable=True,
+        dir_okay=False,
+        help="Read requests from JSON or ecosystem,package,symbol lines.",
+    ),
+    watch: bool = typer.Option(
+        False,
+        "--watch",
+        help="Poll accepted requests with bounded exponential backoff.",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Print the structured API response as JSON.",
     ),
     api_key: Optional[str] = typer.Option(
         None,
@@ -3414,20 +3677,51 @@ def kb_request(
         help="Cisco AI Defense API base URL.",
     ),
 ) -> None:
-    """Request a knowledge base build for a specific SDK version."""
+    """Request coverage for one package or a bounded batch of scan gaps."""
     mgr = KBManager()
     try:
-        result = mgr.request_build(
-            sdk=sdk,
-            version=version,
-            language=language,
-            api_key=api_key,
-            api_base=api_base,
+        requests = _load_kb_requests(
+            ecosystem=ecosystem,
+            package_name=package_name,
+            symbols=symbols or [],
+            from_scan=from_scan,
+            symbols_from=symbols_from,
         )
-        console.print(
-            f"[green]Request submitted:[/] {result.get('request_id', 'unknown')}"
-        )
-        console.print(f"Status: {result.get('status', 'unknown')}")
+        if len(requests) == 1:
+            item = requests[0]
+            result = mgr.request_build(
+                ecosystem=item["ecosystem"],
+                package_name=item["package_name"],
+                symbols=item["symbols"],
+                api_key=api_key,
+                api_base=api_base,
+            )
+            request = result.get("request", {})
+            request_ids = [str(request.get("request_id", ""))]
+        else:
+            result = mgr.request_bulk(
+                requests,
+                api_key=api_key,
+                api_base=api_base,
+            )
+            request_ids = [str(value) for value in result.get("request_ids", [])]
+            request_ids.extend(
+                str(item.get("request_id", "")) for item in result.get("duplicates", [])
+            )
+        request_ids = [value for value in request_ids if value]
+        if json_output:
+            console.print_json(data=result)
+        else:
+            _print_kb_request_result(result)
+        if watch:
+            for request_id in dict.fromkeys(request_ids):
+                _watch_kb_request(
+                    mgr,
+                    request_id,
+                    api_key=api_key,
+                    api_base=api_base,
+                    json_output=json_output,
+                )
     except KBError as exc:
         console.print(f"[bold red]Request failed:[/] {exc}")
         raise typer.Exit(code=1)
@@ -3470,27 +3764,47 @@ def kb_list_requests(
         "--api-base",
         envvar="CISCO_AI_DEFENSE_API_BASE",
     ),
+    limit: int = typer.Option(
+        50,
+        "--limit",
+        min=1,
+        max=100,
+        help="Maximum number of tenant-scoped requests to return.",
+    ),
 ) -> None:
     """List all pending KB build requests."""
     mgr = KBManager()
     try:
-        requests = mgr.list_requests(api_key=api_key, api_base=api_base)
+        requests = mgr.list_requests(
+            api_key=api_key,
+            api_base=api_base,
+            limit=limit,
+        )
         if not requests:
             console.print("No pending requests.")
             return
         table = Table(title="KB Build Requests", box=box.SIMPLE_HEAVY)
         table.add_column("Request ID")
-        table.add_column("SDK")
-        table.add_column("Version")
-        table.add_column("Language")
-        table.add_column("Status")
+        table.add_column("Packages")
+        table.add_column("Symbols")
+        table.add_column("State")
+        table.add_column("Disposition")
         for req in requests:
+            items = req.get("requests") or []
+            packages = ", ".join(
+                f"{item.get('ecosystem', '')}:{item.get('package_name', '')}"
+                for item in items
+                if isinstance(item, dict)
+            )
+            symbol_count = sum(
+                len(item.get("symbols", [])) for item in items if isinstance(item, dict)
+            )
             table.add_row(
                 req.get("request_id", ""),
-                req.get("sdk", ""),
-                req.get("version", ""),
-                req.get("language", ""),
-                req.get("status", ""),
+                packages,
+                str(symbol_count),
+                req.get("state", ""),
+                req.get("disposition", ""),
             )
         console.print(table)
     except KBError as exc:

--- a/aibom/src/aibom/kb/coverage.py
+++ b/aibom/src/aibom/kb/coverage.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared output projection for uncatalogued AI symbols."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from ..models import ScanResult
+
+
+def build_coverage_gaps(result: ScanResult) -> dict[str, Any] | None:
+    """Group uncatalogued AI symbols by package for reports and requests."""
+
+    grouped: dict[tuple[str, str], set[str]] = {}
+    for component in result.all_components:
+        metadata = component.metadata
+        if not metadata.get("uncatalogued_ai_symbol"):
+            continue
+        ecosystem = str(metadata.get("ecosystem") or "").strip().lower()
+        package_name = str(metadata.get("package_name") or "").strip()
+        symbol = str(metadata.get("uncatalogued_symbol") or component.name).strip()
+        if ecosystem and package_name and symbol:
+            grouped.setdefault((ecosystem, package_name), set()).add(symbol)
+    if not grouped:
+        return None
+
+    packages = [
+        {
+            "ecosystem": ecosystem,
+            "package_name": package_name,
+            "symbols": sorted(symbols),
+        }
+        for (ecosystem, package_name), symbols in sorted(grouped.items())
+    ]
+    symbol_count = sum(len(item["symbols"]) for item in packages)
+    has_api_key = bool(os.environ.get("CISCO_AI_DEFENSE_API_KEY"))
+    return {
+        "informational": True,
+        "uncatalogued_ai_symbol_count": symbol_count,
+        "scan_cache_id": str(result.metadata.get("run_id") or ""),
+        "packages": packages,
+        "request_hint": (
+            "Run `cisco-aibom kb request --from-scan <report.json>` to request "
+            "coverage for these symbols."
+            if has_api_key
+            else "Configure a Cisco AI Defense tenant API key to request KB coverage."
+        ),
+    }

--- a/aibom/src/aibom/kb/manager.py
+++ b/aibom/src/aibom/kb/manager.py
@@ -16,27 +16,51 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
+import gzip
 import hashlib
 import json
 import logging
 import os
+import re
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import duckdb
 import httpx
 import platformdirs
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, utils
+from packaging.version import InvalidVersion, Version
 from pydantic import ValidationError
 
-from .manifest import KBManifest, KBManifestIndex
+from ..utils.version import resolve_package_version
+from .manifest import KBManifest, KBManifestIndex, KBManifestV2
 from .vocabulary import CONCEPTS, SCHEMA_VERSION, VOCABULARY_VERSION, schema_major
 
 LOGGER = logging.getLogger(__name__)
 
-DEFAULT_MANIFEST_URL: str | None = None
+DEFAULT_MANIFEST_URL = (
+    "https://cisco-ai-defense-public.s3.us-west-2.amazonaws.com/"
+    "aibom/kb/manifest.json"
+)
 DEFAULT_API_BASE: str | None = None
 HTTP_TIMEOUT = httpx.Timeout(120.0)
+MAX_REDIRECTS = 3
+MAX_MANIFEST_BYTES = 1024 * 1024
+MAX_SIGNATURE_BYTES = 64 * 1024
+MAX_PUBLIC_KEY_BYTES = 64 * 1024
+MAX_COMPRESSED_BYTES = 4 * 1024 * 1024 * 1024
+MAX_DECOMPRESSED_BYTES = 16 * 1024 * 1024 * 1024
+_DIRECT_S3_HOST = re.compile(
+    r"^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\.s3\."
+    r"[a-z]{2}-[a-z0-9-]+-[0-9]+\.amazonaws\.com$"
+)
 
 _REGIONAL_ENDPOINT_HINT = (
     "Regional API hosts follow the same pattern as AIBOM_POST_URL — "
@@ -50,11 +74,19 @@ class KBError(Exception):
 
 
 class KBManager:
-    def __init__(self, *, manifest_url: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        manifest_url: str | None = None,
+        installed_cli_version: str | None = None,
+    ) -> None:
         self._default_manifest_url = (
             manifest_url
             or os.environ.get("CISCO_AIBOM_MANIFEST_URL")
             or DEFAULT_MANIFEST_URL
+        )
+        self._installed_cli_version = installed_cli_version or resolve_package_version(
+            "cisco-aibom"
         )
 
     def _resolve_manifest_url(self, url: str | None) -> str:
@@ -73,6 +105,9 @@ class KBManager:
     def _local_manifest_path(self) -> Path:
         return self._user_root() / "manifest.json"
 
+    def _config_path(self) -> Path:
+        return Path(platformdirs.user_config_dir("aibom")) / "kb.json"
+
     def _local_kb_dir(self) -> Path:
         d = self._user_root() / "catalogs"
         d.mkdir(parents=True, exist_ok=True)
@@ -85,27 +120,253 @@ class KBManager:
                 h.update(chunk)
         return h.hexdigest()
 
+    def _compressed_path(self, kb_version: str) -> Path:
+        return self._local_kb_dir() / f"kb-{kb_version}.duckdb.gz"
+
+    def _signature_path(self, kb_version: str) -> Path:
+        return self._local_kb_dir() / f"kb-{kb_version}.duckdb.gz.sig"
+
+    def _public_key_path(self, kb_version: str) -> Path:
+        return self._local_kb_dir() / f"kb-{kb_version}.pub"
+
+    def configured_pin(self) -> str | None:
+        path = self._config_path()
+        try:
+            exists = path.exists()
+        except OSError as exc:
+            raise KBError(f"Could not read KB configuration: {exc}") from exc
+        if not exists:
+            return None
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise KBError(f"Invalid KB configuration: {exc}") from exc
+        pin = raw.get("kb_pin") if isinstance(raw, dict) else None
+        return pin.strip() if isinstance(pin, str) and pin.strip() else None
+
+    def set_pin(self, pin: str | None) -> Path:
+        path = self._config_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        value = pin.strip() if pin else ""
+        if value.startswith("https://"):
+            self._validate_direct_s3_url(value, field="kb_pin")
+            if not value.endswith("/manifest.json"):
+                raise KBError("Pinned manifest URL must end with /manifest.json")
+        elif value and not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", value):
+            raise KBError("Pinned KB version is invalid")
+        path.write_text(
+            json.dumps({"kb_pin": value or None}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return path
+
     def _api_headers(self, api_key: str, *, json_body: bool = False) -> dict[str, str]:
         h: dict[str, str] = {"x-cisco-ai-defense-tenant-api-key": api_key}
         if json_body:
             h["Content-Type"] = "application/json"
         return h
 
+    def _validate_direct_s3_url(
+        self,
+        raw: str,
+        *,
+        field: str,
+        expected_origin: tuple[str, str] | None = None,
+    ) -> tuple[str, str]:
+        parsed = urlsplit(raw)
+        try:
+            port = parsed.port
+        except ValueError as exc:
+            raise KBError(f"{field} contains an invalid port") from exc
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or port is not None
+            or parsed.query
+            or parsed.fragment
+            or not _DIRECT_S3_HOST.fullmatch(parsed.hostname)
+            or not parsed.path.startswith("/aibom/kb/")
+            or parsed.path.count("/aibom/kb/") != 1
+            or "//" in parsed.path
+            or "%" in parsed.path
+        ):
+            raise KBError(
+                f"{field} must be a direct regional S3 HTTPS URL under /aibom/kb/"
+            )
+        origin = (parsed.scheme, parsed.hostname)
+        if expected_origin and origin != expected_origin:
+            raise KBError(f"{field} must use the manifest's S3 origin")
+        return origin
+
+    def _validate_https_url(self, raw: str, *, field: str) -> None:
+        parsed = urlsplit(raw)
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.fragment
+        ):
+            raise KBError(f"{field} must be an absolute HTTPS URL")
+
+    def _version_manifest_url(self, pointer_url: str, version: str) -> str:
+        parsed = urlsplit(pointer_url)
+        if not parsed.path.endswith("/manifest.json"):
+            raise KBError("KB pointer URL must end with /manifest.json")
+        base_path = parsed.path[: -len("manifest.json")]
+        path = f"{base_path}schema-v2/v{version}/manifest.json"
+        return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+    def _selected_manifest_url(
+        self,
+        *,
+        version: str | None,
+        url: str | None,
+    ) -> str:
+        if version and url:
+            raise KBError("Pass either a KB version or manifest URL, not both")
+        if url:
+            return url
+        pointer = self._resolve_manifest_url(None)
+        if version:
+            return self._version_manifest_url(pointer, version)
+        pin = self.configured_pin()
+        if pin:
+            if pin.startswith("https://"):
+                return pin
+            return self._version_manifest_url(pointer, pin)
+        return pointer
+
+    def _client(self) -> httpx.Client:
+        return httpx.Client(
+            timeout=HTTP_TIMEOUT,
+            follow_redirects=True,
+            max_redirects=MAX_REDIRECTS,
+        )
+
+    def _response_bytes(
+        self,
+        response: httpx.Response,
+        *,
+        limit: int,
+        label: str,
+    ) -> bytes:
+        content_length = response.headers.get("content-length")
+        if content_length:
+            try:
+                if int(content_length) > limit:
+                    raise KBError(f"{label} exceeds the {limit}-byte limit")
+            except ValueError as exc:
+                raise KBError(f"{label} has an invalid Content-Length") from exc
+        data = bytearray()
+        for chunk in response.iter_bytes():
+            if len(data) + len(chunk) > limit:
+                raise KBError(f"{label} exceeds the {limit}-byte limit")
+            data.extend(chunk)
+        return bytes(data)
+
+    def _get_bytes(self, url: str, *, limit: int, label: str) -> bytes:
+        try:
+            with self._client() as client:
+                with client.stream("GET", url) as response:
+                    response.raise_for_status()
+                    for prior in [*response.history, response]:
+                        self._validate_direct_s3_url(
+                            str(prior.url),
+                            field=f"{label} response URL",
+                        )
+                    return self._response_bytes(response, limit=limit, label=label)
+        except KBError:
+            raise
+        except httpx.HTTPError as exc:
+            raise KBError(f"Failed to fetch {label}: {exc}") from exc
+
     def _get_manifest(self, url: str) -> dict[str, Any]:
         try:
-            with httpx.Client(timeout=HTTP_TIMEOUT) as client:
-                resp = client.get(url)
-                resp.raise_for_status()
-                data = resp.json()
+            with self._client() as client:
+                with client.stream("GET", url) as resp:
+                    resp.raise_for_status()
+                    source = urlsplit(url)
+                    if source.hostname and _DIRECT_S3_HOST.fullmatch(source.hostname):
+                        for prior in [*resp.history, resp]:
+                            self._validate_direct_s3_url(
+                                str(prior.url),
+                                field="manifest response URL",
+                            )
+                    body = self._response_bytes(
+                        resp,
+                        limit=MAX_MANIFEST_BYTES,
+                        label="KB manifest",
+                    )
+            data = json.loads(body)
         except httpx.HTTPError as e:
             LOGGER.error("Failed to fetch manifest from %s: %s", url, e)
             raise KBError(f"Failed to fetch manifest: {e}") from e
-        except ValueError as e:
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
             LOGGER.error("Invalid JSON in manifest response from %s: %s", url, e)
             raise KBError("Manifest response is not valid JSON") from e
         if not isinstance(data, dict):
             raise KBError("Manifest root must be a JSON object")
         return data
+
+    def _validate_manifest_v2_urls(
+        self,
+        manifest: KBManifestV2,
+        manifest_url: str,
+    ) -> None:
+        origin = self._validate_direct_s3_url(
+            manifest_url,
+            field="manifest URL",
+        )
+        prefix = f"/aibom/kb/schema-v2/v{manifest.kb_version}/"
+        expected = {
+            "duckdb.url": prefix + "aibom_catalog.duckdb.gz",
+            "signature.url": prefix + "aibom_catalog.duckdb.gz.sig",
+            "source_candidate.validation_report_url": (
+                prefix + "validation-report.json"
+            ),
+        }
+        values = {
+            "duckdb.url": manifest.duckdb.url,
+            "signature.url": manifest.signature.url,
+            "source_candidate.validation_report_url": (
+                manifest.source_candidate.validation_report_url
+            ),
+        }
+        if manifest.signature.algorithm == "ECDSA_SHA_256":
+            expected["signature.public_key_url"] = prefix + "cosign.pub"
+            values["signature.public_key_url"] = manifest.signature.public_key_url
+        for field, value in values.items():
+            self._validate_direct_s3_url(
+                value,
+                field=field,
+                expected_origin=origin,
+            )
+            if urlsplit(value).path != expected[field]:
+                raise KBError(f"{field} must resolve to {expected[field]}")
+        if manifest.freshness_api:
+            self._validate_https_url(
+                manifest.freshness_api,
+                field="freshness_api",
+            )
+
+    def _require_supported_cli(self, manifest: KBManifestV2) -> None:
+        try:
+            installed = Version(self._installed_cli_version)
+            required = Version(manifest.min_cli_version)
+        except InvalidVersion as exc:
+            raise KBError(
+                f"Invalid CLI version in distribution contract: {exc}"
+            ) from exc
+        if installed < required:
+            raise KBError(
+                "This KB requires a newer CLI "
+                f"(installed {installed}, required {required}). "
+                "Upgrade with: pip install --upgrade cisco-aibom. "
+                f"Manifest: {manifest.duckdb.url.rsplit('/', 1)[0]}/manifest.json"
+            )
 
     def _resolve_api_key(self, api_key: str | None) -> str:
         key = api_key or os.environ.get("CISCO_AI_DEFENSE_API_KEY")
@@ -116,7 +377,9 @@ class KBManager:
         return key
 
     def _resolve_api_base(self, api_base: str | None) -> str:
-        base = api_base or os.environ.get("CISCO_AI_DEFENSE_API_BASE") or DEFAULT_API_BASE
+        base = (
+            api_base or os.environ.get("CISCO_AI_DEFENSE_API_BASE") or DEFAULT_API_BASE
+        )
         if not base:
             raise KBError(
                 "API base URL required: pass --api-base or set "
@@ -124,7 +387,9 @@ class KBManager:
             )
         return base.rstrip("/")
 
-    def _select_manifest(self, index: KBManifestIndex, version: str | None) -> KBManifest:
+    def _select_manifest(
+        self, index: KBManifestIndex, version: str | None
+    ) -> KBManifest:
         if version is None:
             return index.latest
         if index.latest.kb_version == version:
@@ -147,9 +412,32 @@ class KBManager:
         except Exception:
             return latest != current
 
-    def download(self, version: str | None = None, url: str | None = None) -> Path:
-        manifest_url = self._resolve_manifest_url(url)
+    def download(
+        self,
+        version: str | None = None,
+        url: str | None = None,
+        *,
+        allow_unsigned: bool = False,
+    ) -> Path:
+        manifest_url = self._selected_manifest_url(version=version, url=url)
         raw = self._get_manifest(manifest_url)
+        if schema_major(raw.get("schema_version")) == SCHEMA_VERSION:
+            try:
+                manifest = KBManifestV2.model_validate(raw)
+            except ValidationError as exc:
+                raise KBError(f"Invalid schema-v2 manifest: {exc}") from exc
+            self._validate_manifest_v2_urls(manifest, manifest_url)
+            self._require_supported_cli(manifest)
+            return self._download_v2(manifest, allow_unsigned=allow_unsigned)
+
+        return self._download_legacy(raw, version=version)
+
+    def _download_legacy(
+        self,
+        raw: dict[str, Any],
+        *,
+        version: str | None,
+    ) -> Path:
         try:
             index = KBManifestIndex.model_validate(raw)
         except ValidationError as e:
@@ -198,9 +486,317 @@ class KBManager:
         LOGGER.info("KB %s saved to %s", chosen.kb_version, dest)
         return dest
 
+    def _download_file(
+        self,
+        url: str,
+        destination: Path,
+        *,
+        limit: int,
+        expected_size: int,
+        label: str,
+    ) -> tuple[bytes, int]:
+        digest = hashlib.sha256()
+        size = 0
+        try:
+            with self._client() as client:
+                with client.stream("GET", url) as response:
+                    response.raise_for_status()
+                    for prior in [*response.history, response]:
+                        self._validate_direct_s3_url(
+                            str(prior.url),
+                            field=f"{label} response URL",
+                        )
+                    content_length = response.headers.get("content-length")
+                    if content_length:
+                        try:
+                            declared = int(content_length)
+                        except ValueError as exc:
+                            raise KBError(
+                                f"{label} has an invalid Content-Length"
+                            ) from exc
+                        if declared > limit:
+                            raise KBError(f"{label} exceeds the {limit}-byte limit")
+                    with destination.open("wb") as output:
+                        for chunk in response.iter_bytes():
+                            size += len(chunk)
+                            if size > limit:
+                                raise KBError(f"{label} exceeds the {limit}-byte limit")
+                            digest.update(chunk)
+                            output.write(chunk)
+        except KBError:
+            destination.unlink(missing_ok=True)
+            raise
+        except (httpx.HTTPError, OSError) as exc:
+            destination.unlink(missing_ok=True)
+            raise KBError(f"Failed to fetch {label}: {exc}") from exc
+        if size != expected_size:
+            destination.unlink(missing_ok=True)
+            raise KBError(
+                f"{label} size {size} does not match manifest size_bytes "
+                f"{expected_size}"
+            )
+        return digest.digest(), size
+
+    def _verify_v2_signature(
+        self,
+        digest: bytes,
+        signature_text: bytes,
+        public_key_bytes: bytes,
+    ) -> None:
+        try:
+            signature = base64.b64decode(signature_text, validate=True)
+        except (ValueError, binascii.Error) as exc:
+            raise KBError("Detached signature is not valid base64") from exc
+        try:
+            public_key = serialization.load_pem_public_key(public_key_bytes)
+        except (ValueError, TypeError) as exc:
+            raise KBError("Public key is not valid PEM") from exc
+        if not isinstance(public_key, ec.EllipticCurvePublicKey) or not isinstance(
+            public_key.curve, ec.SECP256R1
+        ):
+            raise KBError("Public key must be an ECDSA P-256 key")
+        try:
+            public_key.verify(
+                signature,
+                digest,
+                ec.ECDSA(utils.Prehashed(hashes.SHA256())),
+            )
+        except InvalidSignature as exc:
+            raise KBError("Detached signature verification failed") from exc
+
+    def _decompress_v2(self, source: Path, destination: Path) -> None:
+        written = 0
+        try:
+            with (
+                gzip.open(source, "rb") as compressed,
+                destination.open("wb") as output,
+            ):
+                while True:
+                    chunk = compressed.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    written += len(chunk)
+                    if written > MAX_DECOMPRESSED_BYTES:
+                        raise KBError(
+                            "Decompressed KB exceeds the configured size limit"
+                        )
+                    output.write(chunk)
+        except (gzip.BadGzipFile, EOFError, OSError) as exc:
+            destination.unlink(missing_ok=True)
+            raise KBError(f"Failed to decompress KB artifact: {exc}") from exc
+
+    def _validate_duckdb(self, path: Path) -> None:
+        try:
+            connection = duckdb.connect(str(path), read_only=True)
+            try:
+                tables = {
+                    str(row[0]) for row in connection.execute("SHOW TABLES").fetchall()
+                }
+            finally:
+                connection.close()
+        except Exception as exc:
+            raise KBError(
+                f"Downloaded KB is not a readable DuckDB database: {exc}"
+            ) from exc
+        if "component_catalog" not in tables:
+            raise KBError("Downloaded KB is missing component_catalog")
+
+    def _install_v2(
+        self,
+        manifest: KBManifestV2,
+        compressed_part: Path,
+        digest: bytes,
+        signature_bytes: bytes,
+        public_key_bytes: bytes,
+        *,
+        allow_unsigned: bool,
+    ) -> Path:
+        expected = bytes.fromhex(manifest.duckdb.sha256)
+        if digest != expected:
+            raise KBError(
+                "SHA-256 checksum mismatch for compressed KB "
+                f"(expected {manifest.duckdb.sha256}, got {digest.hex()})"
+            )
+        if manifest.signature.algorithm == "disabled":
+            if not allow_unsigned:
+                raise KBError(
+                    "Unsigned KB artifacts are disabled; use the explicit "
+                    "lower-environment override only for rehearsals"
+                )
+            if manifest.authoritative:
+                raise KBError("Authoritative KB artifacts must be signed")
+        else:
+            self._verify_v2_signature(digest, signature_bytes, public_key_bytes)
+
+        destination = self._kb_duckdb_path(manifest.kb_version)
+        db_part = destination.with_suffix(destination.suffix + ".part")
+        self._decompress_v2(compressed_part, db_part)
+        try:
+            self._validate_duckdb(db_part)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            compressed_dest = self._compressed_path(manifest.kb_version)
+            signature_dest = self._signature_path(manifest.kb_version)
+            public_key_dest = self._public_key_path(manifest.kb_version)
+            compressed_part.replace(compressed_dest)
+            signature_dest.write_bytes(signature_bytes)
+            if public_key_bytes:
+                public_key_dest.write_bytes(public_key_bytes)
+            else:
+                public_key_dest.unlink(missing_ok=True)
+            db_part.replace(destination)
+            self._user_root().mkdir(parents=True, exist_ok=True)
+            manifest_part = self._local_manifest_path().with_suffix(".json.part")
+            manifest_part.write_text(
+                manifest.model_dump_json(indent=2),
+                encoding="utf-8",
+            )
+            manifest_part.replace(self._local_manifest_path())
+        except Exception:
+            db_part.unlink(missing_ok=True)
+            raise
+        return destination
+
+    def _download_v2(
+        self,
+        manifest: KBManifestV2,
+        *,
+        allow_unsigned: bool,
+    ) -> Path:
+        compressed_part = self._compressed_path(manifest.kb_version).with_suffix(
+            ".gz.part"
+        )
+        compressed_part.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            digest, _ = self._download_file(
+                manifest.duckdb.url,
+                compressed_part,
+                limit=MAX_COMPRESSED_BYTES,
+                expected_size=manifest.duckdb.size_bytes,
+                label="compressed KB",
+            )
+            signature_bytes = b""
+            public_key_bytes = b""
+            if manifest.signature.algorithm != "disabled":
+                signature_bytes = self._get_bytes(
+                    manifest.signature.url,
+                    limit=MAX_SIGNATURE_BYTES,
+                    label="detached signature",
+                ).strip()
+                public_key_bytes = self._get_bytes(
+                    manifest.signature.public_key_url,
+                    limit=MAX_PUBLIC_KEY_BYTES,
+                    label="public key",
+                )
+            return self._install_v2(
+                manifest,
+                compressed_part,
+                digest,
+                signature_bytes,
+                public_key_bytes,
+                allow_unsigned=allow_unsigned,
+            )
+        except Exception:
+            compressed_part.unlink(missing_ok=True)
+            raise
+
+    def install_prefetched(
+        self,
+        manifest_path: Path,
+        *,
+        artifact_path: Path | None = None,
+        signature_path: Path | None = None,
+        public_key_path: Path | None = None,
+        allow_unsigned: bool = False,
+    ) -> Path:
+        """Install prefetched bytes through the production validation path."""
+
+        try:
+            raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest = KBManifestV2.model_validate(raw)
+        except (OSError, json.JSONDecodeError, ValidationError) as exc:
+            raise KBError(f"Invalid prefetched manifest: {exc}") from exc
+        manifest_url = self._version_manifest_url(
+            self._resolve_manifest_url(None),
+            manifest.kb_version,
+        )
+        self._validate_manifest_v2_urls(manifest, manifest_url)
+        self._require_supported_cli(manifest)
+        artifact = artifact_path or manifest_path.parent / "aibom_catalog.duckdb.gz"
+        signature = (
+            signature_path or manifest_path.parent / "aibom_catalog.duckdb.gz.sig"
+        )
+        public_key = public_key_path or manifest_path.parent / "cosign.pub"
+        try:
+            size = artifact.stat().st_size
+            if size > MAX_COMPRESSED_BYTES:
+                raise KBError("Prefetched KB exceeds the compressed size limit")
+            if size != manifest.duckdb.size_bytes:
+                raise KBError(
+                    f"Prefetched KB size {size} does not match manifest size_bytes "
+                    f"{manifest.duckdb.size_bytes}"
+                )
+            digest = bytes.fromhex(self._compute_sha256(artifact))
+            signature_bytes = (
+                signature.read_bytes().strip()
+                if manifest.signature.algorithm != "disabled"
+                else b""
+            )
+            public_key_bytes = (
+                public_key.read_bytes()
+                if manifest.signature.algorithm != "disabled"
+                else b""
+            )
+            compressed_part = self._compressed_path(manifest.kb_version).with_suffix(
+                ".gz.part"
+            )
+            compressed_part.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(artifact, compressed_part)
+        except OSError as exc:
+            raise KBError(f"Failed to read prefetched KB objects: {exc}") from exc
+        try:
+            return self._install_v2(
+                manifest,
+                compressed_part,
+                digest,
+                signature_bytes,
+                public_key_bytes,
+                allow_unsigned=allow_unsigned,
+            )
+        except Exception:
+            compressed_part.unlink(missing_ok=True)
+            raise
+
     def check(self) -> dict[str, Any]:
-        manifest_url = self._resolve_manifest_url(None)
+        manifest_url = self._selected_manifest_url(version=None, url=None)
         raw = self._get_manifest(manifest_url)
+        if schema_major(raw.get("schema_version")) == SCHEMA_VERSION:
+            try:
+                manifest = KBManifestV2.model_validate(raw)
+            except ValidationError as exc:
+                raise KBError(f"Invalid schema-v2 manifest: {exc}") from exc
+            self._validate_manifest_v2_urls(manifest, manifest_url)
+            self._require_supported_cli(manifest)
+            current_ver = ""
+            local = self._local_manifest_path()
+            if local.exists():
+                try:
+                    installed = json.loads(local.read_text(encoding="utf-8"))
+                    current_ver = str(
+                        installed.get("kb_version") or installed.get("build_id") or ""
+                    )
+                except (OSError, json.JSONDecodeError):
+                    current_ver = ""
+            return {
+                "current_version": current_ver,
+                "latest_version": manifest.kb_version,
+                "update_available": self._version_newer(
+                    manifest.kb_version,
+                    current_ver,
+                ),
+                "download_url": manifest.duckdb.url,
+                "build_type": manifest.build_type,
+                "parent_kb_version": manifest.parent_kb_version,
+            }
         try:
             index = KBManifestIndex.model_validate(raw)
         except ValidationError as e:
@@ -261,9 +857,7 @@ class KBManager:
         try:
             con = duckdb.connect(str(db_path), read_only=True)
             try:
-                row = con.execute(
-                    "SELECT COUNT(*) FROM component_catalog"
-                ).fetchone()
+                row = con.execute("SELECT COUNT(*) FROM component_catalog").fetchone()
                 entity_count = int(row[0]) if row else 0
             finally:
                 con.close()
@@ -271,7 +865,9 @@ class KBManager:
             LOGGER.error("Failed to query entity count: %s", e)
             raise KBError(f"Failed to query KB database: {e}") from e
 
-        last_modified = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
+        last_modified = datetime.fromtimestamp(
+            stat.st_mtime, tz=timezone.utc
+        ).isoformat()
         info: dict[str, Any] = {
             "version": version,
             "path": str(db_path.resolve()),
@@ -286,8 +882,7 @@ class KBManager:
                     "schema_version": schema_version,
                     "vocabulary_version": (
                         vocabulary_version
-                        if isinstance(vocabulary_version, str)
-                        and vocabulary_version
+                        if isinstance(vocabulary_version, str) and vocabulary_version
                         else VOCABULARY_VERSION
                     ),
                     "concept_count": len(CONCEPTS),
@@ -295,6 +890,37 @@ class KBManager:
                 }
             )
         return info
+
+    def output_metadata(self) -> dict[str, Any]:
+        """Return stable KB/CLI identity without opening the DuckDB file."""
+
+        metadata: dict[str, Any] = {
+            "kb_version": "",
+            "build_type": "",
+            "schema_version": "",
+            "cli_version": self._installed_cli_version,
+        }
+        path = self._local_manifest_path()
+        try:
+            exists = path.exists()
+        except OSError:
+            return metadata
+        if not exists:
+            return metadata
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return metadata
+        if not isinstance(raw, dict):
+            return metadata
+        metadata.update(
+            {
+                "kb_version": raw.get("kb_version") or raw.get("build_id") or "",
+                "build_type": raw.get("build_type") or "legacy",
+                "schema_version": raw.get("schema_version") or "",
+            }
+        )
+        return metadata
 
     def _schema_v2_info_source(
         self,
@@ -313,9 +939,7 @@ class KBManager:
 
         duckdb_entry = manifest.get("duckdb")
         if not isinstance(duckdb_entry, dict):
-            raise KBError(
-                "Invalid local schema-v2 manifest: duckdb object is required"
-            )
+            raise KBError("Invalid local schema-v2 manifest: duckdb object is required")
         filename = duckdb_entry.get("filename")
         if isinstance(filename, str) and filename.strip():
             candidate = Path(filename.strip()).expanduser()
@@ -330,8 +954,37 @@ class KBManager:
             LOGGER.warning("verify: no local manifest")
             return False
         try:
-            m = KBManifest.model_validate(json.loads(mp.read_text(encoding="utf-8")))
-        except (json.JSONDecodeError, ValidationError) as e:
+            raw = json.loads(mp.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            LOGGER.warning("verify: invalid manifest: %s", e)
+            return False
+
+        if schema_major(raw.get("schema_version")) == SCHEMA_VERSION:
+            try:
+                manifest = KBManifestV2.model_validate(raw)
+                compressed = self._compressed_path(manifest.kb_version)
+                database = self._kb_duckdb_path(manifest.kb_version)
+                if not compressed.exists() or not database.exists():
+                    return False
+                digest = bytes.fromhex(self._compute_sha256(compressed))
+                if digest != bytes.fromhex(manifest.duckdb.sha256):
+                    return False
+                if manifest.signature.algorithm == "disabled":
+                    return False
+                self._verify_v2_signature(
+                    digest,
+                    self._signature_path(manifest.kb_version).read_bytes().strip(),
+                    self._public_key_path(manifest.kb_version).read_bytes(),
+                )
+                self._validate_duckdb(database)
+                return True
+            except (KBError, OSError, ValidationError, ValueError) as exc:
+                LOGGER.warning("verify: schema-v2 verification failed: %s", exc)
+                return False
+
+        try:
+            m = KBManifest.model_validate(raw)
+        except ValidationError as e:
             LOGGER.warning("verify: invalid manifest: %s", e)
             return False
 
@@ -355,16 +1008,20 @@ class KBManager:
 
     def request_build(
         self,
-        sdk: str,
-        version: str,
-        language: str = "python",
+        ecosystem: str,
+        package_name: str,
+        symbols: list[str],
         api_key: str | None = None,
         api_base: str | None = None,
     ) -> dict[str, Any]:
         base = self._resolve_api_base(api_base)
         key = self._resolve_api_key(api_key)
-        endpoint = f"{base}/api/ai-defense/v1/aibom/kb/requests"
-        payload = {"sdk": sdk, "version": version, "language": language}
+        endpoint = f"{base}/api/v1/aibom/kb/requests"
+        payload = {
+            "ecosystem": ecosystem,
+            "package_name": package_name,
+            "symbols": symbols,
+        }
         try:
             with httpx.Client(timeout=HTTP_TIMEOUT) as client:
                 resp = client.post(
@@ -372,20 +1029,73 @@ class KBManager:
                     json=payload,
                     headers=self._api_headers(key, json_body=True),
                 )
-                resp.raise_for_status()
-                data = resp.json()
+                data = self._api_response(resp, operation="KB build request")
         except httpx.HTTPError as e:
             LOGGER.error("request_build failed: %s", e)
             raise KBError(f"KB build request failed: {e}") from e
         if not isinstance(data, dict):
             raise KBError("Unexpected response from KB build API")
-        return {
-            "request_id": str(
-                data.get("request_id", data.get("id", ""))
-            ),
-            "status": str(data.get("status", "")),
-            "message": str(data.get("message", "")),
+        return self._with_rate_limit(data, resp)
+
+    def request_bulk(
+        self,
+        requests: list[dict[str, Any]],
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> dict[str, Any]:
+        if not 1 <= len(requests) <= 20:
+            raise KBError("Bulk requests require between 1 and 20 packages")
+        total_symbols = sum(len(item.get("symbols", [])) for item in requests)
+        if total_symbols > 200:
+            raise KBError("Bulk requests support at most 200 symbols total")
+        base = self._resolve_api_base(api_base)
+        key = self._resolve_api_key(api_key)
+        endpoint = f"{base}/api/v1/aibom/kb/requests/bulk"
+        try:
+            with httpx.Client(timeout=HTTP_TIMEOUT) as client:
+                resp = client.post(
+                    endpoint,
+                    json={"requests": requests},
+                    headers=self._api_headers(key, json_body=True),
+                )
+                data = self._api_response(resp, operation="bulk KB build request")
+        except httpx.HTTPError as exc:
+            raise KBError(f"Bulk KB build request failed: {exc}") from exc
+        if not isinstance(data, dict):
+            raise KBError("Unexpected response from bulk KB build API")
+        return self._with_rate_limit(data, resp)
+
+    def _api_response(self, response: httpx.Response, *, operation: str) -> Any:
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise KBError(f"{operation} returned invalid JSON") from exc
+        if response.is_error:
+            if isinstance(data, dict):
+                detail = (
+                    data.get("message") or data.get("error") or response.reason_phrase
+                )
+            else:
+                detail = response.reason_phrase
+            retry_after = response.headers.get("retry-after")
+            suffix = f" Retry after {retry_after} seconds." if retry_after else ""
+            raise KBError(
+                f"{operation} failed ({response.status_code}): {detail}.{suffix}"
+            )
+        return data
+
+    def _with_rate_limit(
+        self,
+        data: dict[str, Any],
+        response: httpx.Response,
+    ) -> dict[str, Any]:
+        result = dict(data)
+        result["rate_limit"] = {
+            "limit": response.headers.get("x-ratelimit-limit", ""),
+            "remaining": response.headers.get("x-ratelimit-remaining", ""),
+            "reset": response.headers.get("x-ratelimit-reset", ""),
         }
+        return result
 
     def request_status(
         self,
@@ -395,37 +1105,37 @@ class KBManager:
     ) -> dict[str, Any]:
         base = self._resolve_api_base(api_base)
         key = self._resolve_api_key(api_key)
-        endpoint = f"{base}/api/ai-defense/v1/aibom/kb/requests/{request_id}"
+        endpoint = f"{base}/api/v1/aibom/kb/requests/{request_id}"
         try:
             with httpx.Client(timeout=HTTP_TIMEOUT) as client:
                 resp = client.get(endpoint, headers=self._api_headers(key))
-                resp.raise_for_status()
-                data = resp.json()
+                data = self._api_response(resp, operation="KB request status")
         except httpx.HTTPError as e:
             LOGGER.error("request_status failed: %s", e)
             raise KBError(f"KB request status failed: {e}") from e
         if not isinstance(data, dict):
             raise KBError("Unexpected response from KB status API")
-        return {
-            "request_id": str(data.get("request_id", data.get("id", request_id))),
-            "status": str(data.get("status", "")),
-            "sdk": str(data.get("sdk", "")),
-            "version": str(data.get("version", "")),
-        }
+        return data
 
     def list_requests(
         self,
         api_key: str | None = None,
         api_base: str | None = None,
+        limit: int = 50,
     ) -> list[dict[str, Any]]:
+        if not 1 <= limit <= 100:
+            raise KBError("Request list limit must be between 1 and 100")
         base = self._resolve_api_base(api_base)
         key = self._resolve_api_key(api_key)
-        endpoint = f"{base}/api/ai-defense/v1/aibom/kb/requests"
+        endpoint = f"{base}/api/v1/aibom/kb/requests"
         try:
             with httpx.Client(timeout=HTTP_TIMEOUT) as client:
-                resp = client.get(endpoint, headers=self._api_headers(key))
-                resp.raise_for_status()
-                data = resp.json()
+                resp = client.get(
+                    endpoint,
+                    headers=self._api_headers(key),
+                    params={"limit": limit},
+                )
+                data = self._api_response(resp, operation="KB request list")
         except httpx.HTTPError as e:
             LOGGER.error("list_requests failed: %s", e)
             raise KBError(f"KB list requests failed: {e}") from e

--- a/aibom/src/aibom/kb/manifest.py
+++ b/aibom/src/aibom/kb/manifest.py
@@ -16,7 +16,9 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class KBManifest(BaseModel):
@@ -36,3 +38,104 @@ class KBManifest(BaseModel):
 class KBManifestIndex(BaseModel):
     latest: KBManifest
     versions: list[KBManifest] = Field(default_factory=list)
+
+
+class KBArtifact(BaseModel):
+    """One immutable object referenced by a schema-v2 manifest."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    url: str
+    size_bytes: int = Field(gt=0)
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class KBSignature(BaseModel):
+    """Detached signature metadata for the compressed DuckDB object."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    algorithm: Literal["ECDSA_SHA_256", "disabled"]
+    url: str
+    public_key_url: str
+    key_id: str
+
+    @model_validator(mode="after")
+    def validate_signing_fields(self) -> "KBSignature":
+        if self.algorithm == "disabled":
+            if self.key_id != "disabled" or self.public_key_url:
+                raise ValueError(
+                    "disabled signatures require key_id=disabled and no public key URL"
+                )
+        elif not self.key_id.strip() or not self.public_key_url.strip():
+            raise ValueError(
+                "signed artifacts require a key identity and public key URL"
+            )
+        return self
+
+
+class KBSourceCandidate(BaseModel):
+    """Traceability link from a published artifact to its validated candidate."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    build_id: str = Field(min_length=1, max_length=128)
+    validation_report_url: str
+
+
+class KBManifestV2(BaseModel):
+    """Strict schema-v2 distribution contract emitted by the publisher."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    artifact_state: Literal["authoritative", "rehearsal"]
+    authoritative: bool
+    schema_version: int = Field(ge=2, le=2)
+    vocabulary_version: str = Field(min_length=1)
+    min_cli_version: str = Field(pattern=r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+].+)?$")
+    kb_version: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+    build_type: Literal["floor", "delta"]
+    parent_kb_version: str = ""
+    generated_at: str = Field(
+        pattern=(
+            r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:"
+            r"[0-9]{2}(?:\.[0-9]+)?(?:Z|[+-][0-9]{2}:[0-9]{2})$"
+        )
+    )
+    duckdb: KBArtifact
+    signature: KBSignature
+    freshness_api: str = ""
+    has_enrichment: bool
+    contents: dict[str, Any]
+    provenance: dict[str, str]
+    source_candidate: KBSourceCandidate
+
+    @field_validator("provenance")
+    @classmethod
+    def validate_provenance(cls, value: dict[str, str]) -> dict[str, str]:
+        required = {
+            "source_commit",
+            "pipeline_version",
+            "config_version",
+            "model_version",
+            "tools_version",
+            "input_fingerprint",
+        }
+        missing = sorted(k for k in required if not value.get(k, "").strip())
+        if missing:
+            raise ValueError(f"missing provenance fields: {', '.join(missing)}")
+        return value
+
+    @model_validator(mode="after")
+    def validate_build_relationship(self) -> "KBManifestV2":
+        if self.artifact_state == "authoritative" and not self.authoritative:
+            raise ValueError("authoritative artifacts require authoritative=true")
+        if self.artifact_state == "rehearsal" and self.authoritative:
+            raise ValueError("rehearsal artifacts require authoritative=false")
+        if self.build_type == "floor" and self.parent_kb_version:
+            raise ValueError("floor builds must not declare parent_kb_version")
+        if self.build_type == "delta" and not self.parent_kb_version.strip():
+            raise ValueError("delta builds require parent_kb_version")
+        if not self.contents:
+            raise ValueError("contents must not be empty")
+        return self

--- a/aibom/src/aibom/reporters/cyclonedx_reporter.py
+++ b/aibom/src/aibom/reporters/cyclonedx_reporter.py
@@ -28,6 +28,8 @@ from cyclonedx.output.json import JsonV1Dot6
 from cyclonedx.schema import SchemaVersion
 from cyclonedx.validation.json import JsonValidator
 
+from ..kb.coverage import build_coverage_gaps
+from ..kb.manager import KBManager
 from ..models import AIComponent, AIComponentType, ScanResult
 from .base import BaseReporter
 
@@ -77,9 +79,7 @@ def _prop(name: str, value: str) -> Property:
     return Property(name=name, value=value)
 
 
-def _optional_aibom_properties(
-    comp: AIComponent, include_type: bool
-) -> list[Property]:
+def _optional_aibom_properties(comp: AIComponent, include_type: bool) -> list[Property]:
     props: list[Property] = []
     if include_type:
         props.append(_prop("cisco-aibom:type", comp.component_type.value))
@@ -99,6 +99,12 @@ def _optional_aibom_properties(
         props.append(_prop("cisco-aibom:dataset_source", comp.dataset_source))
     if comp.skill_format:
         props.append(_prop("cisco-aibom:skill_format", comp.skill_format))
+    if comp.metadata.get("uncatalogued_ai_symbol"):
+        props.append(_prop("cisco-aibom:uncatalogued_ai_symbol", "true"))
+        for key in ("ecosystem", "package_name", "uncatalogued_symbol"):
+            value = comp.metadata.get(key)
+            if value:
+                props.append(_prop(f"cisco-aibom:{key}", str(value)))
     return props
 
 
@@ -156,12 +162,28 @@ def _build_bom(result: ScanResult) -> Bom:
         version=_tool_version(meta),
     )
     bom_meta = BomMetaData(tools=[tool])
+    identity = KBManager().output_metadata()
+    properties = [
+        _prop(f"cisco-aibom:{key}", str(value)) for key, value in identity.items()
+    ]
+    coverage_gaps = build_coverage_gaps(result)
+    properties.append(
+        _prop(
+            "cisco-aibom:uncatalogued_ai_symbol_count",
+            str(
+                coverage_gaps.get("uncatalogued_ai_symbol_count", 0)
+                if coverage_gaps
+                else 0
+            ),
+        )
+    )
     return Bom(
         serial_number=uuid4(),
         version=1,
         metadata=bom_meta,
         components=components,
         vulnerabilities=vulnerabilities,
+        properties=properties,
     )
 
 

--- a/aibom/src/aibom/reporters/json_reporter.py
+++ b/aibom/src/aibom/reporters/json_reporter.py
@@ -24,6 +24,7 @@ from collections.abc import Iterable
 from pathlib import Path, PurePosixPath
 from typing import IO, Any
 
+from ..kb.coverage import build_coverage_gaps
 from ..models import AIComponent, ScanResult
 from .base import BaseReporter
 
@@ -179,6 +180,12 @@ def _aibom_payload(
     source_outcomes = raw_metadata.pop("source_outcomes", {})
     source_details = raw_metadata.pop("_report_source_details", {})
     raw_metadata.setdefault("report_schema_version", REPORT_SCHEMA_VERSION)
+    try:
+        from ..kb.manager import KBManager
+
+        raw_metadata.update(KBManager().output_metadata())
+    except Exception:
+        _LOGGER.debug("Could not resolve installed KB metadata", exc_info=True)
     sources_out: dict[str, dict[str, Any]] = {}
     components_by_source: dict[str, list[AIComponent]] = {}
     seen_source_names: dict[str, int] = {}
@@ -239,6 +246,9 @@ def _aibom_payload(
         analysis["component_summary"] = _component_summary(components_by_source)
     analysis["risk"] = base["risk"]
     analysis["errors"] = base["errors"]
+    coverage_gaps = build_coverage_gaps(result)
+    if coverage_gaps:
+        analysis["coverage_gaps"] = coverage_gaps
     if cross_repo_links_out:
         analysis["cross_repo_links"] = cross_repo_links_out
     return {"aibom_analysis": analysis}

--- a/aibom/src/aibom/reporters/spdx_reporter.py
+++ b/aibom/src/aibom/reporters/spdx_reporter.py
@@ -21,6 +21,8 @@ import json
 from datetime import datetime, timezone
 from typing import IO, Any
 
+from ..kb.coverage import build_coverage_gaps
+from ..kb.manager import KBManager
 from ..models import AIComponent, AIComponentType, ScanResult
 from .base import BaseReporter
 
@@ -76,14 +78,21 @@ def _software_primary_purpose(t: AIComponentType) -> str:
 
 
 def _cdx_extension(comp: AIComponent) -> dict[str, Any]:
+    properties: dict[str, Any] = {
+        "cisco-aibom:componentType": comp.component_type.value,
+        "cisco-aibom:instanceId": comp.instance_id,
+        "cisco-aibom:name": comp.name,
+        "cisco-aibom:detectionSource": comp.detection_source.value,
+    }
+    if comp.metadata.get("uncatalogued_ai_symbol"):
+        properties["cisco-aibom:uncatalogued_ai_symbol"] = True
+        for key in ("ecosystem", "package_name", "uncatalogued_symbol"):
+            value = comp.metadata.get(key)
+            if value:
+                properties[f"cisco-aibom:{key}"] = value
     return {
         "type": "CdxPropertiesExtension",
-        "extensionProperties": {
-            "cisco-aibom:componentType": comp.component_type.value,
-            "cisco-aibom:instanceId": comp.instance_id,
-            "cisco-aibom:name": comp.name,
-            "cisco-aibom:detectionSource": comp.detection_source.value,
-        },
+        "extensionProperties": properties,
     }
 
 
@@ -142,9 +151,13 @@ class SpdxReporter(BaseReporter):
         dt = datetime.now(timezone.utc).replace(microsecond=0)
         created = dt.isoformat().replace("+00:00", "Z")
         components = result.all_components
+        identity = KBManager().output_metadata()
+        coverage_gaps = build_coverage_gaps(result)
+        identity["uncatalogued_ai_symbol_count"] = (
+            coverage_gaps.get("uncatalogued_ai_symbol_count", 0) if coverage_gaps else 0
+        )
         element_ids = [
-            _spdx_id(c.component_type.value, _digest(c.instance_id))
-            for c in components
+            _spdx_id(c.component_type.value, _digest(c.instance_id)) for c in components
         ]
 
         doc: dict[str, Any] = {
@@ -157,6 +170,12 @@ class SpdxReporter(BaseReporter):
                 "creators": ["Tool: cisco-aibom"],
             },
             "element": element_ids,
+            "extension_cisco_aibom": {
+                "type": "CdxPropertiesExtension",
+                "extensionProperties": {
+                    f"cisco-aibom:{key}": value for key, value in identity.items()
+                },
+            },
         }
 
         graph: list[dict[str, Any]] = [doc]

--- a/aibom/src/aibom/scanners/env_var_resolver.py
+++ b/aibom/src/aibom/scanners/env_var_resolver.py
@@ -77,6 +77,32 @@ _RUBY_ENV_FETCH = re.compile(
 )
 _RUBY_ENV_PATTERNS = [_RUBY_ENV_BRACKET, _RUBY_ENV_FETCH]
 
+_RUST_ENV_VAR = re.compile(
+    r'''(?:std::)?env::var(?:_os)?\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']'''
+)
+_RUST_ENV_MACRO = re.compile(
+    r'''(?:option_)?env!\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']'''
+)
+_RUST_ENV_PATTERNS = [_RUST_ENV_VAR, _RUST_ENV_MACRO]
+
+_CS_ENVIRONMENT_GET = re.compile(
+    r'''Environment\.GetEnvironmentVariable\(\s*["']'''
+    r'''([A-Za-z_][A-Za-z0-9_]*)["']'''
+)
+_CS_CONFIGURATION_BRACKET = re.compile(
+    r'''(?:builder\.)?(?:Configuration|_configuration)'''
+    r'''\s*\[\s*["']([A-Za-z_][A-Za-z0-9_]*)["']\s*\]'''
+)
+_CS_CONFIGURATION_GET = re.compile(
+    r'''(?:IConfiguration|Configuration|_configuration)\.GetValue'''
+    r'''(?:<[^>]+>)?\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']'''
+)
+_CS_ENV_PATTERNS = [
+    _CS_ENVIRONMENT_GET,
+    _CS_CONFIGURATION_BRACKET,
+    _CS_CONFIGURATION_GET,
+]
+
 _LANG_PATTERNS: dict[str, list[re.Pattern[str]]] = {
     ".py": _PY_ENV_PATTERNS,
     ".ipynb": _PY_ENV_PATTERNS,
@@ -88,6 +114,8 @@ _LANG_PATTERNS: dict[str, list[re.Pattern[str]]] = {
     ".go": [_GO_GETENV],
     ".java": [_JAVA_GETENV],
     ".rb": _RUBY_ENV_PATTERNS,
+    ".rs": _RUST_ENV_PATTERNS,
+    ".cs": _CS_ENV_PATTERNS,
 }
 
 # ---------------------------------------------------------------------------
@@ -267,6 +295,8 @@ _COMMENT_PREFIXES = {
     ".mjs": "//",
     ".go": "//",
     ".java": "//",
+    ".rs": "//",
+    ".cs": "//",
 }
 
 

--- a/aibom/src/aibom/scanners/kb_enrichment_scanner.py
+++ b/aibom/src/aibom/scanners/kb_enrichment_scanner.py
@@ -2141,6 +2141,10 @@ def _process_file_with_cache(
             meta_partial: dict[str, Any] = {
                 "partial_kb_id": match.partial_kb_id,
                 "obs_module": match.obs_module,
+                "uncatalogued_ai_symbol": True,
+                "uncatalogued_symbol": obs_data["name"],
+                "ecosystem": "pypi",
+                "package_name": match.obs_module.split(".", 1)[0],
             }
             if obs_data.get("assigned_target"):
                 meta_partial["assigned_target"] = obs_data["assigned_target"]
@@ -2409,6 +2413,10 @@ def _process_file(
                         "partial_kb_id": match.partial_kb_id,
                         "obs_module": match.obs_module,
                         "observation_type": obs_data["type"],
+                        "uncatalogued_ai_symbol": True,
+                        "uncatalogued_symbol": obs_data["name"],
+                        "ecosystem": "pypi",
+                        "package_name": match.obs_module.split(".", 1)[0],
                     },
                 )
             )

--- a/aibom/tests/test_cli_basic.py
+++ b/aibom/tests/test_cli_basic.py
@@ -65,6 +65,117 @@ def test_analyze_rejects_schema_v2_manifest_without_traceback(
     assert "Traceback" not in result.output
 
 
+def test_kb_request_submits_one_package_with_schema_v2_contract():
+    response = {
+        "request": {
+            "request_id": "00000000-0000-4000-8000-000000000001",
+            "state": "queued",
+            "disposition": "ready_in_build",
+        },
+        "coalesced": False,
+        "quota_remaining": 9,
+        "rate_limit": {"limit": "10", "remaining": "9", "reset": "1234"},
+    }
+    with patch(
+        "aibom.cli.KBManager.request_build",
+        return_value=response,
+    ) as request_build:
+        result = runner.invoke(
+            app,
+            [
+                "kb",
+                "request",
+                "--ecosystem",
+                "pypi",
+                "--package",
+                "example-sdk",
+                "--symbol",
+                "example_sdk.Client",
+                "--api-key",
+                "test-key",
+                "--api-base",
+                "https://api.example.com",
+            ],
+        )
+
+    assert result.exit_code == 0
+    request_build.assert_called_once_with(
+        ecosystem="pypi",
+        package_name="example-sdk",
+        symbols=["example_sdk.Client"],
+        api_key="test-key",
+        api_base="https://api.example.com",
+    )
+    assert "ready_in_build" in result.output
+    assert "Quota remaining: 9" in result.output
+
+
+def test_kb_request_reads_grouped_coverage_gaps_as_one_bulk_request(tmp_path):
+    report = tmp_path / "report.json"
+    report.write_text(
+        json.dumps(
+            {
+                "aibom_analysis": {
+                    "coverage_gaps": {
+                        "packages": [
+                            {
+                                "ecosystem": "pypi",
+                                "package_name": "example-sdk",
+                                "symbols": ["example_sdk.Client"],
+                            },
+                            {
+                                "ecosystem": "npm",
+                                "package_name": "example-ai",
+                                "symbols": ["ExampleAgent"],
+                            },
+                        ]
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    response = {
+        "request_ids": ["00000000-0000-4000-8000-000000000002"],
+        "duplicates": [],
+        "rejected": [],
+        "quota_remaining": 8,
+        "rate_limit": {},
+    }
+    with patch(
+        "aibom.cli.KBManager.request_bulk",
+        return_value=response,
+    ) as request_bulk:
+        result = runner.invoke(
+            app,
+            [
+                "kb",
+                "request",
+                "--from-scan",
+                str(report),
+                "--api-key",
+                "test-key",
+                "--api-base",
+                "https://api.example.com",
+            ],
+        )
+
+    assert result.exit_code == 0
+    requests = request_bulk.call_args.args[0]
+    assert requests == [
+        {
+            "ecosystem": "npm",
+            "package_name": "example-ai",
+            "symbols": ["ExampleAgent"],
+        },
+        {
+            "ecosystem": "pypi",
+            "package_name": "example-sdk",
+            "symbols": ["example_sdk.Client"],
+        },
+    ]
+
+
 def test_analyze_defaults_cache_root_for_scan_and_agentic(tmp_path):
     source_dir = tmp_path / "repo"
     source_dir.mkdir()

--- a/aibom/tests/test_env_var_resolver.py
+++ b/aibom/tests/test_env_var_resolver.py
@@ -245,6 +245,57 @@ class TestRubyEnvVarExtraction:
         assert len(comps) == 1
 
 
+class TestRustEnvVarExtraction:
+    def test_std_env_var_and_var_os(self, tmp_path: Path) -> None:
+        (tmp_path / "main.rs").write_text(
+            'let model = std::env::var("RUST_MODEL").unwrap();\n'
+            'let model_name = std::env::var_os("RUST_MODEL_OS").unwrap();\n'
+        )
+        components, _ = EnvVarResolver().scan(_make_ctx(tmp_path))
+        assert {component.metadata["env"] for component in components} == {
+            "RUST_MODEL",
+            "RUST_MODEL_OS",
+        }
+
+    def test_compile_time_env_macros(self, tmp_path: Path) -> None:
+        (tmp_path / "config.rs").write_text(
+            'let model = env!("BUILD_MODEL");\n'
+            'let model_name = option_env!("OPTIONAL_MODEL");\n'
+        )
+        components, _ = EnvVarResolver().scan(_make_ctx(tmp_path))
+        assert {component.metadata["env"] for component in components} == {
+            "BUILD_MODEL",
+            "OPTIONAL_MODEL",
+        }
+
+
+class TestCSharpEnvVarExtraction:
+    def test_environment_and_configuration_patterns(self, tmp_path: Path) -> None:
+        (tmp_path / "Program.cs").write_text(
+            'var model = Environment.GetEnvironmentVariable("CS_MODEL");\n'
+            'var model_name = Configuration["CS_CONFIG_MODEL"];\n'
+            'var model_id = _configuration.GetValue<string>("CS_TYPED_MODEL");\n'
+            'var deployment_name = builder.Configuration["CS_DEPLOYMENT"];\n'
+        )
+        components, _ = EnvVarResolver().scan(_make_ctx(tmp_path))
+        assert {component.metadata["env"] for component in components} == {
+            "CS_MODEL",
+            "CS_CONFIG_MODEL",
+            "CS_TYPED_MODEL",
+            "CS_DEPLOYMENT",
+        }
+
+    def test_comment_is_ignored(self, tmp_path: Path) -> None:
+        (tmp_path / "Program.cs").write_text(
+            '// var model = Configuration["COMMENTED_MODEL"];\n'
+            'var model = Configuration["ACTIVE_MODEL"];\n'
+        )
+        components, _ = EnvVarResolver().scan(_make_ctx(tmp_path))
+        assert [component.metadata["env"] for component in components] == [
+            "ACTIVE_MODEL"
+        ]
+
+
 class TestCommentSkipping:
     def test_python_comment_skipped(self, tmp_path: Path) -> None:
         (tmp_path / "app.py").write_text(

--- a/aibom/tests/test_kb_manager.py
+++ b/aibom/tests/test_kb_manager.py
@@ -16,6 +16,8 @@
 
 from __future__ import annotations
 
+import base64
+import gzip
 import hashlib
 import json
 import os
@@ -25,13 +27,82 @@ import duckdb
 import httpx
 import pytest
 import respx
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
 
-from aibom.kb.manager import KBError, KBManager
+from aibom.kb.manager import DEFAULT_MANIFEST_URL, KBError, KBManager
 from aibom.kb.manifest import KBManifest, KBManifestIndex
 
-HELLO_SHA256 = (
-    "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
-)
+HELLO_SHA256 = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+
+_S3_ORIGIN = "https://example-public.s3.us-west-2.amazonaws.com"
+
+
+def _schema_v2_bundle(tmp_path, *, kb_version="2.0.0", min_cli_version="2.0.0"):
+    db_path = tmp_path / "source.duckdb"
+    connection = duckdb.connect(str(db_path))
+    try:
+        connection.execute("CREATE TABLE component_catalog (id INTEGER)")
+        connection.execute("INSERT INTO component_catalog VALUES (1)")
+    finally:
+        connection.close()
+
+    artifact = tmp_path / "aibom_catalog.duckdb.gz"
+    with db_path.open("rb") as source, gzip.open(artifact, "wb") as output:
+        output.write(source.read())
+
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    signature = private_key.sign(artifact.read_bytes(), ec.ECDSA(hashes.SHA256()))
+    signature_path = tmp_path / "aibom_catalog.duckdb.gz.sig"
+    signature_path.write_bytes(base64.b64encode(signature) + b"\n")
+    public_key_path = tmp_path / "cosign.pub"
+    public_key_path.write_bytes(
+        private_key.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+
+    prefix = f"{_S3_ORIGIN}/aibom/kb/schema-v2/v{kb_version}"
+    manifest = {
+        "artifact_state": "authoritative",
+        "authoritative": True,
+        "schema_version": 2,
+        "vocabulary_version": "2.0.0",
+        "min_cli_version": min_cli_version,
+        "kb_version": kb_version,
+        "build_type": "floor",
+        "generated_at": "2026-08-01T00:00:00Z",
+        "duckdb": {
+            "url": f"{prefix}/aibom_catalog.duckdb.gz",
+            "size_bytes": artifact.stat().st_size,
+            "sha256": hashlib.sha256(artifact.read_bytes()).hexdigest(),
+        },
+        "signature": {
+            "algorithm": "ECDSA_SHA_256",
+            "url": f"{prefix}/aibom_catalog.duckdb.gz.sig",
+            "public_key_url": f"{prefix}/cosign.pub",
+            "key_id": "test-signing-key",
+        },
+        "freshness_api": "https://api.example.com/api/v1/aibom/kb/packages/freshness",
+        "has_enrichment": True,
+        "contents": {"component_catalog": {"rows": 1}},
+        "provenance": {
+            "source_commit": "test-source",
+            "pipeline_version": "test-pipeline",
+            "config_version": "test-config",
+            "model_version": "test-model",
+            "tools_version": "test-tools",
+            "input_fingerprint": "test-fingerprint",
+        },
+        "source_candidate": {
+            "build_id": "test-build",
+            "validation_report_url": f"{prefix}/validation-report.json",
+        },
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    return manifest, manifest_path, artifact, signature_path, public_key_path
 
 
 def test_kb_manifest_model_creation_and_serialization():
@@ -291,13 +362,223 @@ def test_kb_manager_download_writes_db_manifest_and_verifies_checksum(tmp_path):
     assert saved.duckdb_sha256.lower() == sha.lower()
 
 
+def test_schema_v2_prefetched_install_verifies_signature_and_cache(tmp_path):
+    _, manifest_path, artifact, signature, public_key = _schema_v2_bundle(tmp_path)
+    user_root = tmp_path / "user"
+    manager = KBManager(
+        manifest_url=f"{_S3_ORIGIN}/aibom/kb/manifest.json",
+        installed_cli_version="2.0.0",
+    )
+    with patch.object(manager, "_user_root", return_value=user_root):
+        installed = manager.install_prefetched(
+            manifest_path,
+            artifact_path=artifact,
+            signature_path=signature,
+            public_key_path=public_key,
+        )
+        assert installed.exists()
+        assert manager.verify() is True
+        saved = json.loads((user_root / "manifest.json").read_text(encoding="utf-8"))
+    assert saved["schema_version"] == 2
+    assert saved["build_type"] == "floor"
+
+
+def test_schema_v2_rejects_tampered_signature_and_preserves_last_good(tmp_path):
+    _, manifest_path, artifact, signature, public_key = _schema_v2_bundle(tmp_path)
+    user_root = tmp_path / "user"
+    manager = KBManager(
+        manifest_url=f"{_S3_ORIGIN}/aibom/kb/manifest.json",
+        installed_cli_version="2.0.0",
+    )
+    with patch.object(manager, "_user_root", return_value=user_root):
+        installed = manager.install_prefetched(
+            manifest_path,
+            artifact_path=artifact,
+            signature_path=signature,
+            public_key_path=public_key,
+        )
+        before = installed.read_bytes()
+        signature.write_bytes(base64.b64encode(b"not-a-valid-signature"))
+        with pytest.raises(KBError, match="signature verification failed"):
+            manager.install_prefetched(
+                manifest_path,
+                artifact_path=artifact,
+                signature_path=signature,
+                public_key_path=public_key,
+            )
+        assert installed.read_bytes() == before
+        assert manager.verify() is True
+
+
+@respx.mock
+def test_schema_v2_rejects_min_cli_version_before_artifact_download(tmp_path):
+    manifest, _, _, _, _ = _schema_v2_bundle(
+        tmp_path,
+        min_cli_version="2.1.0",
+    )
+    manifest_url = f"{_S3_ORIGIN}/aibom/kb/manifest.json"
+    artifact_route = respx.get(manifest["duckdb"]["url"]).mock(
+        return_value=httpx.Response(200, content=b"must-not-download")
+    )
+    respx.get(manifest_url).mock(return_value=httpx.Response(200, json=manifest))
+    manager = KBManager(
+        manifest_url=manifest_url,
+        installed_cli_version="2.0.0",
+    )
+    with patch.object(manager, "_user_root", return_value=tmp_path / "user"):
+        with pytest.raises(KBError, match="installed 2.0.0, required 2.1.0"):
+            manager.download()
+    assert artifact_route.called is False
+
+
+@respx.mock
+def test_schema_v2_rejects_non_s3_object_url_before_download(tmp_path):
+    manifest, _, _, _, _ = _schema_v2_bundle(tmp_path)
+    manifest["duckdb"]["url"] = "https://downloads.example.com/aibom_catalog.duckdb.gz"
+    manifest_url = f"{_S3_ORIGIN}/aibom/kb/manifest.json"
+    respx.get(manifest_url).mock(return_value=httpx.Response(200, json=manifest))
+    manager = KBManager(
+        manifest_url=manifest_url,
+        installed_cli_version="2.0.0",
+    )
+    with pytest.raises(KBError, match="direct regional S3 HTTPS URL"):
+        manager.download()
+
+
+def test_schema_v2_manifest_rejects_unknown_fields(tmp_path):
+    manifest, manifest_path, artifact, signature, public_key = _schema_v2_bundle(
+        tmp_path
+    )
+    manifest["unexpected"] = True
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    manager = KBManager(
+        manifest_url=f"{_S3_ORIGIN}/aibom/kb/manifest.json",
+        installed_cli_version="2.0.0",
+    )
+    with pytest.raises(KBError, match="extra_forbidden"):
+        manager.install_prefetched(
+            manifest_path,
+            artifact_path=artifact,
+            signature_path=signature,
+            public_key_path=public_key,
+        )
+
+
+def test_schema_v2_manifest_rejects_coerced_field_types(tmp_path):
+    manifest, manifest_path, artifact, signature, public_key = _schema_v2_bundle(
+        tmp_path
+    )
+    manifest["schema_version"] = "2"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    manager = KBManager(
+        manifest_url=f"{_S3_ORIGIN}/aibom/kb/manifest.json",
+        installed_cli_version="2.0.0",
+    )
+    with pytest.raises(KBError, match="valid integer"):
+        manager.install_prefetched(
+            manifest_path,
+            artifact_path=artifact,
+            signature_path=signature,
+            public_key_path=public_key,
+        )
+
+
+def test_manifest_selection_precedence_is_explicit_then_pin_then_pointer(tmp_path):
+    pointer = f"{_S3_ORIGIN}/aibom/kb/manifest.json"
+    manager = KBManager(manifest_url=pointer, installed_cli_version="2.0.0")
+    config_path = tmp_path / "kb.json"
+    explicit_url = f"{_S3_ORIGIN}/aibom/kb/schema-v2/v2.8.0/manifest.json"
+    with patch.object(manager, "_config_path", return_value=config_path):
+        manager.set_pin("2.4.0")
+        assert manager._selected_manifest_url(version=None, url=None) == (
+            f"{_S3_ORIGIN}/aibom/kb/schema-v2/v2.4.0/manifest.json"
+        )
+        assert manager._selected_manifest_url(version="2.6.0", url=None) == (
+            f"{_S3_ORIGIN}/aibom/kb/schema-v2/v2.6.0/manifest.json"
+        )
+        assert manager._selected_manifest_url(version=None, url=explicit_url) == (
+            explicit_url
+        )
+
+
+def test_unsigned_rehearsal_requires_explicit_override(tmp_path):
+    manifest, manifest_path, artifact, _, _ = _schema_v2_bundle(tmp_path)
+    manifest["artifact_state"] = "rehearsal"
+    manifest["authoritative"] = False
+    manifest["signature"]["algorithm"] = "disabled"
+    manifest["signature"]["public_key_url"] = ""
+    manifest["signature"]["key_id"] = "disabled"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    user_root = tmp_path / "user"
+    manager = KBManager(
+        manifest_url=f"{_S3_ORIGIN}/aibom/kb/manifest.json",
+        installed_cli_version="2.0.0",
+    )
+    with patch.object(manager, "_user_root", return_value=user_root):
+        with pytest.raises(KBError, match="Unsigned KB artifacts are disabled"):
+            manager.install_prefetched(manifest_path, artifact_path=artifact)
+        installed = manager.install_prefetched(
+            manifest_path,
+            artifact_path=artifact,
+            allow_unsigned=True,
+        )
+    assert installed.exists()
+
+
+def test_schema_v2_rejects_checksum_mismatch(tmp_path):
+    manifest, manifest_path, artifact, signature, public_key = _schema_v2_bundle(
+        tmp_path
+    )
+    manifest["duckdb"]["sha256"] = "0" * 64
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    manager = KBManager(
+        manifest_url=f"{_S3_ORIGIN}/aibom/kb/manifest.json",
+        installed_cli_version="2.0.0",
+    )
+    with pytest.raises(KBError, match="checksum mismatch"):
+        manager.install_prefetched(
+            manifest_path,
+            artifact_path=artifact,
+            signature_path=signature,
+            public_key_path=public_key,
+        )
+
+
+def test_schema_v2_rejects_wrong_public_key(tmp_path):
+    _, manifest_path, artifact, signature, public_key = _schema_v2_bundle(tmp_path)
+    wrong_key = ec.generate_private_key(ec.SECP256R1()).public_key()
+    public_key.write_bytes(
+        wrong_key.public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+    manager = KBManager(
+        manifest_url=f"{_S3_ORIGIN}/aibom/kb/manifest.json",
+        installed_cli_version="2.0.0",
+    )
+    with pytest.raises(KBError, match="signature verification failed"):
+        manager.install_prefetched(
+            manifest_path,
+            artifact_path=artifact,
+            signature_path=signature,
+            public_key_path=public_key,
+        )
+
+
 def test_kb_manager_request_build_calls_endpoint_and_payload():
     mgr = KBManager()
     mock_resp = MagicMock()
     mock_resp.json.return_value = {
-        "request_id": "req-1",
-        "status": "queued",
-        "message": "ok",
+        "request": {"request_id": "req-1", "state": "queued"},
+        "coalesced": False,
+        "quota_remaining": 9,
+    }
+    mock_resp.is_error = False
+    mock_resp.headers = {
+        "x-ratelimit-limit": "10",
+        "x-ratelimit-remaining": "9",
+        "x-ratelimit-reset": "1234",
     }
     mock_resp.raise_for_status = MagicMock()
     mock_client = MagicMock()
@@ -306,21 +587,32 @@ def test_kb_manager_request_build_calls_endpoint_and_payload():
     mock_client.__exit__.return_value = None
 
     with patch("aibom.kb.manager.httpx.Client", return_value=mock_client):
-        out = mgr.request_build("openai", "1.0", api_key="k", api_base="https://api.example")
+        out = mgr.request_build(
+            "pypi",
+            "openai",
+            ["openai.OpenAI"],
+            api_key="k",
+            api_base="https://api.example",
+        )
 
-    expected_url = "https://api.example/api/ai-defense/v1/aibom/kb/requests"
+    expected_url = "https://api.example/api/v1/aibom/kb/requests"
     mock_client.post.assert_called_once()
     call_kw = mock_client.post.call_args
     assert call_kw[0][0] == expected_url
     assert call_kw[1]["json"] == {
-        "sdk": "openai",
-        "version": "1.0",
-        "language": "python",
+        "ecosystem": "pypi",
+        "package_name": "openai",
+        "symbols": ["openai.OpenAI"],
     }
     headers = call_kw[1]["headers"]
     assert headers["x-cisco-ai-defense-tenant-api-key"] == "k"
     assert headers["Content-Type"] == "application/json"
-    assert out == {"request_id": "req-1", "status": "queued", "message": "ok"}
+    assert out["request"]["request_id"] == "req-1"
+    assert out["rate_limit"] == {
+        "limit": "10",
+        "remaining": "9",
+        "reset": "1234",
+    }
 
 
 def test_kb_manager_request_build_missing_api_key_raises():
@@ -329,8 +621,9 @@ def test_kb_manager_request_build_missing_api_key_raises():
     with patch.dict(os.environ, env, clear=True):
         with pytest.raises(KBError, match="API key required"):
             mgr.request_build(
+                "pypi",
                 "x",
-                "1.0",
+                ["x.Client"],
                 api_key=None,
                 api_base="https://api.example",
             )
@@ -345,27 +638,25 @@ def test_kb_manager_request_build_missing_api_base_raises():
     }
     with patch.dict(os.environ, env, clear=True):
         with pytest.raises(KBError, match="API base URL required"):
-            mgr.request_build("x", "1.0", api_key="k")
+            mgr.request_build("pypi", "x", ["x.Client"], api_key="k")
 
 
-def test_kb_manager_download_missing_manifest_url_raises():
-    env = {
-        k: v for k, v in os.environ.items() if k != "CISCO_AIBOM_MANIFEST_URL"
-    }
+def test_kb_manager_download_uses_schema_v2_default_manifest():
+    env = {k: v for k, v in os.environ.items() if k != "CISCO_AIBOM_MANIFEST_URL"}
     with patch.dict(os.environ, env, clear=True):
         mgr = KBManager()
-        with pytest.raises(KBError, match="KB manifest URL required"):
-            mgr.download()
+        assert (
+            mgr._selected_manifest_url(version=None, url=None) == DEFAULT_MANIFEST_URL
+        )
 
 
-def test_kb_manager_check_missing_manifest_url_raises():
-    env = {
-        k: v for k, v in os.environ.items() if k != "CISCO_AIBOM_MANIFEST_URL"
-    }
+def test_kb_manager_check_uses_schema_v2_default_manifest():
+    env = {k: v for k, v in os.environ.items() if k != "CISCO_AIBOM_MANIFEST_URL"}
     with patch.dict(os.environ, env, clear=True):
         mgr = KBManager()
-        with pytest.raises(KBError, match="KB manifest URL required"):
-            mgr.check()
+        assert (
+            mgr._selected_manifest_url(version=None, url=None) == DEFAULT_MANIFEST_URL
+        )
 
 
 def test_kb_manager_request_status_calls_get_endpoint():
@@ -373,10 +664,11 @@ def test_kb_manager_request_status_calls_get_endpoint():
     mock_resp = MagicMock()
     mock_resp.json.return_value = {
         "request_id": "rid",
-        "status": "done",
-        "sdk": "openai",
-        "version": "1.0",
+        "state": "available",
+        "requests": [],
     }
+    mock_resp.is_error = False
+    mock_resp.headers = {}
     mock_resp.raise_for_status = MagicMock()
     mock_client = MagicMock()
     mock_client.get.return_value = mock_resp
@@ -390,15 +682,13 @@ def test_kb_manager_request_status_calls_get_endpoint():
             api_base="https://api.example",
         )
 
-    expected = "https://api.example/api/ai-defense/v1/aibom/kb/requests/rid"
+    expected = "https://api.example/api/v1/aibom/kb/requests/rid"
     mock_client.get.assert_called_once_with(
         expected,
         headers={"x-cisco-ai-defense-tenant-api-key": "k"},
     )
     assert out["request_id"] == "rid"
-    assert out["status"] == "done"
-    assert out["sdk"] == "openai"
-    assert out["version"] == "1.0"
+    assert out["state"] == "available"
 
 
 def test_kb_manager_list_requests_returns_list():
@@ -410,6 +700,8 @@ def test_kb_manager_list_requests_returns_list():
             {"id": "b"},
         ]
     }
+    mock_resp.is_error = False
+    mock_resp.headers = {}
     mock_resp.raise_for_status = MagicMock()
     mock_client = MagicMock()
     mock_client.get.return_value = mock_resp
@@ -419,10 +711,11 @@ def test_kb_manager_list_requests_returns_list():
     with patch("aibom.kb.manager.httpx.Client", return_value=mock_client):
         items = mgr.list_requests(api_key="k", api_base="https://api.example")
 
-    expected = "https://api.example/api/ai-defense/v1/aibom/kb/requests"
+    expected = "https://api.example/api/v1/aibom/kb/requests"
     mock_client.get.assert_called_once_with(
         expected,
         headers={"x-cisco-ai-defense-tenant-api-key": "k"},
+        params={"limit": 50},
     )
     assert items == [
         {"id": "a", "status": "x"},
@@ -434,6 +727,8 @@ def test_kb_manager_list_requests_accepts_plain_list():
     mgr = KBManager()
     mock_resp = MagicMock()
     mock_resp.json.return_value = [{"r": 1}]
+    mock_resp.is_error = False
+    mock_resp.headers = {}
     mock_resp.raise_for_status = MagicMock()
     mock_client = MagicMock()
     mock_client.get.return_value = mock_resp

--- a/aibom/tests/test_reporters.py
+++ b/aibom/tests/test_reporters.py
@@ -202,6 +202,78 @@ def test_json_reporter_render(sample_scan_result: ScanResult):
         assert "summary" in src_data
 
 
+def test_json_reporter_stamps_kb_identity_and_groups_coverage_gaps(monkeypatch):
+    monkeypatch.setenv("CISCO_AI_DEFENSE_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "aibom.kb.manager.KBManager.output_metadata",
+        lambda _self: {
+            "kb_version": "2.4.0",
+            "build_type": "delta",
+            "schema_version": 2,
+            "cli_version": "2.0.0",
+        },
+    )
+    components = [
+        AIComponent(
+            name="ExampleClient",
+            component_type=AIComponentType.MODEL,
+            metadata={
+                "uncatalogued_ai_symbol": True,
+                "uncatalogued_symbol": "example_sdk.ExampleClient",
+                "ecosystem": "pypi",
+                "package_name": "example-sdk",
+            },
+        ),
+        AIComponent(
+            name="ExampleModel",
+            component_type=AIComponentType.MODEL,
+            metadata={
+                "uncatalogued_ai_symbol": True,
+                "uncatalogued_symbol": "example_sdk.ExampleModel",
+                "ecosystem": "pypi",
+                "package_name": "example-sdk",
+            },
+        ),
+    ]
+    result = ScanResult(
+        metadata={"run_id": "scan-cache-001"},
+        sources=[SourceResult(path="/tmp/example", components=components)],
+    )
+    output = StringIO()
+    JsonReporter().render(result, output)
+    analysis = json.loads(output.getvalue())["aibom_analysis"]
+
+    assert (
+        analysis["metadata"]
+        | {
+            "kb_version": "2.4.0",
+            "build_type": "delta",
+            "schema_version": 2,
+            "cli_version": "2.0.0",
+        }
+        == analysis["metadata"]
+    )
+    assert analysis["coverage_gaps"] == {
+        "informational": True,
+        "uncatalogued_ai_symbol_count": 2,
+        "scan_cache_id": "scan-cache-001",
+        "packages": [
+            {
+                "ecosystem": "pypi",
+                "package_name": "example-sdk",
+                "symbols": [
+                    "example_sdk.ExampleClient",
+                    "example_sdk.ExampleModel",
+                ],
+            }
+        ],
+        "request_hint": (
+            "Run `cisco-aibom kb request --from-scan <report.json>` to request "
+            "coverage for these symbols."
+        ),
+    }
+
+
 def test_json_reporter_preserves_decision_annotations():
     component = AIComponent(
         name="router_agent",
@@ -424,6 +496,14 @@ def test_cyclonedx_reporter_render(sample_scan_result: ScanResult):
     assert doc["specVersion"] == "1.6"
     assert isinstance(doc.get("components"), list)
     assert len(doc["components"]) == 6
+    properties = {item["name"]: item["value"] for item in doc["properties"]}
+    assert set(properties) >= {
+        "cisco-aibom:kb_version",
+        "cisco-aibom:build_type",
+        "cisco-aibom:schema_version",
+        "cisco-aibom:cli_version",
+        "cisco-aibom:uncatalogued_ai_symbol_count",
+    }
 
 
 def test_sarif_reporter_render(sample_scan_result: ScanResult):
@@ -444,6 +524,14 @@ def test_spdx_reporter_render(sample_scan_result: ScanResult):
     doc = json.loads(buf.getvalue())
     assert "@context" in doc
     assert doc["@context"]
+    properties = doc["@graph"][0]["extension_cisco_aibom"]["extensionProperties"]
+    assert set(properties) >= {
+        "cisco-aibom:kb_version",
+        "cisco-aibom:build_type",
+        "cisco-aibom:schema_version",
+        "cisco-aibom:cli_version",
+        "cisco-aibom:uncatalogued_ai_symbol_count",
+    }
 
 
 def test_html_reporter_render(sample_scan_result: ScanResult):

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -519,6 +519,7 @@ version = "1.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
+    { name = "cryptography" },
     { name = "cyclonedx-python-lib" },
     { name = "duckdb" },
     { name = "fastapi" },
@@ -642,6 +643,7 @@ requires-dist = [
     { name = "cisco-ai-mcp-scanner", marker = "extra == 'security'", specifier = ">=4.8.1" },
     { name = "cisco-ai-skill-scanner", marker = "extra == 'security'", specifier = ">=2.0.12" },
     { name = "cisco-aibom", extras = ["analysis", "security", "agentic", "observability", "llm-openai", "llm-aws", "llm-anthropic", "llm-google", "cloud"], marker = "extra == 'all'" },
+    { name = "cryptography", specifier = ">=45.0.0" },
     { name = "cyclonedx-python-lib", specifier = ">=9.0.0" },
     { name = "deepagents", marker = "extra == 'agentic'", specifier = ">=0.4.12" },
     { name = "detect-secrets", marker = "extra == 'analysis'", specifier = ">=1.5.0" },

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -289,8 +289,29 @@ cisco-aibom kb download [OPTIONS]
 
 | Option | Env Var | Description |
 |--------|---------|-------------|
-| `--version`, `-v` | — | Specific KB version to download (latest if omitted). |
-| `--url` | `CISCO_AIBOM_MANIFEST_URL` | Manifest URL. Required: pass `--url` or set the env var. No default is shipped. |
+| `--aibom-kb-version`, `--version` | — | Exact immutable KB version. Overrides a configured pin. |
+| `--aibom-manifest-url`, `--url` | `CISCO_AIBOM_MANIFEST_URL` | Direct regional S3 HTTPS manifest URL. Overrides a configured pin and the public default. |
+| `--prefetched-manifest` | — | Install a local manifest and its prefetched sibling objects through the same validation and cache-install path used for HTTPS downloads. |
+
+Schema-v2 downloads validate the strict manifest before fetching the database,
+enforce `min_cli_version`, bound redirects and object sizes, verify the compressed
+SHA-256 and detached ECDSA P-256 signature, and only then atomically replace the
+active cache. A failed upgrade leaves the last-known-good KB active. The default
+pointer is
+`https://cisco-ai-defense-public.s3.us-west-2.amazonaws.com/aibom/kb/manifest.json`;
+CLI 1.x release artifacts and their frozen schema-v1 manifest are unaffected.
+
+### `kb pin`
+
+Pin normal downloads to an exact version or immutable direct S3 manifest URL.
+
+```bash
+cisco-aibom kb pin 2.4.0
+cisco-aibom kb pin --clear
+```
+
+Selection precedence is explicit command option, saved pin, then the public
+schema-v2 pointer. An exact pin never falls back to another version.
 
 ### `kb check`
 
@@ -314,7 +335,7 @@ For a schema-v2 manifest, this offline command also displays
 
 ### `kb verify`
 
-Verify the integrity of the locally installed KB (SHA-256 checksum).
+Verify the compressed SHA-256, detached signature, and installed DuckDB.
 
 ```bash
 cisco-aibom kb verify
@@ -322,7 +343,8 @@ cisco-aibom kb verify
 
 ### `kb request`
 
-Request a KB build for a specific SDK version.
+Request coverage for uncatalogued package symbols. One command can submit a
+single package, a scan report's grouped `coverage_gaps`, or a bulk symbols file.
 
 ```bash
 cisco-aibom kb request [OPTIONS]
@@ -330,11 +352,25 @@ cisco-aibom kb request [OPTIONS]
 
 | Option | Env Var | Description |
 |--------|---------|-------------|
-| `--sdk` | — | SDK name, e.g. `langchain`, `openai` (required). |
-| `--version`, `-v` | — | SDK version to request (required). |
-| `--language`, `-l` | — | Programming language (default `python`). |
+| `--ecosystem` | — | Package ecosystem: `cargo`, `npm`, `nuget`, `pypi`, or `rubygems`. |
+| `--package` | — | Package name containing the uncatalogued symbols. |
+| `--symbol` | — | Symbol to request. Repeat for multiple symbols. |
+| `--from-scan` | — | Read grouped requests from a JSON report's `coverage_gaps` block. |
+| `--symbols-from` | — | Read a JSON request array or `ecosystem,package,symbol` lines. |
+| `--watch` | — | Poll accepted requests from 30 seconds up to 5 minutes, capped at 24 hours. |
+| `--json` | — | Print structured responses, including accepted IDs, duplicates, rejections, quota, and rate-limit values. |
 | `--api-key` | `CISCO_AI_DEFENSE_API_KEY` | Cisco AI Defense tenant API key (required). |
 | `--api-base` | `CISCO_AI_DEFENSE_API_BASE` | Regional Cisco AI Defense API host (required). Follows the same pattern as `AIBOM_POST_URL`: `https://api.security.cisco.com` (US), `https://api.eu.security.cisco.com` (EU), `https://api.apj.security.cisco.com` (APJ), `https://api.uae.security.cisco.com` (UAE). No default is shipped. |
+
+Bulk submissions accept at most 20 packages and 200 symbols total. The server
+treats the batch as one quota unit. Coverage gaps are informational and never
+change scan exit status. Without a tenant API key, reports provide a setup hint
+and the CLI makes no request attempt.
+
+JSON, CycloneDX, and SPDX SBOMs stamp `kb_version`, `build_type`,
+`schema_version`, `cli_version`, and `uncatalogued_ai_symbol_count`. Unknown
+symbols also carry package coordinates so policy and enterprise tooling can
+filter or submit the grouped coverage gaps.
 
 ### `kb request-status`
 
@@ -362,6 +398,7 @@ cisco-aibom kb list-requests [OPTIONS]
 |--------|---------|-------------|
 | `--api-key` | `CISCO_AI_DEFENSE_API_KEY` | Cisco AI Defense tenant API key (required). |
 | `--api-base` | `CISCO_AI_DEFENSE_API_BASE` | Regional Cisco AI Defense API host (required). Same regional hosts as `kb request` (e.g. `https://api.security.cisco.com`, `https://api.eu.security.cisco.com`). No default is shipped. |
+| `--limit` | — | Return 1–100 requests (default 50). |
 
 ---
 

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -220,7 +220,7 @@ AI BOM's analysis depth varies by language. Python gets a full CST pipeline; oth
 | Code-level import detection | all imports | allowlist | allowlist | allowlist | allowlist | allowlist | allowlist |
 | Model literal detection (`model="..."`) | yes | yes | yes | yes | yes | yes | yes |
 | Agent / tool instantiation (`new Agent(...)`, `@tool`) | CST | regex | regex | regex | regex | regex | regex |
-| Env-var resolver (`os.getenv`, `process.env`, …) | yes | yes | yes | yes | no | yes | no |
+| Env-var resolver (`os.getenv`, `process.env`, …) | yes | yes | yes | yes | yes | yes | yes |
 | Class / decorator / annotation observations | yes | no | no | no | no | no | no |
 | Method body shape, control-flow loops (ReAct detection) | yes | no | no | no | no | no | no |
 | KB symbol enrichment (DuckDB catalog) | yes | no | no | no | no | no | no |
@@ -230,6 +230,11 @@ AI BOM's analysis depth varies by language. Python gets a full CST pipeline; oth
 | ML-lifecycle detection (training runs, hyperparameters) | yes | no | no | no | no | no | no |
 | Jupyter notebook (`.ipynb`) | yes | — | — | — | — | — | — |
 | Tier 3 agentic classification | yes | yes | yes | yes | yes | yes | yes |
+
+Rust env-var coverage includes `std::env::var`, `std::env::var_os`, `env!`, and
+`option_env!`. C# coverage includes `Environment.GetEnvironmentVariable`,
+`Configuration["..."]`, `_configuration["..."]`,
+`builder.Configuration["..."]`, and `IConfiguration.GetValue<T>("...")`.
 
 ### Why Python is deeper
 


### PR DESCRIPTION
## Summary

- add strict schema-v2 manifest parsing and direct regional S3 HTTPS distribution
- verify compressed artifact checksums and detached ECDSA signatures before atomic installation
- support exact KB version/manifest pins, prefetched private-environment validation, and last-known-good rollback behavior
- add authenticated single and bulk KB coverage requests with status polling and scan-derived payloads
- stamp JSON, CycloneDX, and SPDX output with KB/build/schema/CLI metadata and uncatalogued-symbol details
- recognize Rust and C# environment-variable access patterns

## Safety and compatibility

- the existing packaged schema-v1 path remains available for explicit legacy manifests
- unsigned candidates require the explicit rehearsal-only prefetched installation path
- authoritative schema-v2 manifests always require a valid signature
- failed downloads, compatibility checks, checksums, signatures, decompression, or DuckDB validation do not replace the active KB

## Testing

- `.venv/bin/pytest -q` — 2,469 passed, 13 skipped
- Black check for the touched formatted Python files
- `git diff --cached --check`

## Stack

Depends on #75.
