### PR TITLE
chore: prepare 1.10.0 release

### DIFF
--- a/aibom/pyproject.toml
+++ b/aibom/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-aibom"
-version = "1.0.9"
+version = "1.10.0"
 description = "A tool to generate an AI BOM from source code."
 readme = "README.md"
 requires-python = ">=3.11.4,<3.14"

--- a/aibom/src/aibom/manifest.json
+++ b/aibom/src/aibom/manifest.json
@@ -1,8 +1,8 @@
 {
-  "analyzer_version": "1.0.9",
-  "schema_version": "1.0.9",
+  "analyzer_version": "1.10.0",
+  "schema_version": "1.10.0",
   "duckdb_sha256": "b1165384a646094aa6a4762d676f285c1c68b6d7f9367c90a129b529904a3268",
-  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.0.9.duckdb",
+  "duckdb_file": "~/.aibom/catalogs/aibom_catalog-1.10.0.duckdb",
   "upload_mode": "direct",
   "max_direct_upload_mb": 25,
   "log_level": "INFO"

--- a/aibom/uv.lock
+++ b/aibom/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "cisco-aibom"
-version = "1.0.9"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Prepare the 1.10.0 release by synchronizing the package, manifest, and
lockfile versions.

## Changes included since 1.0.9

- #78 reports incomplete agentic review separately from normal scan
  completion, preserves degradation outcomes through reporting and caching,
  and retries timed-out work in smaller batches within existing limits.
- #77 discovers Claude skills stored under `.claude/skills/<name>/SKILL.md`
  without double-counting nested reference files.

## Release preparation

- update `aibom/pyproject.toml` from 1.0.9 to 1.10.0
- update `analyzer_version`, `schema_version`, and the versioned catalog
  filename in `aibom/src/aibom/manifest.json`
- update the `cisco-aibom` package version in `aibom/uv.lock`
- retain the existing catalog SHA-256 because the catalog content is unchanged

## Validation

- `uv sync --group dev`
- `uv lock --check`
- version synchronization check: 1.10.0
- manifest JSON validation
- `uv run --no-sync pytest`: 2,447 passed, 13 skipped
- `git diff --check`

This release-preparation commit changes only TOML, JSON, and lockfile metadata
and does not modify Python source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application and manifest versions to 1.10.0.
  * Updated the bundled catalog filename to match the new release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->